### PR TITLE
fix(package.json): update build:docs script to use tsconfig.web.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "build:node": "npm run build",
     "build:web": "rimraf ./dist/web && node src/build/buildWeb.js",
     "build:examples": "rimraf ./dist/examples && npx tsc -p tsconfig.examples.json || exit 0",
-    "build:docs": "npx typedoc",
+    "build:docs": "npx typedoc --tsconfig ./tsconfig.web.json",
     "serve:web": "cp src/bindings/compiled/web_bindings/server.js src/bindings/compiled/web_bindings/index.html src/examples/simple_zkapp.js dist/web && node dist/web/server.js",
     "prepublish:web": "NODE_ENV=production node src/build/buildWeb.js",
     "prepublish:node": "npm run build && NODE_ENV=production node src/build/buildNode.js",


### PR DESCRIPTION
# Summary

When using `npm run build:docs` to generate API reference documentation with typedoc, the following error occurs:

```sh
~/Code/o1/o1js-api-docs > npm run build:docs                                                                           λ:main

> o1js@0.13.1 build:docs
> npx typedoc

[info] Loaded plugin typedoc-plugin-markdown
[info] Loaded plugin typedoc-plugin-merge-modules
src/mina-signer/index.d.ts:5:1 - error TS1203: Export assignment cannot be used when targeting ECMAScript modules. Consider using 'export default' or another module format instead.

5 export = Client;
  ~~~
```
  
  It seems as though typedoc is trying walk through `mina-signer`, which is not correct. We can fix this by using the web tsconfig since it doesn't include `mina-signer` and typedoc happily ignores it.