### PR TITLE
[develop] Update bindings to use wasm-bindgen 0.2.85

### DIFF
--- a/src/build/buildWeb.js
+++ b/src/build/buildWeb.js
@@ -137,7 +137,7 @@ function rewriteBundledWasmBindings(src) {
   let exportSlice = src.slice(i);
   let defaultExport = exportSlice.match(/\w* as default/)[0];
   exportSlice = exportSlice
-    .replace(defaultExport, `default: init`)
+    .replace(defaultExport, `default: __wbg_init`)
     .replace('export', 'return');
   src = src.slice(0, i) + exportSlice;
 


### PR DESCRIPTION
Incremental step to bump up to wasm-bindgen `0.2.87`. It is built on top of https://github.com/o1-labs/o1js/pull/1132.

See https://github.com/MinaProtocol/mina/issues/14253 for the different PR's.
Depends on https://github.com/o1-labs/o1js-bindings/pull/168

## Old
This is to prove https://github.com/MinaProtocol/mina/issues/14253
This is built on top of https://github.com/o1-labs/o1js/pull/1132 which uses wasm-bindgen 0.2.84. This PR consists only on upgrading wasm-bindgen to 0.2.85 in bindings, and run `npm run bindings`.

See https://github.com/o1-labs/o1js-bindings/pull/167