### PR TITLE
make Nullifier experimental

### DIFF
--- a/src/examples/nullifier.ts
+++ b/src/examples/nullifier.ts
@@ -1,6 +1,6 @@
 import {
   PrivateKey,
-  Nullifier,
+  Experimental,
   Field,
   SmartContract,
   state,
@@ -17,7 +17,7 @@ class PayoutOnlyOnce extends SmartContract {
   @state(Field) nullifierRoot = State<Field>();
   @state(Field) nullifierMessage = State<Field>();
 
-  @method payout(nullifier: Nullifier) {
+  @method payout(nullifier: Experimental.Nullifier) {
     let nullifierRoot = this.nullifierRoot.getAndAssertEquals();
     let nullifierMessage = this.nullifierMessage.getAndAssertEquals();
 
@@ -87,7 +87,7 @@ console.log(`zkapp balance: ${zkapp.account.balance.get().div(1e9)} MINA`);
 
 console.log('generating nullifier');
 
-let jsonNullifier = Nullifier.createTestNullifier(
+let jsonNullifier = Experimental.Nullifier.createTestNullifier(
   [nullifierMessage],
   privilegedKey
 );
@@ -96,7 +96,7 @@ console.log(jsonNullifier);
 console.log('pay out');
 tx = await Mina.transaction(sender, () => {
   AccountUpdate.fundNewAccount(sender);
-  zkapp.payout(Nullifier.fromJSON(jsonNullifier));
+  zkapp.payout(Experimental.Nullifier.fromJSON(jsonNullifier));
 });
 await tx.prove();
 await tx.sign([senderKey]).send();
@@ -110,7 +110,7 @@ console.log('trying second pay out');
 
 try {
   tx = await Mina.transaction(sender, () => {
-    zkapp.payout(Nullifier.fromJSON(jsonNullifier));
+    zkapp.payout(Experimental.Nullifier.fromJSON(jsonNullifier));
   });
 
   await tx.prove();

--- a/src/index.ts
+++ b/src/index.ts
@@ -72,13 +72,12 @@ export { Character, CircuitString } from './lib/string.js';
 export { MerkleTree, MerkleWitness } from './lib/merkle_tree.js';
 export { MerkleMap, MerkleMapWitness } from './lib/merkle_map.js';
 
-export { Nullifier } from './lib/nullifier.js';
-
 // experimental APIs
 import { ZkProgram } from './lib/proof_system.js';
 import { Callback } from './lib/zkapp.js';
 import { createChildAccountUpdate } from './lib/account_update.js';
 import { memoizeWitness } from './lib/provable.js';
+import { Nullifier as Nullifier_ } from './lib/nullifier.js';
 export { Experimental };
 
 const Experimental_ = {
@@ -86,10 +85,11 @@ const Experimental_ = {
   createChildAccountUpdate,
   memoizeWitness,
   ZkProgram,
+  Nullifier_,
 };
 
 type Callback_<Result> = Callback<Result>;
-
+type Nullifier = Nullifier_;
 /**
  * This module exposes APIs that are unstable, in the sense that the API surface is expected to change.
  * (Not unstable in the sense that they are less functional or tested than other parts.)
@@ -100,6 +100,8 @@ namespace Experimental {
   export let memoizeWitness = Experimental_.memoizeWitness;
   export let Callback = Experimental_.Callback;
   export type Callback<Result> = Callback_<Result>;
+  export let Nullifier = Experimental_.Nullifier_;
+  export type Nullifier = Nullifier_;
 }
 
 Error.stackTraceLimit = 1000;


### PR DESCRIPTION
moves `Nullifier` under the `Experimental` namespace in light of https://github.com/o1-labs/o1js/issues/1174