### PR TITLE
Expose remaining gates

### DIFF
--- a/src/lib/gadgets/bitwise.ts
+++ b/src/lib/gadgets/bitwise.ts
@@ -9,6 +9,7 @@ import {
   witnessNextValue,
   divideWithRemainder,
 } from './common.js';
+import { rangeCheck64 } from './range-check.js';
 
 export { xor, and, rotate };
 
@@ -239,8 +240,8 @@ function rot(
     big2PowerRot
   );
   // Compute next row
-  Gates.rangeCheck64(shifted);
+  rangeCheck64(shifted);
   // Compute following row
-  Gates.rangeCheck64(excess);
+  rangeCheck64(excess);
   return [rotated, excess, shifted];
 }

--- a/src/lib/gadgets/bitwise.ts
+++ b/src/lib/gadgets/bitwise.ts
@@ -5,7 +5,7 @@ import * as Gates from '../gates.js';
 import {
   MAX_BITS,
   assert,
-  witnessSlices,
+  witnessSlice,
   witnessNextValue,
   divideWithRemainder,
 } from './common.js';
@@ -66,22 +66,22 @@ function buildXor(
   while (padLength !== 0) {
     // slices the inputs into 4x 4bit-sized chunks
     // slices of a
-    let in1_0 = witnessSlices(a, 0, 4);
-    let in1_1 = witnessSlices(a, 4, 4);
-    let in1_2 = witnessSlices(a, 8, 4);
-    let in1_3 = witnessSlices(a, 12, 4);
+    let in1_0 = witnessSlice(a, 0, 4);
+    let in1_1 = witnessSlice(a, 4, 4);
+    let in1_2 = witnessSlice(a, 8, 4);
+    let in1_3 = witnessSlice(a, 12, 4);
 
     // slices of b
-    let in2_0 = witnessSlices(b, 0, 4);
-    let in2_1 = witnessSlices(b, 4, 4);
-    let in2_2 = witnessSlices(b, 8, 4);
-    let in2_3 = witnessSlices(b, 12, 4);
+    let in2_0 = witnessSlice(b, 0, 4);
+    let in2_1 = witnessSlice(b, 4, 4);
+    let in2_2 = witnessSlice(b, 8, 4);
+    let in2_3 = witnessSlice(b, 12, 4);
 
     // slices of expected output
-    let out0 = witnessSlices(expectedOutput, 0, 4);
-    let out1 = witnessSlices(expectedOutput, 4, 4);
-    let out2 = witnessSlices(expectedOutput, 8, 4);
-    let out3 = witnessSlices(expectedOutput, 12, 4);
+    let out0 = witnessSlice(expectedOutput, 0, 4);
+    let out1 = witnessSlice(expectedOutput, 4, 4);
+    let out2 = witnessSlice(expectedOutput, 8, 4);
+    let out3 = witnessSlice(expectedOutput, 12, 4);
 
     // assert that the xor of the slices is correct, 16 bit at a time
     Gates.xor(
@@ -221,20 +221,20 @@ function rot(
     rotated,
     excess,
     [
-      witnessSlices(bound, 52, 12), // bits 52-64
-      witnessSlices(bound, 40, 12), // bits 40-52
-      witnessSlices(bound, 28, 12), // bits 28-40
-      witnessSlices(bound, 16, 12), // bits 16-28
+      witnessSlice(bound, 52, 12), // bits 52-64
+      witnessSlice(bound, 40, 12), // bits 40-52
+      witnessSlice(bound, 28, 12), // bits 28-40
+      witnessSlice(bound, 16, 12), // bits 16-28
     ],
     [
-      witnessSlices(bound, 14, 2), // bits 14-16
-      witnessSlices(bound, 12, 2), // bits 12-14
-      witnessSlices(bound, 10, 2), // bits 10-12
-      witnessSlices(bound, 8, 2), // bits 8-10
-      witnessSlices(bound, 6, 2), // bits 6-8
-      witnessSlices(bound, 4, 2), // bits 4-6
-      witnessSlices(bound, 2, 2), // bits 2-4
-      witnessSlices(bound, 0, 2), // bits 0-2
+      witnessSlice(bound, 14, 2), // bits 14-16
+      witnessSlice(bound, 12, 2), // bits 12-14
+      witnessSlice(bound, 10, 2), // bits 10-12
+      witnessSlice(bound, 8, 2), // bits 8-10
+      witnessSlice(bound, 6, 2), // bits 6-8
+      witnessSlice(bound, 4, 2), // bits 4-6
+      witnessSlice(bound, 2, 2), // bits 2-4
+      witnessSlice(bound, 0, 2), // bits 0-2
     ],
     big2PowerRot
   );

--- a/src/lib/gadgets/common.ts
+++ b/src/lib/gadgets/common.ts
@@ -1,15 +1,30 @@
 import { Provable } from '../provable.js';
-import { Field } from '../field.js';
+import { Field, FieldConst } from '../field.js';
+import { TupleN } from '../util/types.js';
+import { Snarky } from '../../snarky.js';
+import { MlArray } from '../ml/base.js';
 
 const MAX_BITS = 64 as const;
 
 export {
   MAX_BITS,
+  exists,
   assert,
   witnessSlices,
   witnessNextValue,
   divideWithRemainder,
 };
+
+function exists<N extends number, C extends () => TupleN<bigint, N>>(
+  n: N,
+  compute: C
+) {
+  let varsMl = Snarky.exists(n, () =>
+    MlArray.mapTo(compute(), FieldConst.fromBigint)
+  );
+  let vars = MlArray.mapFrom(varsMl, (v) => new Field(v));
+  return TupleN.fromArray(n, vars);
+}
 
 function assert(stmt: boolean, message?: string) {
   if (!stmt) {

--- a/src/lib/gadgets/common.ts
+++ b/src/lib/gadgets/common.ts
@@ -11,7 +11,7 @@ export {
   exists,
   assert,
   bitSlice,
-  witnessSlices,
+  witnessSlice,
   witnessNextValue,
   divideWithRemainder,
 };
@@ -37,7 +37,7 @@ function bitSlice(x: bigint, start: number, length: number) {
   return (x >> BigInt(start)) & ((1n << BigInt(length)) - 1n);
 }
 
-function witnessSlices(f: Field, start: number, length: number) {
+function witnessSlice(f: Field, start: number, length: number) {
   if (length <= 0) throw Error('Length must be a positive number');
 
   return Provable.witness(Field, () => {

--- a/src/lib/gadgets/common.ts
+++ b/src/lib/gadgets/common.ts
@@ -10,6 +10,7 @@ export {
   MAX_BITS,
   exists,
   assert,
+  bitSlice,
   witnessSlices,
   witnessNextValue,
   divideWithRemainder,
@@ -30,6 +31,10 @@ function assert(stmt: boolean, message?: string) {
   if (!stmt) {
     throw Error(message ?? 'Assertion failed');
   }
+}
+
+function bitSlice(x: bigint, start: number, length: number) {
+  return (x >> BigInt(start)) & ((1n << BigInt(length)) - 1n);
 }
 
 function witnessSlices(f: Field, start: number, length: number) {

--- a/src/lib/gadgets/range-check.ts
+++ b/src/lib/gadgets/range-check.ts
@@ -1,5 +1,6 @@
-import { type Field } from '../field.js';
+import { Field } from '../field.js';
 import * as Gates from '../gates.js';
+import { bitSlice, exists } from './common.js';
 
 export { rangeCheck64 };
 
@@ -11,7 +12,39 @@ function rangeCheck64(x: Field) {
     if (x.toBigInt() >= 1n << 64n) {
       throw Error(`rangeCheck64: expected field to fit in 64 bits, got ${x}`);
     }
-  } else {
-    Gates.rangeCheck64(x);
+    return;
   }
+
+  // crumbs (2-bit limbs)
+  let [x0, x2, x4, x6, x8, x10, x12, x14] = exists(8, () => {
+    let xx = x.toBigInt();
+    return [
+      bitSlice(xx, 0, 2),
+      bitSlice(xx, 2, 2),
+      bitSlice(xx, 4, 2),
+      bitSlice(xx, 6, 2),
+      bitSlice(xx, 8, 2),
+      bitSlice(xx, 10, 2),
+      bitSlice(xx, 12, 2),
+      bitSlice(xx, 14, 2),
+    ];
+  });
+
+  // 12-bit limbs
+  let [x16, x28, x40, x52] = exists(4, () => {
+    let xx = x.toBigInt();
+    return [
+      bitSlice(xx, 16, 12),
+      bitSlice(xx, 28, 12),
+      bitSlice(xx, 40, 12),
+      bitSlice(xx, 52, 12),
+    ];
+  });
+
+  Gates.rangeCheck0(
+    x,
+    [new Field(0), new Field(0), x52, x40, x28, x16],
+    [x14, x12, x10, x8, x6, x4, x2, x0],
+    false // not using compact mode
+  );
 }

--- a/src/lib/gates.ts
+++ b/src/lib/gates.ts
@@ -1,45 +1,21 @@
 import { Snarky } from '../snarky.js';
-import { FieldVar, FieldConst, type Field } from './field.js';
-import { MlArray } from './ml/base.js';
+import { FieldConst, type Field } from './field.js';
+import { MlArray, MlTuple } from './ml/base.js';
+import { TupleN } from './util/types.js';
 
-export { rangeCheck64, xor, zero, rotate, generic };
+export { rangeCheck0, xor, zero, rotate, generic };
 
-/**
- * Asserts that x is at most 64 bits
- */
-function rangeCheck64(x: Field) {
-  let [, x0, x2, x4, x6, x8, x10, x12, x14] = Snarky.exists(8, () => {
-    let xx = x.toBigInt();
-    // crumbs (2-bit limbs)
-    return [
-      0,
-      getBits(xx, 0, 2),
-      getBits(xx, 2, 2),
-      getBits(xx, 4, 2),
-      getBits(xx, 6, 2),
-      getBits(xx, 8, 2),
-      getBits(xx, 10, 2),
-      getBits(xx, 12, 2),
-      getBits(xx, 14, 2),
-    ];
-  });
-  // 12-bit limbs
-  let [, x16, x28, x40, x52] = Snarky.exists(4, () => {
-    let xx = x.toBigInt();
-    return [
-      0,
-      getBits(xx, 16, 12),
-      getBits(xx, 28, 12),
-      getBits(xx, 40, 12),
-      getBits(xx, 52, 12),
-    ];
-  });
+function rangeCheck0(
+  x: Field,
+  xLimbs12: TupleN<Field, 6>,
+  xLimbs2: TupleN<Field, 8>,
+  isCompact: boolean
+) {
   Snarky.gates.rangeCheck0(
     x.value,
-    [0, FieldVar[0], FieldVar[0], x52, x40, x28, x16],
-    [0, x14, x12, x10, x8, x6, x4, x2, x0],
-    // not using compact mode
-    FieldConst[0]
+    MlTuple.mapTo(xLimbs12, (x) => x.value),
+    MlTuple.mapTo(xLimbs2, (x) => x.value),
+    isCompact ? FieldConst[1] : FieldConst[0]
   );
 }
 
@@ -135,10 +111,4 @@ function generic(
 
 function zero(a: Field, b: Field, c: Field) {
   Snarky.gates.zero(a.value, b.value, c.value);
-}
-
-function getBits(x: bigint, start: number, length: number) {
-  return FieldConst.fromBigint(
-    (x >> BigInt(start)) & ((1n << BigInt(length)) - 1n)
-  );
 }

--- a/src/lib/group.ts
+++ b/src/lib/group.ts
@@ -170,7 +170,7 @@ class Group {
         return s.mul(x1.sub(x3)).sub(y1);
       });
 
-      let [, x, y] = Snarky.group.ecadd(
+      let [, x, y] = Snarky.gates.ecAdd(
         Group.from(x1.seal(), y1.seal()).#toTuple(),
         Group.from(x2.seal(), y2.seal()).#toTuple(),
         Group.from(x3, y3).#toTuple(),

--- a/src/lib/ml/base.ts
+++ b/src/lib/ml/base.ts
@@ -3,7 +3,7 @@
  */
 export {
   MlArray,
-  MlTuple,
+  MlPair,
   MlList,
   MlOption,
   MlBool,
@@ -11,11 +11,12 @@ export {
   MlResult,
   MlUnit,
   MlString,
+  MlTuple,
 };
 
 // ocaml types
 
-type MlTuple<X, Y> = [0, X, Y];
+type MlPair<X, Y> = [0, X, Y];
 type MlArray<T> = [0, ...T[]];
 type MlList<T> = [0, T, 0 | MlList<T>];
 type MlOption<T> = 0 | [0, T];
@@ -48,18 +49,18 @@ const MlArray = {
   },
 };
 
-const MlTuple = Object.assign(
-  function MlTuple<X, Y>(x: X, y: Y): MlTuple<X, Y> {
+const MlPair = Object.assign(
+  function MlTuple<X, Y>(x: X, y: Y): MlPair<X, Y> {
     return [0, x, y];
   },
   {
-    from<X, Y>([, x, y]: MlTuple<X, Y>): [X, Y] {
+    from<X, Y>([, x, y]: MlPair<X, Y>): [X, Y] {
       return [x, y];
     },
-    first<X>(t: MlTuple<X, unknown>): X {
+    first<X>(t: MlPair<X, unknown>): X {
       return t[1];
     },
-    second<Y>(t: MlTuple<unknown, Y>): Y {
+    second<Y>(t: MlPair<unknown, Y>): Y {
       return t[2];
     },
   }
@@ -111,5 +112,29 @@ const MlResult = {
   },
   unitError<T>(): MlResult<T, 0> {
     return [1, 0];
+  },
+};
+
+/**
+ * tuple type that has the length as generic parameter
+ */
+type MlTuple<T, N extends number> = N extends N
+  ? number extends N
+    ? [0, ...T[]] // N is not typed as a constant => fall back to array
+    : [0, ...TupleRec<T, N, []>]
+  : never;
+
+type TupleRec<T, N extends number, R extends unknown[]> = R['length'] extends N
+  ? R
+  : TupleRec<T, N, [T, ...R]>;
+
+type Tuple<T> = [T, ...T[]] | [];
+
+const MlTuple = {
+  map<T extends Tuple<any>, B>(
+    [, ...mlTuple]: [0, ...T],
+    f: (a: T[number]) => B
+  ): [0, ...{ [i in keyof T]: B }] {
+    return [0, ...mlTuple.map(f)] as any;
   },
 };

--- a/src/lib/ml/base.ts
+++ b/src/lib/ml/base.ts
@@ -1,3 +1,5 @@
+import { TupleN } from '../util/types.js';
+
 /**
  * This module contains basic methods for interacting with OCaml
  */
@@ -136,5 +138,19 @@ const MlTuple = {
     f: (a: T[number]) => B
   ): [0, ...{ [i in keyof T]: B }] {
     return [0, ...mlTuple.map(f)] as any;
+  },
+
+  mapFrom<T, N extends number, B>(
+    [, ...mlTuple]: MlTuple<T, N>,
+    f: (a: T) => B
+  ): B[] {
+    return mlTuple.map(f);
+  },
+
+  mapTo<T extends Tuple<any> | TupleN<any, any>, B>(
+    tuple: T,
+    f: (a: T[number]) => B
+  ): [0, ...{ [i in keyof T]: B }] {
+    return [0, ...tuple.map(f)] as any;
   },
 };

--- a/src/lib/ml/conversion.ts
+++ b/src/lib/ml/conversion.ts
@@ -8,7 +8,7 @@ import { Bool, Field } from '../core.js';
 import { FieldConst, FieldVar } from '../field.js';
 import { Scalar, ScalarConst } from '../scalar.js';
 import { PrivateKey, PublicKey } from '../signature.js';
-import { MlTuple, MlBool, MlArray } from './base.js';
+import { MlPair, MlBool, MlArray } from './base.js';
 import { MlFieldConstArray } from './fields.js';
 
 export { Ml, MlHashInput };
@@ -35,7 +35,7 @@ const Ml = {
 type MlHashInput = [
   flag: 0,
   field_elements: MlArray<FieldConst>,
-  packed: MlArray<MlTuple<FieldConst, number>>
+  packed: MlArray<MlPair<FieldConst, number>>
 ];
 
 const MlHashInput = {
@@ -86,7 +86,7 @@ function toPrivateKey(sk: ScalarConst) {
 }
 
 function fromPublicKey(pk: PublicKey): MlPublicKey {
-  return MlTuple(pk.x.toConstant().value[1], MlBool(pk.isOdd.toBoolean()));
+  return MlPair(pk.x.toConstant().value[1], MlBool(pk.isOdd.toBoolean()));
 }
 function toPublicKey([, x, isOdd]: MlPublicKey): PublicKey {
   return PublicKey.from({
@@ -96,7 +96,7 @@ function toPublicKey([, x, isOdd]: MlPublicKey): PublicKey {
 }
 
 function fromPublicKeyVar(pk: PublicKey): MlPublicKeyVar {
-  return MlTuple(pk.x.value, pk.isOdd.toField().value);
+  return MlPair(pk.x.value, pk.isOdd.toField().value);
 }
 function toPublicKeyVar([, x, isOdd]: MlPublicKeyVar): PublicKey {
   return PublicKey.from({ x: Field(x), isOdd: Bool(isOdd) });

--- a/src/lib/proof_system.ts
+++ b/src/lib/proof_system.ts
@@ -25,7 +25,7 @@ import { Provable } from './provable.js';
 import { assert, prettifyStacktracePromise } from './errors.js';
 import { snarkContext } from './provable-context.js';
 import { hashConstant } from './hash.js';
-import { MlArray, MlBool, MlResult, MlTuple, MlUnit } from './ml/base.js';
+import { MlArray, MlBool, MlResult, MlPair, MlUnit } from './ml/base.js';
 import { MlFieldArray, MlFieldConstArray } from './ml/fields.js';
 import { FieldConst, FieldVar } from './field.js';
 import { Cache, readCache, writeCache } from './proof-system/cache.js';
@@ -203,14 +203,14 @@ async function verify(
     let output = MlFieldConstArray.to(
       (proof as JsonProof).publicOutput.map(Field)
     );
-    statement = MlTuple(input, output);
+    statement = MlPair(input, output);
   } else {
     // proof class
     picklesProof = proof.proof;
     let type = getStatementType(proof.constructor as any);
     let input = toFieldConsts(type.input, proof.publicInput);
     let output = toFieldConsts(type.output, proof.publicOutput);
-    statement = MlTuple(input, output);
+    statement = MlPair(input, output);
   }
   return prettifyStacktracePromise(
     withThreadPool(() =>
@@ -361,7 +361,7 @@ function ZkProgram<
       } finally {
         snarkContext.leave(id);
       }
-      let [publicOutputFields, proof] = MlTuple.from(result);
+      let [publicOutputFields, proof] = MlPair.from(result);
       let publicOutput = fromFieldConsts(publicOutputType, publicOutputFields);
       class ProgramProof extends Proof<PublicInput, PublicOutput> {
         static publicInputType = publicInputType;
@@ -397,7 +397,7 @@ function ZkProgram<
         `Cannot verify proof, verification key not found. Try calling \`await program.compile()\` first.`
       );
     }
-    let statement = MlTuple(
+    let statement = MlPair(
       toFieldConsts(publicInputType, proof.publicInput),
       toFieldConsts(publicOutputType, proof.publicOutput)
     );
@@ -714,7 +714,7 @@ function picklesRuleFromFunction(
         proofs.push(proofInstance);
         let input = toFieldVars(type.input, publicInput);
         let output = toFieldVars(type.output, publicOutput);
-        previousStatements.push(MlTuple(input, output));
+        previousStatements.push(MlPair(input, output));
       } else if (arg.type === 'generic') {
         finalArgs[i] = argsWithoutPublicInput?.[i] ?? emptyGeneric();
       }

--- a/src/lib/util/types.ts
+++ b/src/lib/util/types.ts
@@ -1,0 +1,44 @@
+import { assert } from '../errors.js';
+
+export { Tuple, TupleN };
+
+type Tuple<T> = [T, ...T[]] | [];
+
+const Tuple = {
+  map<T extends Tuple<any>, B>(
+    tuple: T,
+    f: (a: T[number]) => B
+  ): [...{ [i in keyof T]: B }] {
+    return tuple.map(f) as any;
+  },
+};
+
+/**
+ * tuple type that has the length as generic parameter
+ */
+type TupleN<T, N extends number> = N extends N
+  ? number extends N
+    ? [...T[]] // N is not typed as a constant => fall back to array
+    : [...TupleRec<T, N, []>]
+  : never;
+
+const TupleN = {
+  map<T, S, N extends number>(
+    tuple: TupleN<T, N>,
+    f: (a: T) => S
+  ): TupleN<S, N> {
+    return tuple.map(f) as any;
+  },
+
+  fromArray<T, N extends number>(n: N, arr: T[]): TupleN<T, N> {
+    assert(
+      arr.length === n,
+      `Expected array of length ${n}, got ${arr.length}`
+    );
+    return arr as any;
+  },
+};
+
+type TupleRec<T, N extends number, R extends unknown[]> = R['length'] extends N
+  ? R
+  : TupleRec<T, N, [T, ...R]>;

--- a/src/snarky.d.ts
+++ b/src/snarky.d.ts
@@ -296,6 +296,33 @@ declare const Snarky: {
   };
 
   gates: {
+    zero(in1: FieldVar, in2: FieldVar, out: FieldVar): void;
+
+    generic(
+      sl: FieldConst,
+      l: FieldVar,
+      sr: FieldConst,
+      r: FieldVar,
+      so: FieldConst,
+      o: FieldVar,
+      sm: FieldConst,
+      sc: FieldConst
+    ): void;
+
+    /**
+     * Low-level Elliptic Curve Addition gate.
+     */
+    ecAdd(
+      p1: MlGroup,
+      p2: MlGroup,
+      p3: MlGroup,
+      inf: FieldVar,
+      same_x: FieldVar,
+      slope: FieldVar,
+      inf_z: FieldVar,
+      x21_inv: FieldVar
+    ): MlGroup;
+
     /**
      * Range check gate
      *
@@ -346,19 +373,6 @@ declare const Snarky: {
       out_2: FieldVar,
       out_3: FieldVar
     ): void;
-
-    zero(in1: FieldVar, in2: FieldVar, out: FieldVar): void;
-
-    generic(
-      sl: FieldConst,
-      l: FieldVar,
-      sr: FieldConst,
-      r: FieldVar,
-      so: FieldConst,
-      o: FieldVar,
-      sm: FieldConst,
-      sc: FieldConst
-    ): void;
   };
 
   bool: {
@@ -374,20 +388,6 @@ declare const Snarky: {
   };
 
   group: {
-    /**
-     * Low-level Elliptic Curve Addition gate.
-     */
-    ecadd(
-      p1: MlGroup,
-      p2: MlGroup,
-      p3: MlGroup,
-      inf: FieldVar,
-      same_x: FieldVar,
-      slope: FieldVar,
-      inf_z: FieldVar,
-      x21_inv: FieldVar
-    ): MlGroup;
-
     scale(p: MlGroup, s: MlArray<BoolVar>): MlGroup;
   };
 

--- a/src/snarky.d.ts
+++ b/src/snarky.d.ts
@@ -306,18 +306,8 @@ declare const Snarky: {
      */
     rangeCheck0(
       v0: FieldVar,
-      v0p: [0, FieldVar, FieldVar, FieldVar, FieldVar, FieldVar, FieldVar],
-      v0c: [
-        0,
-        FieldVar,
-        FieldVar,
-        FieldVar,
-        FieldVar,
-        FieldVar,
-        FieldVar,
-        FieldVar,
-        FieldVar
-      ],
+      v0p: MlTuple<FieldVar, 6>,
+      v0c: MlTuple<FieldVar, 8>,
       compact: FieldConst
     ): void;
 

--- a/src/snarky.d.ts
+++ b/src/snarky.d.ts
@@ -405,10 +405,8 @@ declare const Snarky: {
     rangeCheck1(
       v2: FieldVar,
       v12: FieldVar,
-      v0p: MlTuple<FieldVar, 2>,
-      v1p: MlTuple<FieldVar, 2>,
-      v2p: MlTuple<FieldVar, 4>,
-      v2c: MlTuple<FieldVar, 20>
+      vCurr: MlTuple<FieldVar, 13>,
+      vNext: MlTuple<FieldVar, 15>
     ): void;
 
     xor(

--- a/src/snarky.d.ts
+++ b/src/snarky.d.ts
@@ -321,6 +321,15 @@ declare const Snarky: {
       compact: FieldConst
     ): void;
 
+    rangeCheck1(
+      v2: FieldVar,
+      v12: FieldVar,
+      v0p: MlTuple<FieldVar, 2>,
+      v1p: MlTuple<FieldVar, 2>,
+      v2p: MlTuple<FieldVar, 4>,
+      v2c: MlTuple<FieldVar, 20>
+    ): void;
+
     rotate(
       field: FieldVar,
       rotated: FieldVar,

--- a/src/snarky.d.ts
+++ b/src/snarky.d.ts
@@ -4,7 +4,7 @@ import type { BoolVar, Bool } from './lib/bool.js';
 import type { ScalarConst } from './lib/scalar.js';
 import type {
   MlArray,
-  MlTuple,
+  MlPair,
   MlList,
   MlOption,
   MlBool,
@@ -12,6 +12,7 @@ import type {
   MlResult,
   MlUnit,
   MlString,
+  MlTuple,
 } from './lib/ml/base.js';
 import type { MlHashInput } from './lib/ml/conversion.js';
 import type {
@@ -155,7 +156,7 @@ declare interface ProvablePure<T> extends Provable<T> {
   check: (value: T) => void;
 }
 
-type MlGroup = MlTuple<FieldVar, FieldVar>;
+type MlGroup = MlPair<FieldVar, FieldVar>;
 
 declare namespace Snarky {
   type Main = (publicInput: MlArray<FieldVar>) => void;
@@ -290,7 +291,7 @@ declare const Snarky: {
     ): [
       _: 0,
       constant: MlOption<FieldConst>,
-      terms: MlList<MlTuple<FieldConst, number>>
+      terms: MlList<MlPair<FieldConst, number>>
     ];
   };
 
@@ -435,7 +436,7 @@ declare const Snarky: {
       input: MlArray<FieldVar>
     ): [0, FieldVar, FieldVar, FieldVar];
 
-    hashToGroup(input: MlArray<FieldVar>): MlTuple<FieldVar, FieldVar>;
+    hashToGroup(input: MlArray<FieldVar>): MlPair<FieldVar, FieldVar>;
 
     sponge: {
       create(isChecked: boolean): unknown;
@@ -540,7 +541,7 @@ declare const Test: {
   };
 
   poseidon: {
-    hashToGroup(input: MlArray<FieldConst>): MlTuple<FieldConst, FieldConst>;
+    hashToGroup(input: MlArray<FieldConst>): MlPair<FieldConst, FieldConst>;
   };
 
   signature: {

--- a/src/snarky.d.ts
+++ b/src/snarky.d.ts
@@ -309,6 +309,8 @@ declare const Snarky: {
       sc: FieldConst
     ): void;
 
+    poseidon(state: MlArray<MlTuple<Field, 3>>): void;
+
     /**
      * Low-level Elliptic Curve Addition gate.
      */
@@ -322,6 +324,68 @@ declare const Snarky: {
       inf_z: FieldVar,
       x21_inv: FieldVar
     ): MlGroup;
+
+    ecScale(
+      state: MlArray<
+        [
+          _: 0,
+          accs: MlArray<MlTuple<FieldVar, 2>>,
+          bits: MlArray<FieldVar>,
+          ss: MlArray<FieldVar>,
+          base: MlGroup,
+          nPrev: Field,
+          nNext: Field
+        ]
+      >
+    ): void;
+
+    ecEndoscale(
+      state: MlArray<
+        [
+          _: 0,
+          xt: FieldVar,
+          yt: FieldVar,
+          xp: FieldVar,
+          yp: FieldVar,
+          nAcc: FieldVar,
+          xr: FieldVar,
+          yr: FieldVar,
+          s1: FieldVar,
+          s3: FieldVar,
+          b1: FieldVar,
+          b2: FieldVar,
+          b3: FieldVar,
+          b4: FieldVar
+        ]
+      >,
+      xs: FieldVar,
+      ys: FieldVar,
+      nAcc: FieldVar
+    ): void;
+
+    ecEndoscalar(
+      state: MlArray<
+        [
+          _: 0,
+          n0: FieldVar,
+          n8: FieldVar,
+          a0: FieldVar,
+          b0: FieldVar,
+          a8: FieldVar,
+          b8: FieldVar,
+          x0: FieldVar,
+          x1: FieldVar,
+          x2: FieldVar,
+          x3: FieldVar,
+          x4: FieldVar,
+          x5: FieldVar,
+          x6: FieldVar,
+          x7: FieldVar
+        ]
+      >
+    ): void;
+
+    lookup(input: MlTuple<FieldVar, 7>): void;
 
     /**
      * Range check gate
@@ -347,15 +411,6 @@ declare const Snarky: {
       v2c: MlTuple<FieldVar, 20>
     ): void;
 
-    rotate(
-      field: FieldVar,
-      rotated: FieldVar,
-      excess: FieldVar,
-      limbs: MlArray<FieldVar>,
-      crumbs: MlArray<FieldVar>,
-      two_to_rot: FieldConst
-    ): void;
-
     xor(
       in1: FieldVar,
       in2: FieldVar,
@@ -372,6 +427,48 @@ declare const Snarky: {
       out_1: FieldVar,
       out_2: FieldVar,
       out_3: FieldVar
+    ): void;
+
+    foreignFieldAdd(
+      left: MlTuple<FieldVar, 3>,
+      right: MlTuple<FieldVar, 3>,
+      fieldOverflow: FieldVar,
+      carry: FieldVar,
+      foreignFieldModulus: MlTuple<FieldConst, 3>,
+      sign: FieldConst
+    ): void;
+
+    foreignFieldMul(
+      left: MlTuple<FieldVar, 3>,
+      right: MlTuple<FieldVar, 3>,
+      remainder: MlTuple<FieldVar, 2>,
+      quotient: MlTuple<FieldVar, 3>,
+      quotientHiBound: FieldVar,
+      product1: MlTuple<FieldVar, 3>,
+      carry0: FieldVar,
+      carry1p: MlTuple<FieldVar, 7>,
+      carry1c: MlTuple<FieldVar, 4>,
+      foreignFieldModulus2: FieldConst,
+      negForeignFieldModulus: MlTuple<FieldConst, 3>
+    ): void;
+
+    rotate(
+      field: FieldVar,
+      rotated: FieldVar,
+      excess: FieldVar,
+      limbs: MlArray<FieldVar>,
+      crumbs: MlArray<FieldVar>,
+      two_to_rot: FieldConst
+    ): void;
+
+    addFixedLookupTable(id: number, data: MlArray<MlArray<FieldConst>>): void;
+
+    addRuntimeTableConfig(id: number, firstColumn: MlArray<FieldConst>): void;
+
+    raw(
+      kind: KimchiGateType,
+      values: MlArray<FieldVar>,
+      coefficients: MlArray<FieldConst>
     ): void;
   };
 
@@ -444,6 +541,27 @@ declare const Snarky: {
     };
   };
 };
+
+declare enum KimchiGateType {
+  Zero,
+  Generic,
+  Poseidon,
+  CompleteAdd,
+  VarBaseMul,
+  EndoMul,
+  EndoMulScalar,
+  Lookup,
+  CairoClaim,
+  CairoInstruction,
+  CairoFlags,
+  CairoTransition,
+  RangeCheck0,
+  RangeCheck1,
+  ForeignFieldAdd,
+  ForeignFieldMul,
+  Xor16,
+  Rot64,
+}
 
 type GateType =
   | 'Zero'


### PR DESCRIPTION
* exposes all remaining gates from OCaml
* makes the `rangeCheck64` implementation match the other gadgets, in that witnessing logic is moved to the gadget and the gate is a simple wrapper
* some other tweaks to gadget code and introduce some convenience types

bindings: https://github.com/o1-labs/o1js-bindings/pull/201