### PR TITLE
Expose dummy proofs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,9 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 - `Gadgets.rangeCheck64()`, new provable method to do efficient 64-bit range checks using lookup tables https://github.com/o1-labs/o1js/pull/1181
 
+- `Proof.dummy()` to create dummy proofs https://github.com/o1-labs/o1js/pull/1188
+  - You can use this to write ZkPrograms that handle the base case and the inductive case in the same method.
+
 ## [0.13.1](https://github.com/o1-labs/o1js/compare/c2f392fe5...045faa7)
 
 ### Breaking changes

--- a/src/lib/proof_system.ts
+++ b/src/lib/proof_system.ts
@@ -143,9 +143,10 @@ class Proof<Input, Output> {
   static async dummy<Input, OutPut>(
     publicInput: Input,
     publicOutput: OutPut,
-    maxProofsVerified: 0 | 1 | 2
+    maxProofsVerified: 0 | 1 | 2,
+    domainLog2: number = 14
   ): Promise<Proof<Input, OutPut>> {
-    let dummyRaw = await dummyProof(maxProofsVerified);
+    let dummyRaw = await dummyProof(maxProofsVerified, domainLog2);
     return new this({
       publicInput,
       publicOutput,
@@ -857,12 +858,14 @@ ZkProgram.Proof = function <
   };
 };
 
-function dummyProof(maxProofsVerified: 0 | 1 | 2) {
-  return withThreadPool(async () => Pickles.dummyProof(maxProofsVerified)[1]);
+function dummyProof(maxProofsVerified: 0 | 1 | 2, domainLog2: number) {
+  return withThreadPool(
+    async () => Pickles.dummyProof(maxProofsVerified, domainLog2)[1]
+  );
 }
 
 async function dummyBase64Proof() {
-  let proof = await dummyProof(2);
+  let proof = await dummyProof(2, 15);
   return Pickles.proofToBase64([2, proof]);
 }
 

--- a/src/lib/proof_system.ts
+++ b/src/lib/proof_system.ts
@@ -140,6 +140,27 @@ class Proof<Input, Output> {
     this.maxProofsVerified = maxProofsVerified;
   }
 
+  /**
+   * Dummy proof. This can be useful for ZkPrograms that handle the base case in the same
+   * method as the inductive case, using a pattern like this:
+   *
+   * ```ts
+   * method(proof: SelfProof<I, O>, isRecursive: Bool) {
+   *   proof.verifyIf(isRecursive);
+   *   // ...
+   * }
+   * ```
+   *
+   * To use such a method in the base case, you need a dummy proof:
+   *
+   * ```ts
+   * let dummy = await MyProof.dummy(publicInput, publicOutput, 1);
+   * await myProgram.myMethod(dummy, Bool(false));
+   * ```
+   *
+   * **Note**: The types of `publicInput` and `publicOutput`, as well as the `maxProofsVerified` parameter,
+   * must match your ZkProgram. `maxProofsVerified` is the maximum number of proofs that any of your methods take as arguments.
+   */
   static async dummy<Input, OutPut>(
     publicInput: Input,
     publicOutput: OutPut,

--- a/src/lib/proof_system.ts
+++ b/src/lib/proof_system.ts
@@ -145,9 +145,7 @@ class Proof<Input, Output> {
     publicOutput: OutPut,
     maxProofsVerified: 0 | 1 | 2
   ): Promise<Proof<Input, OutPut>> {
-    // TODO need to select dummy based on maxProofsVerified
-    let dummyBase64 = await dummyBase64Proof();
-    let [, dummyRaw] = Pickles.proofOfBase64(dummyBase64, maxProofsVerified);
+    let dummyRaw = await dummyProof(maxProofsVerified);
     return new this({
       publicInput,
       publicOutput,
@@ -859,8 +857,13 @@ ZkProgram.Proof = function <
   };
 };
 
-function dummyBase64Proof() {
-  return withThreadPool(async () => Pickles.dummyBase64Proof());
+function dummyProof(maxProofsVerified: 0 | 1 | 2) {
+  return withThreadPool(async () => Pickles.dummyProof(maxProofsVerified)[1]);
+}
+
+async function dummyBase64Proof() {
+  let proof = await dummyProof(2);
+  return Pickles.proofToBase64([2, proof]);
 }
 
 // what feature flags to set to enable certain gate types

--- a/src/lib/proof_system.ts
+++ b/src/lib/proof_system.ts
@@ -139,6 +139,22 @@ class Proof<Input, Output> {
     this.proof = proof; // TODO optionally convert from string?
     this.maxProofsVerified = maxProofsVerified;
   }
+
+  static async dummy<Input, OutPut>(
+    publicInput: Input,
+    publicOutput: OutPut,
+    maxProofsVerified: 0 | 1 | 2
+  ): Promise<Proof<Input, OutPut>> {
+    // TODO need to select dummy based on maxProofsVerified
+    let dummyBase64 = await dummyBase64Proof();
+    let [, dummyRaw] = Pickles.proofOfBase64(dummyBase64, maxProofsVerified);
+    return new this({
+      publicInput,
+      publicOutput,
+      proof: dummyRaw,
+      maxProofsVerified,
+    });
+  }
 }
 
 async function verify(

--- a/src/snarky.d.ts
+++ b/src/snarky.d.ts
@@ -650,17 +650,18 @@ declare const Pickles: {
     verificationKey: string
   ): Promise<boolean>;
 
-  dummyBase64Proof: () => string;
+  dummyProof: <N extends 0 | 1 | 2>(maxProofsVerified: N) => [N, Pickles.Proof];
+
   /**
    * @returns (base64 vk, hash)
    */
   dummyVerificationKey: () => [_: 0, data: string, hash: FieldConst];
 
   proofToBase64: (proof: [0 | 1 | 2, Pickles.Proof]) => string;
-  proofOfBase64: (
+  proofOfBase64: <N extends 0 | 1 | 2>(
     base64: string,
-    maxProofsVerified: 0 | 1 | 2
-  ) => [0 | 1 | 2, Pickles.Proof];
+    maxProofsVerified: N
+  ) => [N, Pickles.Proof];
 
   proofToBase64Transaction: (proof: Pickles.Proof) => string;
 };

--- a/src/snarky.d.ts
+++ b/src/snarky.d.ts
@@ -650,7 +650,10 @@ declare const Pickles: {
     verificationKey: string
   ): Promise<boolean>;
 
-  dummyProof: <N extends 0 | 1 | 2>(maxProofsVerified: N) => [N, Pickles.Proof];
+  dummyProof: <N extends 0 | 1 | 2>(
+    maxProofsVerified: N,
+    domainLog2: number
+  ) => [N, Pickles.Proof];
 
   /**
    * @returns (base64 vk, hash)


### PR DESCRIPTION
exposes `Proof.dummy()`

you need dummy proofs to write ZkProgram methods that cover the base case and the recursive case at the same time. if it's the case case you pass a dummy proof and don't verify it. this, empirically, can significantly reduce the proof time of a recursive chain, without negatively impacting the base case efficiency

closes https://github.com/o1-labs/o1js/issues/1185
bindings: https://github.com/o1-labs/o1js-bindings/pull/188