### PR TITLE
make docs node >=18 compatible

### DIFF
--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -14,7 +14,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v2
         with:
-          node-version: '16'
+          node-version: '18'
 
       - name: Run typedoc
         run: |


### PR DESCRIPTION
this makes sure the project builds with node >=18 (LTS)

also updates outdated packages

closes #485