### PR TITLE
An API for interaction with the lightnet accounts manager.

### DIFF
--- a/.github/actions/live-tests-shared/action.yml
+++ b/.github/actions/live-tests-shared/action.yml
@@ -1,11 +1,11 @@
-name: 'Shared steps for live testing jobs'
-description: 'Shared steps for live testing jobs'
+name: "Shared steps for live testing jobs"
+description: "Shared steps for live testing jobs"
 inputs:
   mina-branch-name:
-    description: 'Mina branch name in use by service container'
+    description: "Mina branch name in use by service container"
     required: true
 runs:
-  using: 'composite'
+  using: "composite"
   steps:
     - name: Wait for Mina network readiness
       uses: o1-labs/wait-for-mina-network-action@v1
@@ -16,11 +16,11 @@ runs:
     - name: Setup Node
       uses: actions/setup-node@v3
       with:
-        node-version: '20'
+        node-version: "20"
     - name: Build o1js and execute tests
       env:
-        TEST_TYPE: 'Live integration tests'
-        USE_LOCAL_NETWORK: 'true'
+        TEST_TYPE: "Live integration tests"
+        USE_CUSTOM_LOCAL_NETWORK: "true"
       run: |
         git submodule update --init --recursive
         npm ci

--- a/.github/actions/live-tests-shared/action.yml
+++ b/.github/actions/live-tests-shared/action.yml
@@ -1,11 +1,11 @@
-name: "Shared steps for live testing jobs"
-description: "Shared steps for live testing jobs"
+name: 'Shared steps for live testing jobs'
+description: 'Shared steps for live testing jobs'
 inputs:
   mina-branch-name:
-    description: "Mina branch name in use by service container"
+    description: 'Mina branch name in use by service container'
     required: true
 runs:
-  using: "composite"
+  using: 'composite'
   steps:
     - name: Wait for Mina network readiness
       uses: o1-labs/wait-for-mina-network-action@v1
@@ -16,11 +16,11 @@ runs:
     - name: Setup Node
       uses: actions/setup-node@v3
       with:
-        node-version: "20"
+        node-version: '20'
     - name: Build o1js and execute tests
       env:
-        TEST_TYPE: "Live integration tests"
-        USE_CUSTOM_LOCAL_NETWORK: "true"
+        TEST_TYPE: 'Live integration tests'
+        USE_CUSTOM_LOCAL_NETWORK: 'true'
       run: |
         git submodule update --init --recursive
         npm ci

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,10 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased](https://github.com/o1-labs/o1js/compare/045faa7...HEAD)
 
+### Added
+
+- New API available under the `Leghtnet` namespace to interact with the account manager provided by the [lightnet Mina network](https://hub.docker.com/r/o1labs/mina-local-network). https://github.com/o1-labs/o1js/pull/1167
+
 ## [0.13.1](https://github.com/o1-labs/o1js/compare/c2f392fe5...045faa7)
 
 ### Breaking changes

--- a/src/examples/zkapps/hello_world/run_live.ts
+++ b/src/examples/zkapps/hello_world/run_live.ts
@@ -20,13 +20,13 @@ const network = Mina.Network({
   mina: useCustomLocalNetwork
     ? 'http://localhost:8080/graphql'
     : 'https://proxy.berkeley.minaexplorer.com/graphql',
-  accountsManager: 'http://localhost:8181',
+  lightnetAccountManager: 'http://localhost:8181',
 });
 Mina.setActiveInstance(network);
 
 // Fee payer setup
 const senderKey = useCustomLocalNetwork
-  ? (await acquireKeyPair(true)).privateKey
+  ? (await acquireKeyPair()).privateKey
   : PrivateKey.random();
 const sender = senderKey.toPublicKey();
 if (!useCustomLocalNetwork) {
@@ -100,4 +100,7 @@ try {
 console.log('Success!');
 
 // Tear down
-await releaseKeyPair(senderKey.toPublicKey().toBase58());
+const keyPairReleaseMessage = await releaseKeyPair({
+  publicKey: sender.toBase58(),
+});
+if (keyPairReleaseMessage) console.info(keyPairReleaseMessage);

--- a/src/examples/zkapps/hello_world/run_live.ts
+++ b/src/examples/zkapps/hello_world/run_live.ts
@@ -2,11 +2,10 @@
 import {
   AccountUpdate,
   Field,
+  Lightnet,
   Mina,
   PrivateKey,
-  acquireKeyPair,
   fetchAccount,
-  releaseKeyPair,
 } from 'o1js';
 import { HelloWorld, adminPrivateKey } from './hello_world.js';
 
@@ -26,7 +25,7 @@ Mina.setActiveInstance(network);
 
 // Fee payer setup
 const senderKey = useCustomLocalNetwork
-  ? (await acquireKeyPair()).privateKey
+  ? (await Lightnet.acquireKeyPair()).privateKey
   : PrivateKey.random();
 const sender = senderKey.toPublicKey();
 if (!useCustomLocalNetwork) {
@@ -100,7 +99,7 @@ try {
 console.log('Success!');
 
 // Tear down
-const keyPairReleaseMessage = await releaseKeyPair({
+const keyPairReleaseMessage = await Lightnet.releaseKeyPair({
   publicKey: sender.toBase58(),
 });
 if (keyPairReleaseMessage) console.info(keyPairReleaseMessage);

--- a/src/index.ts
+++ b/src/index.ts
@@ -65,7 +65,6 @@ export {
   setGraphqlEndpoints,
   setArchiveGraphqlEndpoint,
   sendZkapp,
-  KeyPair,
   acquireKeyPair,
   releaseKeyPair
 } from './lib/fetch.js';

--- a/src/index.ts
+++ b/src/index.ts
@@ -65,8 +65,7 @@ export {
   setGraphqlEndpoints,
   setArchiveGraphqlEndpoint,
   sendZkapp,
-  acquireKeyPair,
-  releaseKeyPair
+  Lightnet
 } from './lib/fetch.js';
 export * as Encryption from './lib/encryption.js';
 export * as Encoding from './bindings/lib/encoding.js';

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,85 +1,88 @@
-export type { ProvablePure } from './snarky.js';
-export { Ledger } from './snarky.js';
-export { Field, Bool, Group, Scalar } from './lib/core.js';
-export { Poseidon, TokenSymbol } from './lib/hash.js';
-export * from './lib/signature.js';
+export { Types } from './bindings/mina-transaction/types.js';
+export { Circuit, Keypair, circuitMain, public_ } from './lib/circuit.js';
+export {
+  CircuitValue,
+  Struct,
+  arrayProp,
+  matrixProp,
+  prop,
+  provable,
+  provablePure,
+} from './lib/circuit_value.js';
 export type {
-  ProvableExtended,
   FlexibleProvable,
   FlexibleProvablePure,
   InferProvable,
+  ProvableExtended,
 } from './lib/circuit_value.js';
-export {
-  CircuitValue,
-  prop,
-  arrayProp,
-  matrixProp,
-  provable,
-  provablePure,
-  Struct,
-} from './lib/circuit_value.js';
+export { Bool, Field, Group, Scalar } from './lib/core.js';
+export { Poseidon, TokenSymbol } from './lib/hash.js';
+export { Int64, Sign, UInt32, UInt64 } from './lib/int.js';
 export { Provable } from './lib/provable.js';
-export { Circuit, Keypair, public_, circuitMain } from './lib/circuit.js';
-export { UInt32, UInt64, Int64, Sign } from './lib/int.js';
-export { Types } from './bindings/mina-transaction/types.js';
+export * from './lib/signature.js';
+export { Ledger } from './snarky.js';
+export type { ProvablePure } from './snarky.js';
 
 export * as Mina from './lib/mina.js';
-export type { DeployArgs } from './lib/zkapp.js';
+export { State, declareState, state } from './lib/state.js';
 export {
-  SmartContract,
-  method,
-  declareMethods,
   Account,
-  VerificationKey,
   Reducer,
+  SmartContract,
+  VerificationKey,
+  declareMethods,
+  method,
 } from './lib/zkapp.js';
-export { state, State, declareState } from './lib/state.js';
+export type { DeployArgs } from './lib/zkapp.js';
 
-export type { JsonProof } from './lib/proof_system.js';
 export {
+  Empty,
   Proof,
   SelfProof,
-  verify,
-  Empty,
   Undefined,
   Void,
+  verify,
 } from './lib/proof_system.js';
+export type { JsonProof } from './lib/proof_system.js';
 
 export {
-  Token,
-  TokenId,
   AccountUpdate,
   Permissions,
+  Token,
+  TokenId,
   ZkappPublicInput,
 } from './lib/account_update.js';
 
-export type { TransactionStatus } from './lib/fetch.js';
+export * as Encoding from './bindings/lib/encoding.js';
+export * as Encryption from './lib/encryption.js';
 export {
+  KeyPair,
+  acquireKeyPair,
+  addCachedAccount,
+  checkZkappTransaction,
   fetchAccount,
+  fetchEvents,
   fetchLastBlock,
   fetchTransactionStatus,
-  checkZkappTransaction,
-  fetchEvents,
-  addCachedAccount,
+  releaseKeyPair,
+  sendZkapp,
+  setArchiveGraphqlEndpoint,
   setGraphqlEndpoint,
   setGraphqlEndpoints,
-  setArchiveGraphqlEndpoint,
-  sendZkapp,
 } from './lib/fetch.js';
-export * as Encryption from './lib/encryption.js';
-export * as Encoding from './bindings/lib/encoding.js';
-export { Character, CircuitString } from './lib/string.js';
-export { MerkleTree, MerkleWitness } from './lib/merkle_tree.js';
+export type { TransactionStatus } from './lib/fetch.js';
 export { MerkleMap, MerkleMapWitness } from './lib/merkle_map.js';
+export { MerkleTree, MerkleWitness } from './lib/merkle_tree.js';
+export { Character, CircuitString } from './lib/string.js';
 
 export { Nullifier } from './lib/nullifier.js';
+export { Experimental };
 
 // experimental APIs
-import { ZkProgram } from './lib/proof_system.js';
-import { Callback } from './lib/zkapp.js';
 import { createChildAccountUpdate } from './lib/account_update.js';
+import { ZkProgram } from './lib/proof_system.js';
 import { memoizeWitness } from './lib/provable.js';
-export { Experimental };
+import { Callback } from './lib/zkapp.js';
 
 const Experimental_ = {
   Callback,

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,88 +1,88 @@
-export { Types } from './bindings/mina-transaction/types.js';
-export { Circuit, Keypair, circuitMain, public_ } from './lib/circuit.js';
-export {
-  CircuitValue,
-  Struct,
-  arrayProp,
-  matrixProp,
-  prop,
-  provable,
-  provablePure,
-} from './lib/circuit_value.js';
+export type { ProvablePure } from './snarky.js';
+export { Ledger } from './snarky.js';
+export { Field, Bool, Group, Scalar } from './lib/core.js';
+export { Poseidon, TokenSymbol } from './lib/hash.js';
+export * from './lib/signature.js';
 export type {
+  ProvableExtended,
   FlexibleProvable,
   FlexibleProvablePure,
   InferProvable,
-  ProvableExtended,
 } from './lib/circuit_value.js';
-export { Bool, Field, Group, Scalar } from './lib/core.js';
-export { Poseidon, TokenSymbol } from './lib/hash.js';
-export { Int64, Sign, UInt32, UInt64 } from './lib/int.js';
+export {
+  CircuitValue,
+  prop,
+  arrayProp,
+  matrixProp,
+  provable,
+  provablePure,
+  Struct,
+} from './lib/circuit_value.js';
 export { Provable } from './lib/provable.js';
-export * from './lib/signature.js';
-export { Ledger } from './snarky.js';
-export type { ProvablePure } from './snarky.js';
+export { Circuit, Keypair, public_, circuitMain } from './lib/circuit.js';
+export { UInt32, UInt64, Int64, Sign } from './lib/int.js';
+export { Types } from './bindings/mina-transaction/types.js';
 
 export * as Mina from './lib/mina.js';
-export { State, declareState, state } from './lib/state.js';
-export {
-  Account,
-  Reducer,
-  SmartContract,
-  VerificationKey,
-  declareMethods,
-  method,
-} from './lib/zkapp.js';
 export type { DeployArgs } from './lib/zkapp.js';
-
 export {
-  Empty,
+  SmartContract,
+  method,
+  declareMethods,
+  Account,
+  VerificationKey,
+  Reducer,
+} from './lib/zkapp.js';
+export { state, State, declareState } from './lib/state.js';
+
+export type { JsonProof } from './lib/proof_system.js';
+export {
   Proof,
   SelfProof,
+  verify,
+  Empty,
   Undefined,
   Void,
-  verify,
 } from './lib/proof_system.js';
-export type { JsonProof } from './lib/proof_system.js';
 
 export {
-  AccountUpdate,
-  Permissions,
   Token,
   TokenId,
+  AccountUpdate,
+  Permissions,
   ZkappPublicInput,
 } from './lib/account_update.js';
 
-export * as Encoding from './bindings/lib/encoding.js';
-export * as Encryption from './lib/encryption.js';
+export type { TransactionStatus } from './lib/fetch.js';
 export {
-  KeyPair,
-  acquireKeyPair,
-  addCachedAccount,
-  checkZkappTransaction,
   fetchAccount,
-  fetchEvents,
   fetchLastBlock,
   fetchTransactionStatus,
-  releaseKeyPair,
-  sendZkapp,
-  setArchiveGraphqlEndpoint,
+  checkZkappTransaction,
+  fetchEvents,
+  addCachedAccount,
   setGraphqlEndpoint,
   setGraphqlEndpoints,
+  setArchiveGraphqlEndpoint,
+  sendZkapp,
+  KeyPair,
+  acquireKeyPair,
+  releaseKeyPair
 } from './lib/fetch.js';
-export type { TransactionStatus } from './lib/fetch.js';
-export { MerkleMap, MerkleMapWitness } from './lib/merkle_map.js';
-export { MerkleTree, MerkleWitness } from './lib/merkle_tree.js';
+export * as Encryption from './lib/encryption.js';
+export * as Encoding from './bindings/lib/encoding.js';
 export { Character, CircuitString } from './lib/string.js';
+export { MerkleTree, MerkleWitness } from './lib/merkle_tree.js';
+export { MerkleMap, MerkleMapWitness } from './lib/merkle_map.js';
 
 export { Nullifier } from './lib/nullifier.js';
-export { Experimental };
 
 // experimental APIs
-import { createChildAccountUpdate } from './lib/account_update.js';
 import { ZkProgram } from './lib/proof_system.js';
-import { memoizeWitness } from './lib/provable.js';
 import { Callback } from './lib/zkapp.js';
+import { createChildAccountUpdate } from './lib/account_update.js';
+import { memoizeWitness } from './lib/provable.js';
+export { Experimental };
 
 const Experimental_ = {
   Callback,

--- a/src/lib/fetch.ts
+++ b/src/lib/fetch.ts
@@ -1,52 +1,52 @@
 import 'isomorphic-fetch';
-import { Types } from '../bindings/mina-transaction/types.js';
-import { Actions, TokenId } from './account_update.js';
-import { EpochSeed, LedgerHash, StateHash } from './base58-encodings.js';
 import { Field } from './core.js';
 import { UInt32, UInt64 } from './int.js';
+import { Actions, TokenId } from './account_update.js';
+import { PublicKey, PrivateKey } from './signature.js';
+import { NetworkValue } from './precondition.js';
+import { Types } from '../bindings/mina-transaction/types.js';
 import { ActionStates } from './mina.js';
+import { LedgerHash, EpochSeed, StateHash } from './base58-encodings.js';
 import {
   Account,
-  FetchedAccount,
-  PartialAccount,
   accountQuery,
+  FetchedAccount,
   fillPartialAccount,
   parseFetchedAccount,
+  PartialAccount,
 } from './mina/account.js';
-import { NetworkValue } from './precondition.js';
-import { PrivateKey, PublicKey } from './signature.js';
 
 export {
-  EventActionFilterOptions,
-  KeyPair,
-  TransactionStatus,
-  acquireKeyPair,
-  addCachedAccount,
-  checkZkappTransaction,
   fetchAccount,
-  fetchActions,
-  fetchEvents,
   fetchLastBlock,
+  checkZkappTransaction,
+  parseFetchedAccount,
+  markAccountToBeFetched,
+  markNetworkToBeFetched,
+  markActionsToBeFetched,
   fetchMissingData,
   fetchTransactionStatus,
+  TransactionStatus,
+  EventActionFilterOptions,
   getCachedAccount,
-  getCachedActions,
   getCachedNetwork,
-  markAccountToBeFetched,
-  markActionsToBeFetched,
-  markNetworkToBeFetched,
+  getCachedActions,
+  addCachedAccount,
   networkConfig,
-  parseFetchedAccount,
-  releaseKeyPair,
-  removeJsonQuotes,
-  sendZkapp,
-  sendZkappQuery,
-  setAccountsManagerEndpoint,
-  setArchiveGraphqlEndpoint,
-  setArchiveGraphqlFallbackEndpoints,
   setGraphqlEndpoint,
   setGraphqlEndpoints,
   setMinaGraphqlFallbackEndpoints,
+  setArchiveGraphqlEndpoint,
+  setArchiveGraphqlFallbackEndpoints,
+  setAccountsManagerEndpoint,
+  sendZkappQuery,
+  sendZkapp,
+  removeJsonQuotes,
+  fetchEvents,
+  fetchActions,
+  KeyPair,
+  acquireKeyPair,
+  releaseKeyPair
 };
 
 type NetworkConfig = {

--- a/src/lib/mina.ts
+++ b/src/lib/mina.ts
@@ -679,26 +679,22 @@ LocalBlockchain satisfies (...args: any) => Mina;
 function Network(graphqlEndpoint: string): Mina;
 function Network(endpoints: {
   mina: string | string[];
-  accountsManager?: string;
-}): Mina;
-function Network(endpoints: {
-  mina: string | string[];
-  archive: string | string[];
-  accountsManager?: string;
+  archive?: string | string[];
+  lightnetAccountManager?: string;
 }): Mina;
 function Network(
   input:
     | {
         mina: string | string[];
         archive?: string | string[];
-        accountsManager?: string;
+        lightnetAccountManager?: string;
       }
     | string
 ): Mina {
   let accountCreationFee = UInt64.from(defaultAccountCreationFee);
   let minaGraphqlEndpoint: string;
   let archiveEndpoint: string;
-  let accountsManagerEndpoint: string;
+  let lightnetAccountManagerEndpoint: string;
 
   if (input && typeof input === 'string') {
     minaGraphqlEndpoint = input;
@@ -706,7 +702,7 @@ function Network(
   } else if (input && typeof input === 'object') {
     if (!input.mina)
       throw new Error(
-        "Network: malformed input. Please provide an object with 'mina' and 'archive' endpoints."
+        "Network: malformed input. Please provide an object with 'mina' endpoint."
       );
     if (Array.isArray(input.mina) && input.mina.length !== 0) {
       minaGraphqlEndpoint = input.mina[0];
@@ -717,7 +713,7 @@ function Network(
       Fetch.setGraphqlEndpoint(minaGraphqlEndpoint);
     }
 
-    if (input.archive) {
+    if (input.archive !== undefined) {
       if (Array.isArray(input.archive) && input.archive.length !== 0) {
         archiveEndpoint = input.archive[0];
         Fetch.setArchiveGraphqlEndpoint(archiveEndpoint);
@@ -728,9 +724,12 @@ function Network(
       }
     }
 
-    if (input.accountsManager && typeof input.accountsManager === 'string') {
-      accountsManagerEndpoint = input.accountsManager;
-      Fetch.setAccountsManagerEndpoint(accountsManagerEndpoint);
+    if (
+      input.lightnetAccountManager !== undefined &&
+      typeof input.lightnetAccountManager === 'string'
+    ) {
+      lightnetAccountManagerEndpoint = input.lightnetAccountManager;
+      Fetch.setLightnetAccountManagerEndpoint(lightnetAccountManagerEndpoint);
     }
   } else {
     throw new Error(

--- a/src/lib/mina.ts
+++ b/src/lib/mina.ts
@@ -1,69 +1,69 @@
+import { Ledger } from '../snarky.js';
+import { Field } from './core.js';
+import { UInt32, UInt64 } from './int.js';
+import { PrivateKey, PublicKey } from './signature.js';
+import {
+  addMissingProofs,
+  addMissingSignatures,
+  FeePayerUnsigned,
+  ZkappCommand,
+  AccountUpdate,
+  ZkappPublicInput,
+  TokenId,
+  CallForest,
+  Authorization,
+  Actions,
+  Events,
+  dummySignature,
+} from './account_update.js';
+import * as Fetch from './fetch.js';
+import { assertPreconditionInvariants, NetworkValue } from './precondition.js';
+import { cloneCircuitValue, toConstant } from './circuit_value.js';
+import { Empty, Proof, verify } from './proof_system.js';
+import { Context } from './global-context.js';
+import { SmartContract } from './zkapp.js';
+import { invalidTransactionError } from './mina/errors.js';
 import { Types, TypesBigint } from '../bindings/mina-transaction/types.js';
+import { Account } from './mina/account.js';
+import { TransactionCost, TransactionLimits } from './mina/constants.js';
+import { Provable } from './provable.js';
+import { prettifyStacktrace } from './errors.js';
+import { Ml } from './ml/conversion.js';
 import {
   transactionCommitments,
   verifyAccountUpdateSignature,
 } from '../mina-signer/src/sign-zkapp-command.js';
-import { Ledger } from '../snarky.js';
-import {
-  AccountUpdate,
-  Actions,
-  Authorization,
-  CallForest,
-  Events,
-  FeePayerUnsigned,
-  TokenId,
-  ZkappCommand,
-  ZkappPublicInput,
-  addMissingProofs,
-  addMissingSignatures,
-  dummySignature,
-} from './account_update.js';
-import { cloneCircuitValue, toConstant } from './circuit_value.js';
-import { Field } from './core.js';
-import { prettifyStacktrace } from './errors.js';
-import * as Fetch from './fetch.js';
-import { Context } from './global-context.js';
-import { UInt32, UInt64 } from './int.js';
-import { Account } from './mina/account.js';
-import { TransactionCost, TransactionLimits } from './mina/constants.js';
-import { invalidTransactionError } from './mina/errors.js';
-import { Ml } from './ml/conversion.js';
-import { NetworkValue, assertPreconditionInvariants } from './precondition.js';
-import { Empty, Proof, verify } from './proof_system.js';
-import { Provable } from './provable.js';
-import { PrivateKey, PublicKey } from './signature.js';
-import { SmartContract } from './zkapp.js';
 
 export {
-  ActionStates,
+  createTransaction,
   BerkeleyQANet,
-  CurrentTransaction,
-  FeePayerSpec,
-  LocalBlockchain,
   Network,
+  LocalBlockchain,
+  currentTransaction,
+  CurrentTransaction,
   Transaction,
   TransactionId,
-  accountCreationFee,
   activeInstance,
-  createTransaction,
-  currentSlot,
-  currentTransaction,
-  faucet,
-  fetchActions,
-  fetchEvents,
-  // for internal testing only
-  filterGroups,
-  getAccount,
-  getActions,
-  getBalance,
-  getNetworkState,
-  getProofsEnabled,
-  hasAccount,
-  sendTransaction,
-  sender,
   setActiveInstance,
   transaction,
+  sender,
+  currentSlot,
+  getAccount,
+  hasAccount,
+  getBalance,
+  getNetworkState,
+  accountCreationFee,
+  sendTransaction,
+  fetchEvents,
+  fetchActions,
+  getActions,
+  FeePayerSpec,
+  ActionStates,
+  faucet,
   waitForFunding,
+  getProofsEnabled,
+  // for internal testing only
+  filterGroups,
 };
 interface TransactionId {
   isSuccess: boolean;


### PR DESCRIPTION
This PR attempts to provide the simple API integrated into `o1js` in order to retrieve and release accounts managed by [lightnet Mina network](https://hub.docker.com/r/o1labs/mina-local-network).
`Note`: Keep in mind that `accounts manager` synchronises access to the endpoints in order to guarantee the proper accounts management for concurrent requests.

As an example the corresponding live test was updated as well.

1. Run the local Mina:

  ```shell
  docker run -id --env NETWORK_TYPE="single-node" --env PROOF_LEVEL="none" -p 3085:3085 -p 5432:5432 -p 8080:8080 -p 8181:8181 o1labs/mina-local-network:rampup-latest-lightnet
  ```

2. Build `o1js`:

  ```shell
  npm run build && npm run build:node
  ```

3. Run live tests:

  ```shell
  USE_CUSTOM_LOCAL_NETWORK=true TEST_TYPE="Live integration tests" ./run-ci-tests.sh
  ```

In result test will pass and in Docker container you should see the output like:

```shell
[2023-10-08 12:54:13] [INFO   ] Checking the 'http://localhost:8080/graphql' availability...
[2023-10-08 12:54:13] [INFO   ] An attempt to acquire non-zkApp account...
[2023-10-08 12:54:13] [INFO   ] Acquired account with Index #636 and Public Key: B62qrYhoJRyTtQ7RdU3KutCBQHs69BgYnMBjSY3E72QTNH6CkneM84B
[2023-10-08 12:56:10] [INFO   ] Account with public key B62qrYhoJRyTtQ7RdU3KutCBQHs69BgYnMBjSY3E72QTNH6CkneM84B is set to be released.
```

---

We have linter dependency but we don't provide scripts nor automatic linting on commit, hence some imports/exports were reformatted.
Am I missing something or we need to enable linter properly? 

---

Closes https://github.com/o1-labs/quality-and-testing/issues/121
Closes https://github.com/o1-labs/o1js/issues/1074