### PR TITLE
Add ZkProgram name as required argument

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,17 +26,14 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 ### Changed
 
 - `ZkProgram` has moved out of the `Experimental` namespace and is now available as a top-level import directly. `Experimental.ZkProgram` has been deprecated.
+- `ZkProgram` gets a new input argument `name: string` which is required in the non-experimental API. The name is used to identify a ZkProgram when caching prover keys. https://github.com/o1-labs/o1js/pull/1200
 
 ### Added
 
 - `Lightnet` namespace to interact with the account manager provided by the [lightnet Mina network](https://hub.docker.com/r/o1labs/mina-local-network). https://github.com/o1-labs/o1js/pull/1167
-
 - Internal support for several custom gates (range check, bitwise operations, foreign field operations) and lookup tables https://github.com/o1-labs/o1js/pull/1176
-
 - `Gadgets.rangeCheck64()`, new provable method to do efficient 64-bit range checks using lookup tables https://github.com/o1-labs/o1js/pull/1181
-
 - Added bitwise `XOR` operation support for native field elements. https://github.com/o1-labs/o1js/pull/1177
-
 - `Proof.dummy()` to create dummy proofs https://github.com/o1-labs/o1js/pull/1188
   - You can use this to write ZkPrograms that handle the base case and the inductive case in the same method.
 

--- a/src/examples/benchmarks/mul-web.ts
+++ b/src/examples/benchmarks/mul-web.ts
@@ -1,9 +1,8 @@
 /**
  * benchmark a circuit filled with generic gates
  */
-import { Circuit, Field, Provable, circuitMain, Experimental } from 'o1js';
+import { Circuit, Field, Provable, circuitMain, ZkProgram } from 'o1js';
 import { tic, toc } from './tic-toc.js';
-let { ZkProgram } = Experimental;
 
 // parameters
 let nMuls = (1 << 16) + (1 << 15); // not quite 2^17 generic gates = not quite 2^16 rows
@@ -39,6 +38,7 @@ function simpleKimchiCircuit(nMuls: number) {
 
 function picklesCircuit(nMuls: number) {
   return ZkProgram({
+    name: 'mul-chain',
     methods: {
       run: {
         privateInputs: [],

--- a/src/examples/benchmarks/mul.ts
+++ b/src/examples/benchmarks/mul.ts
@@ -1,9 +1,8 @@
 /**
  * benchmark a circuit filled with generic gates
  */
-import { Circuit, Field, Provable, circuitMain, Experimental } from 'o1js';
+import { Circuit, Field, Provable, circuitMain, ZkProgram } from 'o1js';
 import { tic, toc } from '../zkapps/tictoc.js';
-let { ZkProgram } = Experimental;
 
 // parameters
 let nMuls = (1 << 16) + (1 << 15); // not quite 2^17 generic gates = not quite 2^16 rows
@@ -37,6 +36,7 @@ function simpleKimchiCircuit(nMuls: number) {
 
 function picklesCircuit(nMuls: number) {
   return ZkProgram({
+    name: 'mul-chain',
     methods: {
       run: {
         privateInputs: [],

--- a/src/examples/ex02_root_program.ts
+++ b/src/examples/ex02_root_program.ts
@@ -1,8 +1,7 @@
-import { Field, UInt64, Experimental, Gadgets } from 'o1js';
-
-let { ZkProgram } = Experimental;
+import { Field, UInt64, Gadgets, ZkProgram } from 'o1js';
 
 const Main = ZkProgram({
+  name: 'example-with-custom-gates',
   publicInput: Field,
   methods: {
     main: {

--- a/src/examples/gadgets.ts
+++ b/src/examples/gadgets.ts
@@ -1,6 +1,7 @@
-import { Field, Provable, Gadgets, Experimental } from 'o1js';
+import { Field, Provable, Gadgets, ZkProgram } from 'o1js';
 
-const XOR = Experimental.ZkProgram({
+const XOR = ZkProgram({
+  name: 'xor-example',
   methods: {
     baseCase: {
       privateInputs: [],

--- a/src/examples/program-with-input.ts
+++ b/src/examples/program-with-input.ts
@@ -12,6 +12,7 @@ import {
 await isReady;
 
 let MyProgram = ZkProgram({
+  name: 'example-with-input',
   publicInput: Field,
 
   methods: {

--- a/src/examples/program.ts
+++ b/src/examples/program.ts
@@ -13,6 +13,7 @@ import {
 await isReady;
 
 let MyProgram = ZkProgram({
+  name: 'example-with-output',
   publicOutput: Field,
 
   methods: {

--- a/src/index.ts
+++ b/src/index.ts
@@ -76,7 +76,7 @@ export { MerkleMap, MerkleMapWitness } from './lib/merkle_map.js';
 
 export { Nullifier } from './lib/nullifier.js';
 
-import { ZkProgram } from './lib/proof_system.js';
+import { ExperimentalZkProgram, ZkProgram } from './lib/proof_system.js';
 export { ZkProgram };
 
 // experimental APIs
@@ -89,7 +89,6 @@ const Experimental_ = {
   Callback,
   createChildAccountUpdate,
   memoizeWitness,
-  ZkProgram,
 };
 
 type Callback_<Result> = Callback<Result>;
@@ -102,7 +101,7 @@ namespace Experimental {
   /** @deprecated `ZkProgram` has moved out of the Experimental namespace and is now directly available as a top-level import `ZkProgram`.
    * The old `Experimental.ZkProgram` API has been deprecated in favor of the new `ZkProgram` top-level import.
    */
-  export let ZkProgram = Experimental_.ZkProgram;
+  export let ZkProgram = ExperimentalZkProgram;
   export let createChildAccountUpdate = Experimental_.createChildAccountUpdate;
   export let memoizeWitness = Experimental_.memoizeWitness;
   export let Callback = Experimental_.Callback;

--- a/src/lib/gadgets/bitwise.unit-test.ts
+++ b/src/lib/gadgets/bitwise.unit-test.ts
@@ -12,6 +12,7 @@ import { Gadgets } from './gadgets.js';
 import { Random } from '../testing/property.js';
 
 let Bitwise = ZkProgram({
+  name: 'bitwise',
   publicOutput: Field,
   methods: {
     xor: {

--- a/src/lib/gadgets/range-check.unit-test.ts
+++ b/src/lib/gadgets/range-check.unit-test.ts
@@ -13,6 +13,7 @@ import { Gadgets } from './gadgets.js';
 // TODO: make a ZkFunction or something that doesn't go through Pickles
 
 let RangeCheck64 = ZkProgram({
+  name: 'range-check-64',
   methods: {
     run: {
       privateInputs: [Field],

--- a/src/lib/proof_system.ts
+++ b/src/lib/proof_system.ts
@@ -35,6 +35,7 @@ export {
   SelfProof,
   JsonProof,
   ZkProgram,
+  ExperimentalZkProgram,
   verify,
   Empty,
   Undefined,
@@ -240,6 +241,7 @@ function ZkProgram<
   }
 >(
   config: StatementType & {
+    name: string;
     methods: {
       [I in keyof Types]: Method<
         InferProvableOrUndefined<Get<StatementType, 'publicInput'>>,
@@ -273,7 +275,7 @@ function ZkProgram<
   let publicInputType: ProvablePure<any> = config.publicInput! ?? Undefined;
   let publicOutputType: ProvablePure<any> = config.publicOutput! ?? Void;
 
-  let selfTag = { name: `Program${i++}` };
+  let selfTag = { name: config.name };
   type PublicInput = InferProvableOrUndefined<
     Get<StatementType, 'publicInput'>
   >;
@@ -1021,3 +1023,30 @@ type UnwrapPromise<P> = P extends Promise<infer T> ? T : never;
 type Get<T, Key extends string> = T extends { [K in Key]: infer Value }
   ? Value
   : undefined;
+
+// deprecated experimental API
+
+function ExperimentalZkProgram<
+  StatementType extends {
+    publicInput?: FlexibleProvablePure<any>;
+    publicOutput?: FlexibleProvablePure<any>;
+  },
+  Types extends {
+    [I in string]: Tuple<PrivateInput>;
+  }
+>(
+  config: StatementType & {
+    name?: string;
+    methods: {
+      [I in keyof Types]: Method<
+        InferProvableOrUndefined<Get<StatementType, 'publicInput'>>,
+        InferProvableOrVoid<Get<StatementType, 'publicOutput'>>,
+        Types[I]
+      >;
+    };
+    overrideWrapDomain?: 0 | 1 | 2;
+  }
+) {
+  let config_ = { ...config, name: config.name ?? `Program${i++}` };
+  return ZkProgram<StatementType, Types>(config_);
+}

--- a/src/lib/proof_system.unit-test.ts
+++ b/src/lib/proof_system.unit-test.ts
@@ -5,6 +5,7 @@ import { ZkProgram } from './proof_system.js';
 import { expect } from 'expect';
 
 const EmptyProgram = ZkProgram({
+  name: 'empty',
   publicInput: Field,
   methods: {
     run: {
@@ -30,6 +31,7 @@ class CounterPublicInput extends Struct({
   updated: UInt64,
 }) {}
 const CounterProgram = ZkProgram({
+  name: 'counter',
   publicInput: CounterPublicInput,
   methods: {
     increment: {

--- a/src/mina-signer/tests/verify-in-snark.unit-test.ts
+++ b/src/mina-signer/tests/verify-in-snark.unit-test.ts
@@ -32,6 +32,7 @@ signature.verify(publicKey, fieldsSnarky).assertTrue();
 const Message = Provable.Array(Field, fields.length);
 
 const MyProgram = ZkProgram({
+  name: 'verify-signature',
   methods: {
     verifySignature: {
       privateInputs: [Signature, Message],

--- a/src/tests/inductive-proofs-small.ts
+++ b/src/tests/inductive-proofs-small.ts
@@ -11,6 +11,7 @@ import { tic, toc } from '../examples/zkapps/tictoc.js';
 await isReady;
 
 let MaxProofsVerifiedOne = ZkProgram({
+  name: 'recursive-1',
   publicInput: Field,
 
   methods: {

--- a/src/tests/inductive-proofs.ts
+++ b/src/tests/inductive-proofs.ts
@@ -11,6 +11,7 @@ import { tic, toc } from '../examples/zkapps/tictoc.js';
 await isReady;
 
 let MaxProofsVerifiedZero = ZkProgram({
+  name: 'no-recursion',
   publicInput: Field,
 
   methods: {
@@ -25,6 +26,7 @@ let MaxProofsVerifiedZero = ZkProgram({
 });
 
 let MaxProofsVerifiedOne = ZkProgram({
+  name: 'recursive-1',
   publicInput: Field,
 
   methods: {
@@ -48,6 +50,7 @@ let MaxProofsVerifiedOne = ZkProgram({
 });
 
 let MaxProofsVerifiedTwo = ZkProgram({
+  name: 'recursive-2',
   publicInput: Field,
 
   methods: {

--- a/tests/integration/inductive-proofs.js
+++ b/tests/integration/inductive-proofs.js
@@ -10,6 +10,7 @@ import { tic, toc } from './tictoc.js';
 await isReady;
 
 let MaxProofsVerifiedZero = ZkProgram({
+  name: 'no-recursion',
   publicInput: Field,
 
   methods: {
@@ -24,6 +25,7 @@ let MaxProofsVerifiedZero = ZkProgram({
 });
 
 let MaxProofsVerifiedOne = ZkProgram({
+  name: 'recursive-1',
   publicInput: Field,
 
   methods: {
@@ -47,6 +49,7 @@ let MaxProofsVerifiedOne = ZkProgram({
 });
 
 let MaxProofsVerifiedTwo = ZkProgram({
+  name: 'recursive-2',
   publicInput: Field,
 
   methods: {


### PR DESCRIPTION
Adds `name` argument to ZkProgram.

* `name` is required in the new non-experimental API, but still optional in the old `Experimental.ZkProgram`
* the name is an arbitrary string
* the name will be used for caching. when using the name in filenames, we'll need some way to remove unsupported letters. the caching PR will handle this.
* all examples updated to non-experimental API and to having a name