### PR TITLE
Add check to assert proofs are attached if required

### DIFF
--- a/src/lib/mina.ts
+++ b/src/lib/mina.ts
@@ -471,8 +471,7 @@ function LocalBlockchain({
         // this resulted in an assertion OCaml error, which didn't contain any useful information
         if (kindIsProof && !authIsProof) {
           throw Error(
-            `The actual authorization does not match the expected authorization kind.
-            Did you forget to invoke \`await tx.prove();\`?`
+            `The actual authorization does not match the expected authorization kind. Did you forget to invoke \`await tx.prove();\`?`
           );
         }
 


### PR DESCRIPTION
If the developer forgot to invoke `await tx.prove()` but the transaction/account update expected a proof, sending said transaction resulted in an ugly OCaml assertion error that didn't indicate what was wrong with it. This is an edge case that only impacted proofs, missing signatures are already handled elsewhere and produce an understandable error message. 


```sh
Assert_failure src/lib/transaction_logic/zkapp_command_logic.ml:1266:17
      at raise_error (../../../../home/gregor/.opam/4.14.0/lib/js_of_ocaml-compiler/runtime/jsoo_runtime.ml:110:3)
      at apply_json_transaction (../../../../workspace_root/src/lib/snarky_js_bindings/lib/snarky_js_bindings_lib.ml:2933:11)
      at caml_call_gen (../../../../builtin/+stdlib.js:32:12)
      at Object.applyJsonTransaction (../../../../builtin/+jslib.js:289:12)
      at Object.sendTransaction (node_modules/snarkyjs/src/lib/mina.ts:436:16)
      at sendTransaction (node_modules/snarkyjs/src/lib/mina.ts:1021:10)
      at Object.send (node_modules/snarkyjs/src/lib/mina.ts:299:14)
      at Object.<anonymous> (src/lending/Lender.test.ts:427:20)
```

new error message:

```sh
Error: The actual authorization does not match the expected authorization kind.
            Did you forget to invoke `await tx.prove();`?
    at Object.sendTransaction (snarkyjs/src/lib/mina.ts:472:17)
    at processTicksAndRejections (node:internal/process/task_queues:96:5)
    at null.sendTransaction (snarkyjs/src/lib/mina.ts:1184:10)
    at Object.send (snarkyjs/src/lib/mina.ts:325:16)
    at async file:///home/trivo/Development/snarkyjs/src/examples/simple_zkapp.tmp.js:71:1
```

closes #808