### PR TITLE
Cache prover keys

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,12 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 - Internal support for several custom gates (range check, bitwise operations, foreign field operations) and lookup tables https://github.com/o1-labs/o1js/pull/1176
 
+### Changed
+
+- Use cached prover keys in `compile()` when running in Node.js https://github.com/o1-labs/o1js/pull/1187
+  - Caching is configurable by passing a custom `Storable` (new export) to `compile()`
+  - By default, prover keys are stored in an OS-dependent cache directory; `~/.cache/pickles` on Mac and Linux
+
 ## [0.13.1](https://github.com/o1-labs/o1js/compare/c2f392fe5...045faa7)
 
 ### Breaking changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,22 +31,17 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 ### Added
 
 - `Lightnet` namespace to interact with the account manager provided by the [lightnet Mina network](https://hub.docker.com/r/o1labs/mina-local-network). https://github.com/o1-labs/o1js/pull/1167
-
 - Internal support for several custom gates (range check, bitwise operations, foreign field operations) and lookup tables https://github.com/o1-labs/o1js/pull/1176
-
 - `Gadgets.rangeCheck64()`, new provable method to do efficient 64-bit range checks using lookup tables https://github.com/o1-labs/o1js/pull/1181
-
 - `Gadgets.rotate()`, new provable method to support bitwise rotation for native field elements. https://github.com/o1-labs/o1js/pull/1182
-
 - `Gadgets.xor()`, new provable method to support bitwise xor for native field elements. https://github.com/o1-labs/o1js/pull/1177
-
 - `Proof.dummy()` to create dummy proofs https://github.com/o1-labs/o1js/pull/1188
   - You can use this to write ZkPrograms that handle the base case and the inductive case in the same method.
 
 ### Changed
 
 - Use cached prover keys in `compile()` when running in Node.js https://github.com/o1-labs/o1js/pull/1187
-  - Caching is configurable by passing a custom `Storable` (new export) to `compile()`
+  - Caching is configurable by passing a custom `Cache` (new export) to `compile()`
   - By default, prover keys are stored in an OS-dependent cache directory; `~/.cache/pickles` on Mac and Linux
 
 ## [0.13.1](https://github.com/o1-labs/o1js/compare/c2f392fe5...045faa7)

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "blakejs": "1.2.1",
+        "cachedir": "^2.4.0",
         "detect-gpu": "^5.0.5",
         "isomorphic-fetch": "^3.0.0",
         "js-sha256": "^0.9.0",
@@ -2619,6 +2620,14 @@
       "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
       "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
       "dev": true
+    },
+    "node_modules/cachedir": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/cachedir/-/cachedir-2.4.0.tgz",
+      "integrity": "sha512-9EtFOZR8g22CL7BWjJ9BUx1+A/djkofnyW3aOXZORNW2kxoUpx2h+uN2cOqwPmFhnpVmxg+KW2OjOSgChTEvsQ==",
+      "engines": {
+        "node": ">=6"
+      }
     },
     "node_modules/callsites": {
       "version": "3.1.0",
@@ -9760,6 +9769,11 @@
       "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
       "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
       "dev": true
+    },
+    "cachedir": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/cachedir/-/cachedir-2.4.0.tgz",
+      "integrity": "sha512-9EtFOZR8g22CL7BWjJ9BUx1+A/djkofnyW3aOXZORNW2kxoUpx2h+uN2cOqwPmFhnpVmxg+KW2OjOSgChTEvsQ=="
     },
     "callsites": {
       "version": "3.1.0",

--- a/package.json
+++ b/package.json
@@ -96,6 +96,7 @@
   },
   "dependencies": {
     "blakejs": "1.2.1",
+    "cachedir": "^2.4.0",
     "detect-gpu": "^5.0.5",
     "isomorphic-fetch": "^3.0.0",
     "js-sha256": "^0.9.0",

--- a/src/examples/simple_zkapp.ts
+++ b/src/examples/simple_zkapp.ts
@@ -77,7 +77,9 @@ let zkappKey = PrivateKey.random();
 let zkappAddress = zkappKey.toPublicKey();
 
 // a special account that is allowed to pull out half of the zkapp balance, once
-let privilegedKey = PrivateKey.random();
+let privilegedKey = PrivateKey.fromBase58(
+  'EKEeoESE2A41YQnSht9f7mjiKpJSeZ4jnfHXYatYi8xJdYSxWBep'
+);
 let privilegedAddress = privilegedKey.toPublicKey();
 
 let initialBalance = 10_000_000_000;

--- a/src/examples/simple_zkapp.web.ts
+++ b/src/examples/simple_zkapp.web.ts
@@ -1,0 +1,131 @@
+import {
+  Field,
+  state,
+  State,
+  method,
+  UInt64,
+  PrivateKey,
+  SmartContract,
+  Mina,
+  AccountUpdate,
+  Bool,
+  PublicKey,
+} from 'o1js';
+
+const doProofs = true;
+
+const beforeGenesis = UInt64.from(Date.now());
+
+class SimpleZkapp extends SmartContract {
+  @state(Field) x = State<Field>();
+
+  events = { update: Field, payout: UInt64, payoutReceiver: PublicKey };
+
+  @method init() {
+    super.init();
+    this.x.set(initialState);
+  }
+
+  @method update(y: Field): Field {
+    this.account.provedState.assertEquals(Bool(true));
+    this.network.timestamp.assertBetween(beforeGenesis, UInt64.MAXINT());
+    this.emitEvent('update', y);
+    let x = this.x.get();
+    this.x.assertEquals(x);
+    let newX = x.add(y);
+    this.x.set(newX);
+    return newX;
+  }
+
+  /**
+   * This method allows a certain privileged account to claim half of the zkapp balance, but only once
+   * @param caller the privileged account
+   */
+  @method payout(caller: PrivateKey) {
+    this.account.provedState.assertEquals(Bool(true));
+
+    // check that caller is the privileged account
+    let callerAddress = caller.toPublicKey();
+    callerAddress.assertEquals(privilegedAddress);
+
+    // assert that the caller account is new - this way, payout can only happen once
+    let callerAccountUpdate = AccountUpdate.create(callerAddress);
+    callerAccountUpdate.account.isNew.assertEquals(Bool(true));
+    // pay out half of the zkapp balance to the caller
+    let balance = this.account.balance.get();
+    this.account.balance.assertEquals(balance);
+    let halfBalance = balance.div(2);
+    this.send({ to: callerAccountUpdate, amount: halfBalance });
+
+    // emit some events
+    this.emitEvent('payoutReceiver', callerAddress);
+    this.emitEvent('payout', halfBalance);
+  }
+}
+
+let Local = Mina.LocalBlockchain({ proofsEnabled: doProofs });
+Mina.setActiveInstance(Local);
+
+// a test account that pays all the fees, and puts additional funds into the zkapp
+let { privateKey: senderKey, publicKey: sender } = Local.testAccounts[0];
+
+// the zkapp account
+let zkappKey = PrivateKey.random();
+let zkappAddress = zkappKey.toPublicKey();
+
+// a special account that is allowed to pull out half of the zkapp balance, once
+let privilegedKey = PrivateKey.fromBase58(
+  'EKEeoESE2A41YQnSht9f7mjiKpJSeZ4jnfHXYatYi8xJdYSxWBep'
+);
+let privilegedAddress = privilegedKey.toPublicKey();
+
+let initialBalance = 10_000_000_000;
+let initialState = Field(1);
+let zkapp = new SimpleZkapp(zkappAddress);
+
+if (doProofs) {
+  console.log('compile');
+  await SimpleZkapp.compile();
+}
+
+console.log('deploy');
+let tx = await Mina.transaction(sender, () => {
+  let senderUpdate = AccountUpdate.fundNewAccount(sender);
+  senderUpdate.send({ to: zkappAddress, amount: initialBalance });
+  zkapp.deploy({ zkappKey });
+});
+await tx.prove();
+await tx.sign([senderKey]).send();
+
+console.log('initial state: ' + zkapp.x.get());
+console.log(`initial balance: ${zkapp.account.balance.get().div(1e9)} MINA`);
+
+let account = Mina.getAccount(zkappAddress);
+console.log('account state is proved:', account.zkapp?.provedState.toBoolean());
+
+console.log('update');
+tx = await Mina.transaction(sender, () => {
+  zkapp.update(Field(3));
+});
+await tx.prove();
+await tx.sign([senderKey]).send();
+
+// pay more into the zkapp -- this doesn't need a proof
+console.log('receive');
+tx = await Mina.transaction(sender, () => {
+  let payerAccountUpdate = AccountUpdate.createSigned(sender);
+  payerAccountUpdate.send({ to: zkappAddress, amount: UInt64.from(8e9) });
+});
+await tx.sign([senderKey]).send();
+
+console.log('payout');
+tx = await Mina.transaction(sender, () => {
+  AccountUpdate.fundNewAccount(sender);
+  zkapp.payout(privilegedKey);
+});
+await tx.prove();
+await tx.sign([senderKey]).send();
+sender;
+
+console.log('final state: ' + zkapp.x.get());
+console.log(`final balance: ${zkapp.account.balance.get().div(1e9)} MINA`);

--- a/src/examples/simple_zkapp.web.ts
+++ b/src/examples/simple_zkapp.web.ts
@@ -125,7 +125,6 @@ tx = await Mina.transaction(sender, () => {
 });
 await tx.prove();
 await tx.sign([senderKey]).send();
-sender;
 
 console.log('final state: ' + zkapp.x.get());
 console.log(`final balance: ${zkapp.account.balance.get().div(1e9)} MINA`);

--- a/src/index.ts
+++ b/src/index.ts
@@ -44,6 +44,7 @@ export {
   Undefined,
   Void,
 } from './lib/proof_system.js';
+export { Storable } from './lib/storable.js';
 
 export {
   Token,

--- a/src/index.ts
+++ b/src/index.ts
@@ -45,7 +45,7 @@ export {
   Undefined,
   Void,
 } from './lib/proof_system.js';
-export { Cache } from './lib/storable.js';
+export { Cache } from './lib/proof-system/cache.js';
 
 export {
   Token,

--- a/src/index.ts
+++ b/src/index.ts
@@ -45,7 +45,7 @@ export {
   Undefined,
   Void,
 } from './lib/proof_system.js';
-export { Storable } from './lib/storable.js';
+export { Cache } from './lib/storable.js';
 
 export {
   Token,

--- a/src/lib/ml/base.ts
+++ b/src/lib/ml/base.ts
@@ -10,6 +10,7 @@ export {
   MlBytes,
   MlResult,
   MlUnit,
+  MlString,
 };
 
 // ocaml types
@@ -27,6 +28,7 @@ type MlUnit = 0;
  * see https://github.com/ocsigen/js_of_ocaml/blob/master/runtime/mlBytes.js
  */
 type MlBytes = { t: number; c: string; l: number };
+type MlString = MlBytes;
 
 const MlArray = {
   to<T>(arr: T[]): MlArray<T> {

--- a/src/lib/ml/base.ts
+++ b/src/lib/ml/base.ts
@@ -1,7 +1,7 @@
 /**
  * This module contains basic methods for interacting with OCaml
  */
-export { MlArray, MlTuple, MlList, MlOption, MlBool, MlBytes };
+export { MlArray, MlTuple, MlList, MlOption, MlBool, MlBytes, MlResult };
 
 // ocaml types
 
@@ -10,6 +10,7 @@ type MlArray<T> = [0, ...T[]];
 type MlList<T> = [0, T, 0 | MlList<T>];
 type MlOption<T> = 0 | [0, T];
 type MlBool = 0 | 1;
+type MlResult<T, E> = [0, T] | [1, E];
 
 /**
  * js_of_ocaml representation of a byte array,
@@ -85,3 +86,12 @@ const MlOption = Object.assign(
     },
   }
 );
+
+const MlResult = {
+  return<T>(t: T): MlResult<T, any> {
+    return [0, t];
+  },
+  unitError(): MlResult<any, 0> {
+    return [1, 0];
+  },
+};

--- a/src/lib/ml/base.ts
+++ b/src/lib/ml/base.ts
@@ -1,7 +1,16 @@
 /**
  * This module contains basic methods for interacting with OCaml
  */
-export { MlArray, MlTuple, MlList, MlOption, MlBool, MlBytes, MlResult };
+export {
+  MlArray,
+  MlTuple,
+  MlList,
+  MlOption,
+  MlBool,
+  MlBytes,
+  MlResult,
+  MlUnit,
+};
 
 // ocaml types
 
@@ -11,6 +20,7 @@ type MlList<T> = [0, T, 0 | MlList<T>];
 type MlOption<T> = 0 | [0, T];
 type MlBool = 0 | 1;
 type MlResult<T, E> = [0, T] | [1, E];
+type MlUnit = 0;
 
 /**
  * js_of_ocaml representation of a byte array,

--- a/src/lib/ml/base.ts
+++ b/src/lib/ml/base.ts
@@ -88,10 +88,10 @@ const MlOption = Object.assign(
 );
 
 const MlResult = {
-  return<T>(t: T): MlResult<T, any> {
+  ok<T, E>(t: T): MlResult<T, E> {
     return [0, t];
   },
-  unitError(): MlResult<any, 0> {
+  unitError<T>(): MlResult<T, 0> {
     return [1, 0];
   },
 };

--- a/src/lib/proof-system/cache.ts
+++ b/src/lib/proof-system/cache.ts
@@ -118,7 +118,7 @@ const FileSystem = (cacheDirectory: string): Cache => ({
   canWrite: jsEnvironment === 'node',
 });
 
-const FileSystemDefault = FileSystem(cacheDir('pickles'));
+const FileSystemDefault = FileSystem(cacheDir('o1js'));
 
 const Cache = {
   /**

--- a/src/lib/proof-system/cache.ts
+++ b/src/lib/proof-system/cache.ts
@@ -4,8 +4,8 @@ import {
   mkdirSync,
   resolve,
   cacheDir,
-} from './util/fs.js';
-import { jsEnvironment } from '../bindings/crypto/bindings/env.js';
+} from '../util/fs.js';
+import { jsEnvironment } from '../../bindings/crypto/bindings/env.js';
 
 export { Cache, CacheHeader, cacheHeaderVersion };
 

--- a/src/lib/proof-system/cache.ts
+++ b/src/lib/proof-system/cache.ts
@@ -41,7 +41,7 @@ type CommonHeader = {
    */
   version: number;
   /**
-   * An identifier that is persistent even as version of the data change. Safe to use as a file path.
+   * An identifier that is persistent even as versions of the data change. Safe to use as a file path.
    */
   persistentId: string;
   /**

--- a/src/lib/proof-system/cache.ts
+++ b/src/lib/proof-system/cache.ts
@@ -19,7 +19,7 @@ type Cache = {
    *
    * @param header A small header to identify what is read from the cache.
    */
-  read(header: CacheHeader): Uint8Array;
+  read(header: CacheHeader): Uint8Array | undefined;
   /**
    * Write a value to the cache.
    *
@@ -27,6 +27,10 @@ type Cache = {
    * @param value The value to write to the cache, as a byte array.
    */
   write(header: CacheHeader, value: Uint8Array): void;
+  /**
+   * Indicates whether the cache is writable.
+   */
+  canWrite: boolean;
 };
 
 const cacheHeaderVersion = 0.1;
@@ -75,6 +79,7 @@ const None: Cache = {
   write() {
     throw Error('not available');
   },
+  canWrite: false,
 };
 
 const FileSystem = (cacheDirectory: string): Cache => ({
@@ -95,6 +100,7 @@ const FileSystem = (cacheDirectory: string): Cache => ({
       encoding: dataType === 'string' ? 'utf8' : undefined,
     });
   },
+  canWrite: jsEnvironment === 'node',
 });
 
 const FileSystemDefault = FileSystem(cacheDir('pickles'));

--- a/src/lib/proof-system/prover-keys.ts
+++ b/src/lib/proof-system/prover-keys.ts
@@ -102,7 +102,7 @@ type AnyValue =
   | [KeyType.WrapVerificationKey, MlWrapVerificationKey];
 
 function parseHeader(
-  programId: string,
+  programName: string,
   methods: MethodInterface[],
   key: AnyKey
 ): CacheHeader {
@@ -113,13 +113,15 @@ function parseHeader(
       let kind = snarkKeyStringKind[key[0]];
       let methodIndex = key[1][3];
       let methodName = methods[methodIndex].methodName;
-      // TODO sanitize unique id
-      let uniqueId = `${kind}-${programId}-${methodIndex}-${methodName}-${hash}`;
+      // TODO sanitize ids
+      let persistentId = `${kind}-${programName}-${methodName}`;
+      let uniqueId = `${kind}-${programName}-${methodIndex}-${methodName}-${hash}`;
       return {
         version: cacheHeaderVersion,
         uniqueId,
         kind,
-        programId,
+        persistentId,
+        programName,
         methodName,
         methodIndex,
         hash,
@@ -130,13 +132,15 @@ function parseHeader(
     case KeyType.WrapVerificationKey: {
       let kind = snarkKeyStringKind[key[0]];
       let dataType = snarkKeySerializationType[key[0]];
-      // TODO sanitize unique id
-      let uniqueId = `${kind}-${programId}-${hash}`;
+      // TODO sanitize ids
+      let persistentId = `${kind}-${programName}`;
+      let uniqueId = `${kind}-${programName}-${hash}`;
       return {
         version: cacheHeaderVersion,
         uniqueId,
         kind,
-        programId,
+        persistentId,
+        programName,
         hash,
         dataType,
       };

--- a/src/lib/proof-system/prover-keys.ts
+++ b/src/lib/proof-system/prover-keys.ts
@@ -12,72 +12,6 @@ import type { MethodInterface } from '../proof_system.js';
 export { parseHeader, encodeProverKey, decodeProverKey, AnyKey, AnyValue };
 export type { MlWrapVerificationKey };
 
-// Plonk_constraint_system.Make()().t
-
-class MlConstraintSystem {
-  // opaque type
-}
-
-// Dlog_plonk_based_keypair.Make().t
-
-type MlBackendKeyPair<WasmIndex> = [
-  _: 0,
-  index: WasmIndex,
-  cs: MlConstraintSystem
-];
-
-// Snarky_keys_header.t
-
-type MlSnarkKeysHeader = [
-  _: 0,
-  headerVersion: number,
-  kind: [_: 0, type: MlString, identifier: MlString],
-  constraintConstants: unknown,
-  commits: unknown,
-  length: number,
-  commitDate: MlString,
-  constraintSystemHash: MlString,
-  identifyingHash: MlString
-];
-
-// Pickles.Cache.{Step,Wrap}.Key.Proving.t
-
-type MlStepProvingKeyHeader = [
-  _: 0,
-  typeEqual: number,
-  snarkKeysHeader: MlSnarkKeysHeader,
-  index: number,
-  constraintSystem: MlConstraintSystem
-];
-
-type MlStepVerificationKeyHeader = [
-  _: 0,
-  typeEqual: number,
-  snarkKeysHeader: MlSnarkKeysHeader,
-  index: number,
-  digest: unknown
-];
-
-type MlWrapProvingKeyHeader = [
-  _: 0,
-  typeEqual: number,
-  snarkKeysHeader: MlSnarkKeysHeader,
-  constraintSystem: MlConstraintSystem
-];
-
-type MlWrapVerificationKeyHeader = [
-  _: 0,
-  typeEqual: number,
-  snarkKeysHeader: MlSnarkKeysHeader,
-  digest: unknown
-];
-
-// Pickles.Verification_key.t
-
-class MlWrapVerificationKey {
-  // opaque type
-}
-
 // pickles_bindings.ml, any_key enum
 
 enum KeyType {
@@ -86,8 +20,6 @@ enum KeyType {
   WrapProvingKey,
   WrapVerificationKey,
 }
-
-// TODO better names
 
 type AnyKey =
   | [KeyType.StepProvingKey, MlStepProvingKeyHeader]
@@ -233,3 +165,71 @@ const snarkKeySerializationType = {
   [KeyType.WrapProvingKey]: 'bytes',
   [KeyType.WrapVerificationKey]: 'string',
 } as const;
+
+// pickles types
+
+// Plonk_constraint_system.Make()().t
+
+class MlConstraintSystem {
+  // opaque type
+}
+
+// Dlog_plonk_based_keypair.Make().t
+
+type MlBackendKeyPair<WasmIndex> = [
+  _: 0,
+  index: WasmIndex,
+  cs: MlConstraintSystem
+];
+
+// Snarky_keys_header.t
+
+type MlSnarkKeysHeader = [
+  _: 0,
+  headerVersion: number,
+  kind: [_: 0, type: MlString, identifier: MlString],
+  constraintConstants: unknown,
+  commits: unknown,
+  length: number,
+  commitDate: MlString,
+  constraintSystemHash: MlString,
+  identifyingHash: MlString
+];
+
+// Pickles.Cache.{Step,Wrap}.Key.Proving.t
+
+type MlStepProvingKeyHeader = [
+  _: 0,
+  typeEqual: number,
+  snarkKeysHeader: MlSnarkKeysHeader,
+  index: number,
+  constraintSystem: MlConstraintSystem
+];
+
+type MlStepVerificationKeyHeader = [
+  _: 0,
+  typeEqual: number,
+  snarkKeysHeader: MlSnarkKeysHeader,
+  index: number,
+  digest: unknown
+];
+
+type MlWrapProvingKeyHeader = [
+  _: 0,
+  typeEqual: number,
+  snarkKeysHeader: MlSnarkKeysHeader,
+  constraintSystem: MlConstraintSystem
+];
+
+type MlWrapVerificationKeyHeader = [
+  _: 0,
+  typeEqual: number,
+  snarkKeysHeader: MlSnarkKeysHeader,
+  digest: unknown
+];
+
+// Pickles.Verification_key.t
+
+class MlWrapVerificationKey {
+  // opaque type
+}

--- a/src/lib/proof-system/prover-keys.ts
+++ b/src/lib/proof-system/prover-keys.ts
@@ -74,36 +74,24 @@ function encodeProverKey(value: AnyValue): Uint8Array {
   switch (value[0]) {
     case KeyType.StepProvingKey: {
       let index = value[1][1];
-      console.time('encode index');
       let encoded = wasm.caml_pasta_fp_plonk_index_encode(index);
-      console.timeEnd('encode index');
       return encoded;
     }
     case KeyType.StepVerificationKey: {
       let vkMl = value[1];
-      console.time('create rust conversion');
       const rustConversion = getRustConversion(getWasm());
-      console.timeEnd('create rust conversion');
-      console.time('verifierIndexToRust');
       let vkWasm = rustConversion.fp.verifierIndexToRust(vkMl);
-      console.timeEnd('verifierIndexToRust');
-      console.time('encode vk');
       let string = wasm.caml_pasta_fp_plonk_verifier_index_serialize(vkWasm);
-      console.timeEnd('encode vk');
       return new TextEncoder().encode(string);
     }
     case KeyType.WrapProvingKey: {
       let index = value[1][1];
-      console.time('encode wrap index');
       let encoded = wasm.caml_pasta_fq_plonk_index_encode(index);
-      console.timeEnd('encode wrap index');
       return encoded;
     }
     case KeyType.WrapVerificationKey: {
       let vk = value[1];
-      console.time('encode wrap vk');
       let string = Pickles.encodeVerificationKey(vk);
-      console.timeEnd('encode wrap vk');
       return new TextEncoder().encode(string);
     }
     default:
@@ -117,42 +105,30 @@ function decodeProverKey(key: AnyKey, bytes: Uint8Array): AnyValue {
   switch (key[0]) {
     case KeyType.StepProvingKey: {
       let srs = Pickles.loadSrsFp();
-      console.time('decode index');
       let index = wasm.caml_pasta_fp_plonk_index_decode(bytes, srs);
-      console.timeEnd('decode index');
       let cs = key[1][4];
       return [KeyType.StepProvingKey, [0, index, cs]];
     }
     case KeyType.StepVerificationKey: {
       let srs = Pickles.loadSrsFp();
       let string = new TextDecoder().decode(bytes);
-      console.time('decode vk');
       let vkWasm = wasm.caml_pasta_fp_plonk_verifier_index_deserialize(
         srs,
         string
       );
-      console.timeEnd('decode vk');
-      console.time('create rust conversion');
       const rustConversion = getRustConversion(getWasm());
-      console.timeEnd('create rust conversion');
-      console.time('verifierIndexFromRust');
       let vkMl = rustConversion.fp.verifierIndexFromRust(vkWasm);
-      console.timeEnd('verifierIndexFromRust');
       return [KeyType.StepVerificationKey, vkMl];
     }
     case KeyType.WrapProvingKey: {
       let srs = Pickles.loadSrsFq();
-      console.time('decode wrap index');
       let index = wasm.caml_pasta_fq_plonk_index_decode(bytes, srs);
-      console.timeEnd('decode wrap index');
       let cs = key[1][3];
       return [KeyType.WrapProvingKey, [0, index, cs]];
     }
     case KeyType.WrapVerificationKey: {
       let string = new TextDecoder().decode(bytes);
-      console.time('decode wrap vk');
       let vk = Pickles.decodeVerificationKey(string);
-      console.timeEnd('decode wrap vk');
       return [KeyType.WrapVerificationKey, vk];
     }
     default:

--- a/src/lib/proof-system/prover-keys.ts
+++ b/src/lib/proof-system/prover-keys.ts
@@ -113,9 +113,10 @@ function parseHeader(
       let kind = snarkKeyStringKind[key[0]];
       let methodIndex = key[1][3];
       let methodName = methods[methodIndex].methodName;
-      // TODO sanitize ids
-      let persistentId = `${kind}-${programName}-${methodName}`;
-      let uniqueId = `${kind}-${programName}-${methodIndex}-${methodName}-${hash}`;
+      let persistentId = sanitize(`${kind}-${programName}-${methodName}`);
+      let uniqueId = sanitize(
+        `${kind}-${programName}-${methodIndex}-${methodName}-${hash}`
+      );
       return {
         version: cacheHeaderVersion,
         uniqueId,
@@ -132,9 +133,8 @@ function parseHeader(
     case KeyType.WrapVerificationKey: {
       let kind = snarkKeyStringKind[key[0]];
       let dataType = snarkKeySerializationType[key[0]];
-      // TODO sanitize ids
-      let persistentId = `${kind}-${programName}`;
-      let uniqueId = `${kind}-${programName}-${hash}`;
+      let persistentId = sanitize(`${kind}-${programName}`);
+      let uniqueId = sanitize(`${kind}-${programName}-${hash}`);
       return {
         version: cacheHeaderVersion,
         uniqueId,
@@ -214,6 +214,10 @@ function decodeProverKey(key: AnyKey, bytes: Uint8Array): AnyValue {
       key satisfies never;
       throw Error('todo');
   }
+}
+
+function sanitize(string: string): string {
+  return string.toLowerCase().replace(/[^a-z0-9_-]/g, '_');
 }
 
 const snarkKeyStringKind = {

--- a/src/lib/proof-system/prover-keys.ts
+++ b/src/lib/proof-system/prover-keys.ts
@@ -43,12 +43,10 @@ type AnyValue =
 
 function encodeProverKey(value: AnyValue): Uint8Array {
   console.log('ENCODE', value);
-  // TODO
-  return value as any;
+  throw Error('todo');
 }
 
 function decodeProverKey(key: AnyKey, bytes: Uint8Array): AnyValue {
   console.log('DECODE', key);
-  // TODO
-  return bytes as any;
+  throw Error('todo');
 }

--- a/src/lib/proof-system/prover-keys.ts
+++ b/src/lib/proof-system/prover-keys.ts
@@ -6,7 +6,7 @@ import { Pickles, getWasm } from '../../snarky.js';
 import { VerifierIndex } from '../../bindings/crypto/bindings/kimchi-types.js';
 import { getRustConversion } from '../../bindings/crypto/bindings.js';
 import { MlString } from '../ml/base.js';
-import { CacheHeader, cacheHeaderVersion } from '../storable.js';
+import { CacheHeader, cacheHeaderVersion } from './cache.js';
 import type { MethodInterface } from '../proof_system.js';
 
 export { parseHeader, encodeProverKey, decodeProverKey, AnyKey, AnyValue };

--- a/src/lib/proof-system/prover-keys.ts
+++ b/src/lib/proof-system/prover-keys.ts
@@ -2,6 +2,7 @@ import {
   WasmPastaFpPlonkIndex,
   WasmPastaFqPlonkIndex,
 } from '../../bindings/compiled/node_bindings/plonk_wasm.cjs';
+import { getWasm } from '../../snarky.js';
 
 export { encodeProverKey, decodeProverKey, AnyKey, AnyValue };
 
@@ -37,16 +38,37 @@ type AnyKey =
 
 type AnyValue =
   | [KeyType.StepProverKey, MlBackendKeyPair<WasmPastaFpPlonkIndex>]
-  | [KeyType.StepVerifierKey, TODO]
+  | [KeyType.StepVerifierKey, unknown]
   | [KeyType.WrapProverKey, MlBackendKeyPair<WasmPastaFqPlonkIndex>]
-  | [KeyType.WrapVerifierKey, TODO];
+  | [KeyType.WrapVerifierKey, unknown];
 
 function encodeProverKey(value: AnyValue): Uint8Array {
   console.log('ENCODE', value);
-  throw Error('todo');
+  let wasm = getWasm();
+  switch (value[0]) {
+    case KeyType.StepProverKey:
+      return wasm.caml_pasta_fp_plonk_index_encode(value[1][1]);
+    default:
+      throw Error('todo');
+  }
 }
 
 function decodeProverKey(key: AnyKey, bytes: Uint8Array): AnyValue {
   console.log('DECODE', key);
-  throw Error('todo');
+  let wasm = getWasm();
+  switch (key[0]) {
+    case KeyType.StepProverKey:
+      throw Error('todo');
+    // return [
+    //   KeyType.StepProverKey,
+    //   [
+    //     0,
+    //     wasm.caml_pasta_fp_plonk_index_decode(bytes),
+    //     // TODO
+    //     null,
+    //   ],
+    // ];
+    default:
+      throw Error('todo');
+  }
 }

--- a/src/lib/proof-system/prover-keys.ts
+++ b/src/lib/proof-system/prover-keys.ts
@@ -9,14 +9,7 @@ import { MlString } from '../ml/base.js';
 import { CacheHeader, cacheHeaderVersion } from '../storable.js';
 import type { MethodInterface } from '../proof_system.js';
 
-export {
-  parseHeader,
-  encodeProverKey,
-  decodeProverKey,
-  proverKeyType,
-  AnyKey,
-  AnyValue,
-};
+export { parseHeader, encodeProverKey, decodeProverKey, AnyKey, AnyValue };
 export type { MlWrapVerificationKey };
 
 // Plonk_constraint_system.Make()().t
@@ -130,14 +123,23 @@ function parseHeader(
         methodName,
         methodIndex,
         hash,
+        dataType: snarkKeySerializationType[key[0]],
       };
     }
     case KeyType.WrapProvingKey:
     case KeyType.WrapVerificationKey: {
       let kind = snarkKeyStringKind[key[0]];
+      let dataType = snarkKeySerializationType[key[0]];
       // TODO sanitize unique id
       let uniqueId = `${kind}-${programId}-${hash}`;
-      return { version: cacheHeaderVersion, uniqueId, kind, programId, hash };
+      return {
+        version: cacheHeaderVersion,
+        uniqueId,
+        kind,
+        programId,
+        hash,
+        dataType,
+      };
     }
   }
 }
@@ -217,13 +219,9 @@ const snarkKeyStringKind = {
   [KeyType.WrapVerificationKey]: 'wrap-vk',
 } as const;
 
-const proverKeySerializationType = {
+const snarkKeySerializationType = {
   [KeyType.StepProvingKey]: 'bytes',
   [KeyType.StepVerificationKey]: 'string',
   [KeyType.WrapProvingKey]: 'bytes',
   [KeyType.WrapVerificationKey]: 'string',
 } as const;
-
-function proverKeyType(key: AnyKey): 'string' | 'bytes' {
-  return proverKeySerializationType[key[0]];
-}

--- a/src/lib/proof-system/prover-keys.ts
+++ b/src/lib/proof-system/prover-keys.ts
@@ -1,0 +1,54 @@
+import {
+  WasmPastaFpPlonkIndex,
+  WasmPastaFqPlonkIndex,
+} from '../../bindings/compiled/node_bindings/plonk_wasm.cjs';
+
+export { encodeProverKey, decodeProverKey, AnyKey, AnyValue };
+
+type TODO = any;
+type Opaque = unknown;
+
+type MlConstraintSystem = Opaque; // opaque
+
+// Dlog_plonk_based_keypair.Make().t
+
+type MlBackendKeyPair<WasmIndex> = [
+  _: 0,
+  index: WasmIndex,
+  cs: MlConstraintSystem
+];
+
+// pickles_bindings.ml, any_key enum
+
+enum KeyType {
+  StepProverKey,
+  StepVerifierKey,
+  WrapProverKey,
+  WrapVerifierKey,
+}
+
+// TODO better names
+
+type AnyKey =
+  | [KeyType.StepProverKey, TODO]
+  | [KeyType.StepVerifierKey, TODO]
+  | [KeyType.WrapProverKey, TODO]
+  | [KeyType.WrapVerifierKey, TODO];
+
+type AnyValue =
+  | [KeyType.StepProverKey, MlBackendKeyPair<WasmPastaFpPlonkIndex>]
+  | [KeyType.StepVerifierKey, TODO]
+  | [KeyType.WrapProverKey, MlBackendKeyPair<WasmPastaFqPlonkIndex>]
+  | [KeyType.WrapVerifierKey, TODO];
+
+function encodeProverKey(value: AnyValue): Uint8Array {
+  console.log('ENCODE', value);
+  // TODO
+  return value as any;
+}
+
+function decodeProverKey(key: AnyKey, bytes: Uint8Array): AnyValue {
+  console.log('DECODE', key);
+  // TODO
+  return bytes as any;
+}

--- a/src/lib/proof_system.ts
+++ b/src/lib/proof_system.ts
@@ -550,14 +550,23 @@ async function compileProgram({
   let storable: Pickles.Storable = [
     0,
     function read_(key, path) {
-      let bytes = read(path);
-      if (bytes === undefined) return MlResult.unitError();
-      return MlResult.ok(decodeProverKey(key, bytes));
+      try {
+        let bytes = read(path);
+        return MlResult.ok(decodeProverKey(key, bytes));
+      } catch (e: any) {
+        console.log('read failed', e.message);
+        return MlResult.unitError();
+      }
     },
     function write_(key, value, path) {
-      let bytes = encodeProverKey(value);
-      if (write(path, bytes)) return MlResult.ok(undefined);
-      return MlResult.unitError();
+      try {
+        let bytes = encodeProverKey(value);
+        write(path, bytes);
+        return MlResult.ok(undefined);
+      } catch (e: any) {
+        console.log('write failed', e.message);
+        return MlResult.unitError();
+      }
     },
     MlBool(true),
   ];

--- a/src/lib/proof_system.ts
+++ b/src/lib/proof_system.ts
@@ -590,7 +590,6 @@ async function compileProgram({
   let picklesCache: Pickles.Cache = [
     0,
     function read_(mlHeader) {
-      // TODO sanitize program name
       let header = parseHeader(proofSystemTag.name, methodIntfs, mlHeader);
       try {
         let bytes = cache.read(header);
@@ -602,7 +601,7 @@ async function compileProgram({
     },
     function write_(mlHeader, value) {
       if (!cache.canWrite) return MlResult.unitError();
-      // TODO sanitize program name
+
       let header = parseHeader(proofSystemTag.name, methodIntfs, mlHeader);
       try {
         let bytes = encodeProverKey(value);

--- a/src/lib/proof_system.ts
+++ b/src/lib/proof_system.ts
@@ -624,7 +624,7 @@ async function compileProgram({
           result = Pickles.compile(MlArray.to(rules), {
             publicInputSize: publicInputType.sizeInFields(),
             publicOutputSize: publicOutputType.sizeInFields(),
-            cache: picklesCache,
+            storable: picklesCache,
             overrideWrapDomain,
           });
         } finally {

--- a/src/lib/proof_system.ts
+++ b/src/lib/proof_system.ts
@@ -523,7 +523,7 @@ async function compileProgram({
   methods,
   gates,
   proofSystemTag,
-  storable: { read, write } = Storable.None,
+  storable: { read, write } = Storable.FileSystemDefault,
   overrideWrapDomain,
 }: {
   publicInputType: ProvablePure<any>;

--- a/src/lib/proof_system.ts
+++ b/src/lib/proof_system.ts
@@ -28,7 +28,7 @@ import { hashConstant } from './hash.js';
 import { MlArray, MlBool, MlResult, MlTuple, MlUnit } from './ml/base.js';
 import { MlFieldArray, MlFieldConstArray } from './ml/fields.js';
 import { FieldConst, FieldVar } from './field.js';
-import { Cache } from './storable.js';
+import { Cache } from './proof-system/cache.js';
 import {
   decodeProverKey,
   encodeProverKey,

--- a/src/lib/proof_system.ts
+++ b/src/lib/proof_system.ts
@@ -278,7 +278,7 @@ function ZkProgram<
       }
     | undefined;
 
-  async function compile() {
+  async function compile({ storable = Storable.FileSystemDefault } = {}) {
     let methodsMeta = analyzeMethods();
     let gates = methodsMeta.map((m) => m.gates);
     let { provers, verify, verificationKey } = await compileProgram({
@@ -288,6 +288,7 @@ function ZkProgram<
       methods: methodFunctions,
       gates,
       proofSystemTag: selfTag,
+      storable,
       overrideWrapDomain: config.overrideWrapDomain,
     });
     compileOutput = { provers, verify };
@@ -523,7 +524,7 @@ async function compileProgram({
   methods,
   gates,
   proofSystemTag,
-  storable: { read, write } = Storable.FileSystemDefault,
+  storable: { read, write },
   overrideWrapDomain,
 }: {
   publicInputType: ProvablePure<any>;
@@ -532,7 +533,7 @@ async function compileProgram({
   methods: ((...args: any) => void)[];
   gates: Gate[][];
   proofSystemTag: { name: string };
-  storable?: Storable;
+  storable: Storable;
   overrideWrapDomain?: 0 | 1 | 2;
 }) {
   let rules = methodIntfs.map((methodEntry, i) =>

--- a/src/lib/proof_system.ts
+++ b/src/lib/proof_system.ts
@@ -523,7 +523,7 @@ async function compileProgram({
   methods,
   gates,
   proofSystemTag,
-  storable: { read, write } = Storable.FileSystemDefault,
+  storable: { read, write } = Storable.None,
   overrideWrapDomain,
 }: {
   publicInputType: ProvablePure<any>;
@@ -556,7 +556,7 @@ async function compileProgram({
         let bytes = read(path, type);
         return MlResult.ok(decodeProverKey(key, bytes));
       } catch (e: any) {
-        console.log('read failed', e);
+        console.log('read failed', e.message);
         return MlResult.unitError();
       }
     },

--- a/src/lib/proof_system.ts
+++ b/src/lib/proof_system.ts
@@ -593,7 +593,6 @@ async function compileProgram({
         let bytes = read(path, type);
         return MlResult.ok(decodeProverKey(key, bytes));
       } catch (e: any) {
-        console.log('read failed', e.message);
         return MlResult.unitError();
       }
     },
@@ -604,7 +603,6 @@ async function compileProgram({
         write(path, bytes, type);
         return MlResult.ok(undefined);
       } catch (e: any) {
-        console.log('write failed', e.message);
         return MlResult.unitError();
       }
     },

--- a/src/lib/proof_system.ts
+++ b/src/lib/proof_system.ts
@@ -32,6 +32,7 @@ import { Storable } from './storable.js';
 import {
   decodeProverKey,
   encodeProverKey,
+  parseHeader,
   proverKeyType,
 } from './proof-system/prover-keys.js';
 
@@ -590,6 +591,8 @@ async function compileProgram({
   let storable: Pickles.Storable = [
     0,
     function read_(key, path) {
+      // TODO sanitize program name
+      let header = parseHeader(proofSystemTag.name, methodIntfs, key);
       try {
         let type = proverKeyType(key);
         let bytes = read(path, type);
@@ -599,6 +602,8 @@ async function compileProgram({
       }
     },
     function write_(key, value, path) {
+      // TODO sanitize program name
+      let header = parseHeader(proofSystemTag.name, methodIntfs, key);
       try {
         let type = proverKeyType(key);
         let bytes = encodeProverKey(value);

--- a/src/lib/proof_system.ts
+++ b/src/lib/proof_system.ts
@@ -32,6 +32,7 @@ import { Storable } from './storable.js';
 import {
   decodeProverKey,
   encodeProverKey,
+  proverKeyType,
 } from './proof-system/prover-keys.js';
 
 // public API
@@ -551,7 +552,8 @@ async function compileProgram({
     0,
     function read_(key, path) {
       try {
-        let bytes = read(path);
+        let type = proverKeyType(key);
+        let bytes = read(path, type);
         return MlResult.ok(decodeProverKey(key, bytes));
       } catch (e: any) {
         console.log('read failed', e);
@@ -560,8 +562,9 @@ async function compileProgram({
     },
     function write_(key, value, path) {
       try {
+        let type = proverKeyType(key);
         let bytes = encodeProverKey(value);
-        write(path, bytes);
+        write(path, bytes, type);
         return MlResult.ok(undefined);
       } catch (e: any) {
         console.log('write failed', e.message);

--- a/src/lib/proof_system.ts
+++ b/src/lib/proof_system.ts
@@ -554,7 +554,7 @@ async function compileProgram({
         let bytes = read(path);
         return MlResult.ok(decodeProverKey(key, bytes));
       } catch (e: any) {
-        console.log('read failed', e.message);
+        console.log('read failed', e);
         return MlResult.unitError();
       }
     },

--- a/src/lib/proof_system.ts
+++ b/src/lib/proof_system.ts
@@ -532,7 +532,7 @@ async function compileProgram({
   methods: ((...args: any) => void)[];
   gates: Gate[][];
   proofSystemTag: { name: string };
-  storable?: Storable<Uint8Array>;
+  storable?: Storable;
   overrideWrapDomain?: 0 | 1 | 2;
 }) {
   let rules = methodIntfs.map((methodEntry, i) =>

--- a/src/lib/storable.ts
+++ b/src/lib/storable.ts
@@ -1,0 +1,42 @@
+import { writeFileSync, readFileSync, mkdirSync } from './util/fs.js';
+import { jsEnvironment } from '../bindings/crypto/bindings/env.js';
+
+export { Storable };
+
+type Storable<T> = {
+  write(key: string, value: T): boolean;
+  read(key: string): T | undefined;
+};
+
+const FileSystem = (cacheDirectory: string): Storable<Uint8Array> => ({
+  read(key) {
+    if (jsEnvironment !== 'node') return undefined;
+    console.log('READ', key);
+    try {
+      let buffer = readFileSync(`${cacheDirectory}/${key}`);
+      return new Uint8Array(buffer.buffer);
+    } catch (e: any) {
+      console.log('read failed', e.message);
+      return undefined;
+    }
+  },
+  write(key, value) {
+    if (jsEnvironment !== 'node') return false;
+    console.log('WRITE', key);
+    try {
+      mkdirSync(cacheDirectory, { recursive: true });
+      writeFileSync(`${cacheDirectory}/${key}`, value);
+      return true;
+    } catch (e: any) {
+      console.log('write failed', e.message);
+      return false;
+    }
+  },
+});
+
+const FileSystemDefault = FileSystem('/tmp');
+
+const Storable = {
+  FileSystem,
+  FileSystemDefault,
+};

--- a/src/lib/storable.ts
+++ b/src/lib/storable.ts
@@ -7,7 +7,7 @@ import {
 } from './util/fs.js';
 import { jsEnvironment } from '../bindings/crypto/bindings/env.js';
 
-export { Storable };
+export { Storable, CacheHeader, cacheHeaderVersion };
 
 /**
  * Interface for storing and retrieving values, for caching.
@@ -31,6 +31,29 @@ type Storable = {
    */
   write(key: string, value: Uint8Array, type: 'string' | 'bytes'): void;
 };
+
+const cacheHeaderVersion = 0;
+
+type CommonHeader = { version: number; uniqueId: string };
+type StepKeyHeader<Kind> = {
+  kind: Kind;
+  programId: string;
+  methodName: string;
+  methodIndex: number;
+  hash: string;
+};
+type WrapKeyHeader<Kind> = { kind: Kind; programId: string; hash: string };
+
+/**
+ * A header that is passed to the caching layer, to support richer caching strategies.
+ */
+type CacheHeader = (
+  | StepKeyHeader<'step-pk'>
+  | StepKeyHeader<'step-vk'>
+  | WrapKeyHeader<'wrap-pk'>
+  | WrapKeyHeader<'wrap-vk'>
+) &
+  CommonHeader;
 
 const None: Storable = {
   read() {

--- a/src/lib/storable.ts
+++ b/src/lib/storable.ts
@@ -3,34 +3,27 @@ import { jsEnvironment } from '../bindings/crypto/bindings/env.js';
 
 export { Storable };
 
+/**
+ * Interface for storing and retrieving values for caching.
+ * `read()` and `write()` can just throw errors on failure.
+ */
 type Storable<T> = {
-  write(key: string, value: T): boolean;
-  read(key: string): T | undefined;
+  read(key: string): T;
+  write(key: string, value: T): void;
 };
 
 const FileSystem = (cacheDirectory: string): Storable<Uint8Array> => ({
   read(key) {
-    if (jsEnvironment !== 'node') return undefined;
+    if (jsEnvironment !== 'node') throw Error('file system not available');
     console.log('READ', key);
-    try {
-      let buffer = readFileSync(`${cacheDirectory}/${key}`);
-      return new Uint8Array(buffer.buffer);
-    } catch (e: any) {
-      console.log('read failed', e.message);
-      return undefined;
-    }
+    let buffer = readFileSync(`${cacheDirectory}/${key}`);
+    return new Uint8Array(buffer.buffer);
   },
   write(key, value) {
-    if (jsEnvironment !== 'node') return false;
+    if (jsEnvironment !== 'node') throw Error('file system not available');
     console.log('WRITE', key);
-    try {
-      mkdirSync(cacheDirectory, { recursive: true });
-      writeFileSync(`${cacheDirectory}/${key}`, value);
-      return true;
-    } catch (e: any) {
-      console.log('write failed', e.message);
-      return false;
-    }
+    mkdirSync(cacheDirectory, { recursive: true });
+    writeFileSync(`${cacheDirectory}/${key}`, value);
   },
 });
 

--- a/src/lib/storable.ts
+++ b/src/lib/storable.ts
@@ -7,12 +7,12 @@ export { Storable };
  * Interface for storing and retrieving values for caching.
  * `read()` and `write()` can just throw errors on failure.
  */
-type Storable<T> = {
-  read(key: string, type: 'string' | 'bytes'): T;
-  write(key: string, value: T, type: 'string' | 'bytes'): void;
+type Storable = {
+  read(key: string, type: 'string' | 'bytes'): Uint8Array;
+  write(key: string, value: Uint8Array, type: 'string' | 'bytes'): void;
 };
 
-const None: Storable<Uint8Array> = {
+const None: Storable = {
   read() {
     throw Error('not available');
   },
@@ -21,7 +21,7 @@ const None: Storable<Uint8Array> = {
   },
 };
 
-const FileSystem = (cacheDirectory: string): Storable<Uint8Array> => ({
+const FileSystem = (cacheDirectory: string): Storable => ({
   read(key, type: 'string' | 'bytes') {
     if (jsEnvironment !== 'node') throw Error('file system not available');
     console.log('READ', key);

--- a/src/lib/storable.ts
+++ b/src/lib/storable.ts
@@ -12,6 +12,15 @@ type Storable<T> = {
   write(key: string, value: T, type: 'string' | 'bytes'): void;
 };
 
+const None: Storable<Uint8Array> = {
+  read() {
+    throw Error('not available');
+  },
+  write() {
+    throw Error('not available');
+  },
+};
+
 const FileSystem = (cacheDirectory: string): Storable<Uint8Array> => ({
   read(key, type: 'string' | 'bytes') {
     if (jsEnvironment !== 'node') throw Error('file system not available');
@@ -39,4 +48,5 @@ const FileSystemDefault = FileSystem('/tmp');
 const Storable = {
   FileSystem,
   FileSystemDefault,
+  None,
 };

--- a/src/lib/storable.ts
+++ b/src/lib/storable.ts
@@ -1,14 +1,34 @@
-import { writeFileSync, readFileSync, mkdirSync, cacheDir } from './util/fs.js';
+import {
+  writeFileSync,
+  readFileSync,
+  mkdirSync,
+  resolve,
+  cacheDir,
+} from './util/fs.js';
 import { jsEnvironment } from '../bindings/crypto/bindings/env.js';
 
 export { Storable };
 
 /**
- * Interface for storing and retrieving values for caching.
+ * Interface for storing and retrieving values, for caching.
  * `read()` and `write()` can just throw errors on failure.
  */
 type Storable = {
+  /**
+   * Read a value from the cache.
+   *
+   * @param key The key to read from the cache. Can safely be used as a file path.
+   * @param type Specifies whether the data to be read is a utf8-encoded string or raw binary data. This was added
+   * because node's `fs.readFileSync` returns garbage when reading string files without specifying the encoding.
+   */
   read(key: string, type: 'string' | 'bytes'): Uint8Array;
+  /**
+   * Write a value to the cache.
+   *
+   * @param key The key of the data to write to the cache. This will be used by `read()` to retrieve the data. Can safely be used as a file path.
+   * @param value The value to write to the cache, as a byte array.
+   * @param type Specifies whether the value originated from a utf8-encoded string or raw binary data.
+   */
   write(key: string, value: Uint8Array, type: 'string' | 'bytes'): void;
 };
 
@@ -26,10 +46,10 @@ const FileSystem = (cacheDirectory: string): Storable => ({
     if (jsEnvironment !== 'node') throw Error('file system not available');
     console.log('READ', key);
     if (type === 'string') {
-      let string = readFileSync(`${cacheDirectory}/${key}`, 'utf8');
+      let string = readFileSync(resolve(cacheDirectory, key), 'utf8');
       return new TextEncoder().encode(string);
     } else {
-      let buffer = readFileSync(`${cacheDirectory}/${key}`);
+      let buffer = readFileSync(resolve(cacheDirectory, key));
       return new Uint8Array(buffer.buffer);
     }
   },
@@ -37,7 +57,7 @@ const FileSystem = (cacheDirectory: string): Storable => ({
     if (jsEnvironment !== 'node') throw Error('file system not available');
     console.log('WRITE', key);
     mkdirSync(cacheDirectory, { recursive: true });
-    writeFileSync(`${cacheDirectory}/${key}`, value, {
+    writeFileSync(resolve(cacheDirectory, key), value, {
       encoding: type === 'string' ? 'utf8' : undefined,
     });
   },
@@ -46,7 +66,20 @@ const FileSystem = (cacheDirectory: string): Storable => ({
 const FileSystemDefault = FileSystem(cacheDir('pickles'));
 
 const Storable = {
+  /**
+   * Store data on the file system, in a directory of your choice.
+   *
+   * Note: this {@link Storable} only caches data in Node.js.
+   */
   FileSystem,
+  /**
+   * Store data on the file system, in a standard cache directory depending on the OS.
+   *
+   * Note: this {@link Storable} only caches data in Node.js.
+   */
   FileSystemDefault,
+  /**
+   * Don't store anything.
+   */
   None,
 };

--- a/src/lib/storable.ts
+++ b/src/lib/storable.ts
@@ -1,4 +1,4 @@
-import { writeFileSync, readFileSync, mkdirSync } from './util/fs.js';
+import { writeFileSync, readFileSync, mkdirSync, cacheDir } from './util/fs.js';
 import { jsEnvironment } from '../bindings/crypto/bindings/env.js';
 
 export { Storable };
@@ -43,7 +43,7 @@ const FileSystem = (cacheDirectory: string): Storable => ({
   },
 });
 
-const FileSystemDefault = FileSystem('/tmp');
+const FileSystemDefault = FileSystem(cacheDir('pickles'));
 
 const Storable = {
   FileSystem,

--- a/src/lib/storable.ts
+++ b/src/lib/storable.ts
@@ -44,7 +44,6 @@ const None: Storable = {
 const FileSystem = (cacheDirectory: string): Storable => ({
   read(key, type: 'string' | 'bytes') {
     if (jsEnvironment !== 'node') throw Error('file system not available');
-    console.log('READ', key);
     if (type === 'string') {
       let string = readFileSync(resolve(cacheDirectory, key), 'utf8');
       return new TextEncoder().encode(string);
@@ -55,7 +54,6 @@ const FileSystem = (cacheDirectory: string): Storable => ({
   },
   write(key, value, type: 'string' | 'bytes') {
     if (jsEnvironment !== 'node') throw Error('file system not available');
-    console.log('WRITE', key);
     mkdirSync(cacheDirectory, { recursive: true });
     writeFileSync(resolve(cacheDirectory, key), value, {
       encoding: type === 'string' ? 'utf8' : undefined,

--- a/src/lib/storable.ts
+++ b/src/lib/storable.ts
@@ -7,34 +7,45 @@ import {
 } from './util/fs.js';
 import { jsEnvironment } from '../bindings/crypto/bindings/env.js';
 
-export { Storable, CacheHeader, cacheHeaderVersion };
+export { Cache, CacheHeader, cacheHeaderVersion };
 
 /**
  * Interface for storing and retrieving values, for caching.
  * `read()` and `write()` can just throw errors on failure.
  */
-type Storable = {
+type Cache = {
   /**
    * Read a value from the cache.
    *
-   * @param key The key to read from the cache. Can safely be used as a file path.
-   * @param type Specifies whether the data to be read is a utf8-encoded string or raw binary data. This was added
-   * because node's `fs.readFileSync` returns garbage when reading string files without specifying the encoding.
+   * @param header A small header to identify what is read from the cache.
    */
-  read(key: string, type: 'string' | 'bytes'): Uint8Array;
+  read(header: CacheHeader): Uint8Array;
   /**
    * Write a value to the cache.
    *
-   * @param key The key of the data to write to the cache. This will be used by `read()` to retrieve the data. Can safely be used as a file path.
+   * @param header A small header to identify what is written to the cache. This will be used by `read()` to retrieve the data.
    * @param value The value to write to the cache, as a byte array.
-   * @param type Specifies whether the value originated from a utf8-encoded string or raw binary data.
    */
-  write(key: string, value: Uint8Array, type: 'string' | 'bytes'): void;
+  write(header: CacheHeader, value: Uint8Array): void;
 };
 
-const cacheHeaderVersion = 0;
+const cacheHeaderVersion = 0.1;
 
-type CommonHeader = { version: number; uniqueId: string };
+type CommonHeader = {
+  /**
+   * Header version to avoid parsing incompatible headers.
+   */
+  version: number;
+  /**
+   * A unique identifier for the data to be read. Safe to use as a file path.
+   */
+  uniqueId: string;
+  /**
+   * Specifies whether the data to be read is a utf8-encoded string or raw binary data. This was added
+   * because node's `fs.readFileSync` returns garbage when reading string files without specifying the encoding.
+   */
+  dataType: 'string' | 'bytes';
+};
 type StepKeyHeader<Kind> = {
   kind: Kind;
   programId: string;
@@ -46,6 +57,8 @@ type WrapKeyHeader<Kind> = { kind: Kind; programId: string; hash: string };
 
 /**
  * A header that is passed to the caching layer, to support richer caching strategies.
+ *
+ * Both `uniqueId` and `programId` can safely be used as a file path.
  */
 type CacheHeader = (
   | StepKeyHeader<'step-pk'>
@@ -55,7 +68,7 @@ type CacheHeader = (
 ) &
   CommonHeader;
 
-const None: Storable = {
+const None: Cache = {
   read() {
     throw Error('not available');
   },
@@ -64,39 +77,39 @@ const None: Storable = {
   },
 };
 
-const FileSystem = (cacheDirectory: string): Storable => ({
-  read(key, type: 'string' | 'bytes') {
+const FileSystem = (cacheDirectory: string): Cache => ({
+  read({ uniqueId, dataType }) {
     if (jsEnvironment !== 'node') throw Error('file system not available');
-    if (type === 'string') {
-      let string = readFileSync(resolve(cacheDirectory, key), 'utf8');
+    if (dataType === 'string') {
+      let string = readFileSync(resolve(cacheDirectory, uniqueId), 'utf8');
       return new TextEncoder().encode(string);
     } else {
-      let buffer = readFileSync(resolve(cacheDirectory, key));
+      let buffer = readFileSync(resolve(cacheDirectory, uniqueId));
       return new Uint8Array(buffer.buffer);
     }
   },
-  write(key, value, type: 'string' | 'bytes') {
+  write({ uniqueId, dataType }, data) {
     if (jsEnvironment !== 'node') throw Error('file system not available');
     mkdirSync(cacheDirectory, { recursive: true });
-    writeFileSync(resolve(cacheDirectory, key), value, {
-      encoding: type === 'string' ? 'utf8' : undefined,
+    writeFileSync(resolve(cacheDirectory, uniqueId), data, {
+      encoding: dataType === 'string' ? 'utf8' : undefined,
     });
   },
 });
 
 const FileSystemDefault = FileSystem(cacheDir('pickles'));
 
-const Storable = {
+const Cache = {
   /**
    * Store data on the file system, in a directory of your choice.
    *
-   * Note: this {@link Storable} only caches data in Node.js.
+   * Note: this {@link Cache} only caches data in Node.js.
    */
   FileSystem,
   /**
    * Store data on the file system, in a standard cache directory depending on the OS.
    *
-   * Note: this {@link Storable} only caches data in Node.js.
+   * Note: this {@link Cache} only caches data in Node.js.
    */
   FileSystemDefault,
   /**

--- a/src/lib/util/fs.ts
+++ b/src/lib/util/fs.ts
@@ -1,0 +1,2 @@
+export { writeFileSync, readFileSync, mkdirSync } from 'node:fs';
+export { resolve } from 'node:path';

--- a/src/lib/util/fs.ts
+++ b/src/lib/util/fs.ts
@@ -1,2 +1,5 @@
+import cachedir from 'cachedir';
+
 export { writeFileSync, readFileSync, mkdirSync } from 'node:fs';
 export { resolve } from 'node:path';
+export { cachedir as cacheDir };

--- a/src/lib/util/fs.web.ts
+++ b/src/lib/util/fs.web.ts
@@ -1,0 +1,5 @@
+export { dummy as writeFileSync, dummy as readFileSync, dummy as resolve };
+
+function dummy() {
+  throw Error('not implemented');
+}

--- a/src/lib/util/fs.web.ts
+++ b/src/lib/util/fs.web.ts
@@ -1,4 +1,9 @@
-export { dummy as writeFileSync, dummy as readFileSync, dummy as resolve };
+export {
+  dummy as writeFileSync,
+  dummy as readFileSync,
+  dummy as resolve,
+  dummy as mkdirSync,
+};
 
 function dummy() {
   throw Error('not implemented');

--- a/src/lib/util/fs.web.ts
+++ b/src/lib/util/fs.web.ts
@@ -3,8 +3,13 @@ export {
   dummy as readFileSync,
   dummy as resolve,
   dummy as mkdirSync,
+  cacheDir,
 };
 
 function dummy() {
   throw Error('not implemented');
+}
+
+function cacheDir() {
+  return '';
 }

--- a/src/lib/zkapp.ts
+++ b/src/lib/zkapp.ts
@@ -56,7 +56,7 @@ import {
   inProver,
   snarkContext,
 } from './provable-context.js';
-import { Storable } from './storable.js';
+import { Cache } from './storable.js';
 
 // external API
 export {
@@ -662,7 +662,7 @@ class SmartContract {
    * it so that proofs end up in the original finite field). These are fairly expensive operations, so **expect compiling to take at least 20 seconds**,
    * up to several minutes if your circuit is large or your hardware is not optimal for these operations.
    */
-  static async compile({ storable = Storable.FileSystemDefault } = {}) {
+  static async compile({ cache = Cache.FileSystemDefault } = {}) {
     let methodIntfs = this._methods ?? [];
     let methods = methodIntfs.map(({ methodName }) => {
       return (
@@ -689,7 +689,7 @@ class SmartContract {
       methods,
       gates,
       proofSystemTag: this,
-      storable,
+      cache,
     });
     let verificationKey = {
       data: verificationKey_.data,

--- a/src/lib/zkapp.ts
+++ b/src/lib/zkapp.ts
@@ -56,7 +56,7 @@ import {
   inProver,
   snarkContext,
 } from './provable-context.js';
-import { Cache } from './storable.js';
+import { Cache } from './proof-system/cache.js';
 
 // external API
 export {

--- a/src/lib/zkapp.ts
+++ b/src/lib/zkapp.ts
@@ -56,6 +56,7 @@ import {
   inProver,
   snarkContext,
 } from './provable-context.js';
+import { Storable } from './storable.js';
 
 // external API
 export {
@@ -661,7 +662,7 @@ class SmartContract {
    * it so that proofs end up in the original finite field). These are fairly expensive operations, so **expect compiling to take at least 20 seconds**,
    * up to several minutes if your circuit is large or your hardware is not optimal for these operations.
    */
-  static async compile() {
+  static async compile({ storable = Storable.FileSystemDefault } = {}) {
     let methodIntfs = this._methods ?? [];
     let methods = methodIntfs.map(({ methodName }) => {
       return (
@@ -688,6 +689,7 @@ class SmartContract {
       methods,
       gates,
       proofSystemTag: this,
+      storable,
     });
     let verificationKey = {
       data: verificationKey_.data,

--- a/src/snarky.d.ts
+++ b/src/snarky.d.ts
@@ -14,8 +14,9 @@ import type {
 } from './lib/ml/base.js';
 import type { MlHashInput } from './lib/ml/conversion.js';
 import type * as ProverKeys from './lib/proof-system/prover-keys.ts';
+import { getWasm } from './bindings/js/wrapper.js';
 
-export { ProvablePure, Provable, Ledger, Pickles, Gate, GateType };
+export { ProvablePure, Provable, Ledger, Pickles, Gate, GateType, getWasm };
 
 // internal
 export {

--- a/src/snarky.d.ts
+++ b/src/snarky.d.ts
@@ -14,7 +14,11 @@ import type {
   MlString,
 } from './lib/ml/base.js';
 import type { MlHashInput } from './lib/ml/conversion.js';
-import type * as ProverKeys from './lib/proof-system/prover-keys.js';
+import type {
+  SnarkKey,
+  SnarkKeyHeader,
+  MlWrapVerificationKey,
+} from './lib/proof-system/prover-keys.js';
 import { getWasm } from './bindings/js/wrapper.js';
 import type {
   WasmFpSrs,
@@ -639,13 +643,10 @@ declare namespace Pickles {
    */
   type Cache = [
     _: 0,
-    read: (
-      key: ProverKeys.AnyKey,
-      path: string
-    ) => MlResult<ProverKeys.AnyValue, MlUnit>,
+    read: (header: SnarkKeyHeader, path: string) => MlResult<SnarkKey, MlUnit>,
     write: (
-      key: ProverKeys.AnyKey,
-      value: ProverKeys.AnyValue,
+      header: SnarkKeyHeader,
+      value: SnarkKey,
       path: string
     ) => MlResult<undefined, MlUnit>,
     canWrite: MlBool
@@ -719,8 +720,8 @@ declare const Pickles: {
    */
   dummyVerificationKey: () => [_: 0, data: string, hash: FieldConst];
 
-  encodeVerificationKey: (vk: ProverKeys.MlWrapVerificationKey) => string;
-  decodeVerificationKey: (vk: string) => ProverKeys.MlWrapVerificationKey;
+  encodeVerificationKey: (vk: MlWrapVerificationKey) => string;
+  decodeVerificationKey: (vk: string) => MlWrapVerificationKey;
 
   proofToBase64: (proof: [0 | 1 | 2, Pickles.Proof]) => string;
   proofOfBase64: <N extends 0 | 1 | 2>(

--- a/src/snarky.d.ts
+++ b/src/snarky.d.ts
@@ -685,6 +685,9 @@ declare const Pickles: {
    */
   dummyVerificationKey: () => [_: 0, data: string, hash: FieldConst];
 
+  encodeVerificationKey: (vk: ProverKeys.MlWrapVerificationKey) => string;
+  decodeVerificationKey: (vk: string) => ProverKeys.MlWrapVerificationKey;
+
   proofToBase64: (proof: [0 | 1 | 2, Pickles.Proof]) => string;
   proofOfBase64: (
     base64: string,

--- a/src/snarky.d.ts
+++ b/src/snarky.d.ts
@@ -684,7 +684,7 @@ declare const Pickles: {
     config: {
       publicInputSize: number;
       publicOutputSize: number;
-      cache?: Pickles.Cache;
+      storable?: Pickles.Cache;
       overrideWrapDomain?: 0 | 1 | 2;
     }
   ) => {

--- a/src/snarky.d.ts
+++ b/src/snarky.d.ts
@@ -11,6 +11,7 @@ import type {
   MlBytes,
   MlResult,
   MlUnit,
+  MlString,
 } from './lib/ml/base.js';
 import type { MlHashInput } from './lib/ml/conversion.js';
 import type * as ProverKeys from './lib/proof-system/prover-keys.js';
@@ -728,4 +729,9 @@ declare const Pickles: {
   ) => [N, Pickles.Proof];
 
   proofToBase64Transaction: (proof: Pickles.Proof) => string;
+
+  util: {
+    toMlString(s: string): MlString;
+    fromMlString(s: MlString): string;
+  };
 };

--- a/src/snarky.d.ts
+++ b/src/snarky.d.ts
@@ -637,7 +637,7 @@ declare namespace Pickles {
   /**
    * Type to configure how Pickles should cache prover keys
    */
-  type Storable = [
+  type Cache = [
     _: 0,
     read: (
       key: ProverKeys.AnyKey,
@@ -684,7 +684,7 @@ declare const Pickles: {
     config: {
       publicInputSize: number;
       publicOutputSize: number;
-      storable?: Pickles.Storable;
+      cache?: Pickles.Cache;
       overrideWrapDomain?: 0 | 1 | 2;
     }
   ) => {

--- a/src/snarky.d.ts
+++ b/src/snarky.d.ts
@@ -10,8 +10,10 @@ import type {
   MlBool,
   MlBytes,
   MlResult,
+  MlUnit,
 } from './lib/ml/base.js';
 import type { MlHashInput } from './lib/ml/conversion.js';
+import type * as ProverKeys from './lib/proof-system/prover-keys.ts';
 
 export { ProvablePure, Provable, Ledger, Pickles, Gate, GateType };
 
@@ -602,8 +604,15 @@ declare namespace Pickles {
    */
   type Storable = [
     _: 0,
-    read: (key: any, path: string) => MlResult<unknown, 0>,
-    write: (key: any, value: any, path: string) => MlResult<undefined, 0>,
+    read: (
+      key: ProverKeys.AnyKey,
+      path: string
+    ) => MlResult<ProverKeys.AnyValue, MlUnit>,
+    write: (
+      key: ProverKeys.AnyKey,
+      value: ProverKeys.AnyValue,
+      path: string
+    ) => MlResult<undefined, MlUnit>,
     canWrite: MlBool
   ];
 

--- a/src/snarky.d.ts
+++ b/src/snarky.d.ts
@@ -13,8 +13,12 @@ import type {
   MlUnit,
 } from './lib/ml/base.js';
 import type { MlHashInput } from './lib/ml/conversion.js';
-import type * as ProverKeys from './lib/proof-system/prover-keys.ts';
+import type * as ProverKeys from './lib/proof-system/prover-keys.js';
 import { getWasm } from './bindings/js/wrapper.js';
+import type {
+  WasmFpSrs,
+  WasmFqSrs,
+} from './bindings/compiled/node_bindings/plonk_wasm.cjs';
 
 export { ProvablePure, Provable, Ledger, Pickles, Gate, GateType, getWasm };
 
@@ -671,6 +675,9 @@ declare const Pickles: {
     proof: Pickles.Proof,
     verificationKey: string
   ): Promise<boolean>;
+
+  loadSrsFp(): WasmFpSrs;
+  loadSrsFq(): WasmFqSrs;
 
   dummyBase64Proof: () => string;
   /**

--- a/src/snarky.d.ts
+++ b/src/snarky.d.ts
@@ -9,6 +9,7 @@ import type {
   MlOption,
   MlBool,
   MlBytes,
+  MlResult,
 } from './lib/ml/base.js';
 import type { MlHashInput } from './lib/ml/conversion.js';
 
@@ -596,6 +597,16 @@ declare namespace Pickles {
     proofsToVerify: MlArray<{ isSelf: true } | { isSelf: false; tag: unknown }>;
   };
 
+  /**
+   * Type to configure how Pickles should cache prover keys
+   */
+  type Storable = [
+    _: 0,
+    read: (key: any, path: string) => MlResult<unknown, 0>,
+    write: (key: any, value: any, path: string) => MlResult<undefined, 0>,
+    canWrite: MlBool
+  ];
+
   type Prover = (
     publicInput: MlArray<FieldConst>,
     previousProofs: MlArray<Proof>
@@ -626,9 +637,10 @@ declare const Pickles: {
    */
   compile: (
     rules: MlArray<Pickles.Rule>,
-    signature: {
+    config: {
       publicInputSize: number;
       publicOutputSize: number;
+      storable?: Pickles.Storable;
       overrideWrapDomain?: 0 | 1 | 2;
     }
   ) => {

--- a/src/snarky.js
+++ b/src/snarky.js
@@ -1,9 +1,9 @@
 import './bindings/crypto/bindings.js';
-import { getSnarky, withThreadPool } from './bindings/js/wrapper.js';
+import { getSnarky, getWasm, withThreadPool } from './bindings/js/wrapper.js';
 import snarkySpec from './bindings/js/snarky-class-spec.js';
 import { proxyClasses } from './bindings/js/proxy.js';
 
-export { Snarky, Ledger, Pickles, Test, withThreadPool };
+export { Snarky, Ledger, Pickles, Test, withThreadPool, getWasm };
 let isReadyBoolean = true;
 let isItReady = () => isReadyBoolean;
 


### PR DESCRIPTION
closes #87 

mina: https://github.com/MinaProtocol/mina/pull/14396 and https://github.com/MinaProtocol/mina/pull/14412
bindings: https://github.com/o1-labs/o1js-bindings/pull/187

This PR enables caching of prover and verifier keys in Node.js. The caching interface is kept flexible and will allow a variety of other caching strategies -- for example, bundling snark keys with your web app, or downloading them from some CDN, etc.

**Results** for calling `compile()` on the `simple_zkapp.ts` example (my machine)
* before this PR / on the first compile: **20s**
* on subsequent compiles when no circuit changed: **13s** 

The majority of the remaining 13s is spent in recreating SRS and Lagrange bases (= long lists of elliptic curve points which are the same every time). Caching of those is added in a follow-up PR.

After caching a bunch of `SmartContract`s and `ZkProgram`s, your cache directory will look like this:
![image](https://github.com/o1-labs/o1js/assets/20989968/380112b6-3f9c-4cfa-8d2e-ee4e48bcde0f)

Note that per contract, several different keys are cached:
* a step prover key (`step-pk`) and verification key (`step-vk`) _for every method_.
* a wrap prover key (`wrap-pk`) and verification key (`wrap-vk`) for the entire contract
* a `.header` file for each cache item. this just contains a unique string which is used to determine whether we can use the cached data

If only one of the methods changes, then only the wrap keys and _one_ of the step keys will be regenerated.