### PR TITLE
Increase fetch timeout

### DIFF
--- a/src/lib/fetch.ts
+++ b/src/lib/fetch.ts
@@ -143,8 +143,8 @@ type FetchError = {
 type ActionStatesStringified = {
   [K in keyof ActionStates]: string;
 };
-// Specify 30s as the default timeout
-const defaultTimeout = 30000;
+// Specify 5min as the default timeout
+const defaultTimeout = 5 * 60 * 1000;
 
 let accountCache = {} as Record<
   string,


### PR DESCRIPTION
Some people are running into the timeout. We want to make sure the timeout of 30s is not too tight to prevent otherwise valid requests in case the graphQL server is slow to respond