### PR TITLE
Make `tx.wait()` more reliable by increasing block length check to default of 20 blocks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,9 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased](https://github.com/o1-labs/o1js/compare/26363465d...HEAD)
 
-> No unreleased changes yet
+### Fixed
+
+- Add a parameter to `checkZkappTransaction` for block length to check for transaction inclusion. This fixes a case where `Transaction.wait()` only checked the latest block, which led to an error once the transaction was included in a block that was not the latest. https://github.com/o1-labs/o1js/pull/1239
 
 ## [0.14.1](https://github.com/o1-labs/o1js/compare/e8e7510e1...26363465d)
 

--- a/src/lib/fetch.ts
+++ b/src/lib/fetch.ts
@@ -542,7 +542,7 @@ async function checkZkappTransaction(txnId: string, blockLength = 20) {
   }
   return {
     success: false,
-    failureReason: `Transaction ${txnId} not found in the latest ${blockLength} blocks.`,
+    failureReason: null,
   };
 }
 

--- a/src/lib/fetch.ts
+++ b/src/lib/fetch.ts
@@ -482,7 +482,7 @@ type LastBlockQueryFailureCheckResponse = {
 };
 
 const lastBlockQueryFailureCheck = `{
-  bestChain(maxLength: 1) {
+  bestChain(maxLength: 20) {
     transactions {
       zkappCommands {
         hash


### PR DESCRIPTION
# Summary
This update introduces improvements to `tx.wait()`, addressing reliability issues in transaction inclusion checking within blocks. It includes a fix by checking for the last 20 blocks of a transaction inclusion instead of 1. Additionally, the number of blocks to check for `fetchLatestBlockZkappStatus` is now customizable.

