### PR TITLE
Test DSL to detect broken gate chains

### DIFF
--- a/src/lib/field.ts
+++ b/src/lib/field.ts
@@ -78,13 +78,22 @@ const FieldVar = {
   isConstant(x: FieldVar): x is ConstantFieldVar {
     return x[0] === FieldType.Constant;
   },
-  // TODO: handle (special) constants
   add(x: FieldVar, y: FieldVar): FieldVar {
+    if (FieldVar.isConstant(x) && x[1][1] === 0n) return y;
+    if (FieldVar.isConstant(y) && y[1][1] === 0n) return x;
+    if (FieldVar.isConstant(x) && FieldVar.isConstant(y)) {
+      return FieldVar.constant(Fp.add(x[1][1], y[1][1]));
+    }
     return [FieldType.Add, x, y];
   },
-  // TODO: handle (special) constants
-  scale(c: FieldConst, x: FieldVar): FieldVar {
-    return [FieldType.Scale, c, x];
+  scale(c: bigint | FieldConst, x: FieldVar): FieldVar {
+    let c0 = typeof c === 'bigint' ? FieldConst.fromBigint(c) : c;
+    if (c0[1] === 0n) return FieldVar.constant(0n);
+    if (c0[1] === 1n) return x;
+    if (FieldVar.isConstant(x)) {
+      return FieldVar.constant(Fp.mul(c0[1], x[1][1]));
+    }
+    return [FieldType.Scale, c0, x];
   },
   [0]: [FieldType.Constant, FieldConst[0]] satisfies ConstantFieldVar,
   [1]: [FieldType.Constant, FieldConst[1]] satisfies ConstantFieldVar,

--- a/src/lib/testing/constraint-system.ts
+++ b/src/lib/testing/constraint-system.ts
@@ -40,6 +40,7 @@ type TypeAndValue<T> = { type: Provable<T>; value: T };
 // main DSL
 
 function constraintSystem<In extends Tuple<CsVarSpec<any>>>(
+  label: string,
   inputs: { from: In },
   main: (...args: CsParams<In>) => void,
   csTest: CsTest
@@ -70,9 +71,10 @@ function constraintSystem<In extends Tuple<CsVarSpec<any>>>(
       // TODO nice printed representation of cs
       console.log(gates);
 
-      let s = failures.length === 1 ? '' : 's';
       throw Error(
-        `Failed constraint system test${s}:\n${failures.join('\n')}\n`
+        `Constraint system test: ${label}\n\n${failures
+          .map((f) => `FAIL: ${f}`)
+          .join('\n')}\n`
       );
     }
   });
@@ -107,13 +109,13 @@ function run(test: CsTest, cs: Gate[], inputs: TypeAndValue<any>[]): Result {
     case 'and': {
       let results = test.tests.map((t) => run(t, cs, inputs));
       let ok = results.every((r) => r.ok);
-      let failures = results.flatMap((r) => r.failures);
+      let failures = ok ? [] : results.flatMap((r) => r.failures);
       return { ok, failures };
     }
     case 'or': {
       let results = test.tests.map((t) => run(t, cs, inputs));
       let ok = results.some((r) => r.ok);
-      let failures = results.flatMap((r) => r.failures);
+      let failures = ok ? [] : results.flatMap((r) => r.failures);
       return { ok, failures };
     }
   }

--- a/src/lib/testing/constraint-system.ts
+++ b/src/lib/testing/constraint-system.ts
@@ -67,6 +67,7 @@ function constraintSystem<In extends Tuple<CsVarSpec<any>>>(
 
     if (!ok) {
       console.log('Constraint system:');
+      // TODO nice printed representation of cs
       console.log(gates);
 
       let s = failures.length === 1 ? '' : 's';
@@ -167,7 +168,9 @@ function equals(gates: GateType[]): CsTest {
  * contains([['Rot64', 'RangeCheck0'], ['Rot64', 'RangeCheck0']]])
  * ```
  */
-function contains(gates: GateType | GateType[] | GateType[][]): CsTest {
+function contains(
+  gates: GateType | readonly GateType[] | readonly GateType[][]
+): CsTest {
   let expectedGatess = toGatess(gates);
   return {
     run(cs) {
@@ -253,7 +256,7 @@ const log: CsTest = {
 };
 
 function toGatess(
-  gateTypes: GateType | GateType[] | GateType[][]
+  gateTypes: GateType | readonly GateType[] | readonly GateType[][]
 ): GateType[][] {
   if (typeof gateTypes === 'string') return [[gateTypes]];
   if (Array.isArray(gateTypes[0])) return gateTypes as GateType[][];

--- a/src/lib/testing/constraint-system.ts
+++ b/src/lib/testing/constraint-system.ts
@@ -1,0 +1,206 @@
+/**
+ * DSL for testing that a gadget generates the expected constraint system.
+ *
+ * An essential feature is that `constraintSystem()` automatically generates a
+ * variety of fieldvar types for the inputs: constants, variables, and combinators.
+ */
+import { Gate, GateType } from '../../snarky.js';
+import { randomBytes } from '../../bindings/crypto/random.js';
+import { Field, FieldType, FieldVar } from '../field.js';
+import { Provable } from '../provable.js';
+import { Tuple } from '../util/types.js';
+import { Random } from './random.js';
+import { test } from './property.js';
+
+export { constraintSystem, contains, log };
+
+type CsVarSpec<T> = Provable<T> | { provable: Provable<T> };
+type InferCsVar<T> = T extends { provable: Provable<infer U> }
+  ? U
+  : T extends Provable<infer U>
+  ? U
+  : never;
+type CsParams<In extends Tuple<CsVarSpec<any>>> = {
+  [k in keyof In]: InferCsVar<In[k]>;
+};
+
+type CsTest = { run: (cs: Gate[]) => boolean; label: string };
+
+// main DSL
+
+function constraintSystem<In extends Tuple<CsVarSpec<any>>>(
+  inputs: { from: In },
+  main: (...args: CsParams<In>) => void,
+  tests: CsTest[]
+) {
+  // create random generators
+  let types = inputs.from.map(provable);
+  let rngs = types.map(layout);
+
+  test(...rngs, (...args) => {
+    let layouts = args.slice(0, -1);
+
+    // compute the constraint system
+    let result = Provable.constraintSystem(() => {
+      // each random input "layout" has to be instantiated into vars in this circuit
+      let values = types.map((type, i) =>
+        instantiate(type, layouts[i])
+      ) as CsParams<In>;
+      main(...values);
+    });
+
+    // run tests
+    let failures = tests
+      .map((test) => [test.run(result.gates), test.label] as const)
+      .filter(([ok]) => !ok)
+      .map(([, label]) => label);
+
+    if (failures.length > 0) {
+      console.log('Constraint system:');
+      console.log(result.gates);
+
+      let s = failures.length === 1 ? '' : 's';
+      throw Error(
+        `Failed constraint system test${s}:\n${failures.join('\n')}\n`
+      );
+    }
+  });
+}
+
+// DSL for writing tests
+
+/**
+ * Test that constraint system contains each of a list of gates consecutively.
+ *
+ * You can also pass a list of lists. In that case, the constraint system has to contain
+ * each of the lists of gates in the given order, but not necessarily consecutively.
+ *
+ * @example
+ * ```ts
+ * // constraint system contains a Rot64 gate
+ * contains('Rot64')
+ *
+ * // constraint system contains a Rot64 gate, followed directly by a RangeCheck0 gate
+ * contains(['Rot64', 'RangeCheck0'])
+ *
+ * // constraint system contains two instances of the combination [Rot64, RangeCheck0]
+ * contains([['Rot64', 'RangeCheck0'], ['Rot64', 'RangeCheck0']]])
+ * ```
+ */
+function contains(gates: GateType | GateType[] | GateType[][]): CsTest {
+  let expectedGatess = toGatess(gates);
+  return {
+    run(cs) {
+      let gates = cs.map((g) => g.type);
+      let i = 0;
+      let j = 0;
+      for (let gate of gates) {
+        if (gate === expectedGatess[i][j]) {
+          j++;
+          if (j === expectedGatess[i].length) {
+            i++;
+            j = 0;
+            if (i === expectedGatess.length) return true;
+          }
+        } else if (gate === expectedGatess[i][0]) {
+          j = 1;
+        } else {
+          j = 0;
+        }
+      }
+      return false;
+    },
+    label: `contains ${JSON.stringify(expectedGatess)}`,
+  };
+}
+
+/**
+ * "Test" that just logs the constraint system.
+ */
+const log: CsTest = {
+  run(cs) {
+    console.log('Constraint system:');
+    console.log(cs);
+    return true;
+  },
+  label: '',
+};
+
+function toGatess(
+  gateTypes: GateType | GateType[] | GateType[][]
+): GateType[][] {
+  if (typeof gateTypes === 'string') return [[gateTypes]];
+  if (Array.isArray(gateTypes[0])) return gateTypes as GateType[][];
+  return [gateTypes as GateType[]];
+}
+
+// Random generator for arbitrary provable types
+
+function provable<T>(spec: CsVarSpec<T>): Provable<T> {
+  return 'provable' in spec ? spec.provable : spec;
+}
+
+function layout<T>(type: Provable<T>): Random<T> {
+  let length = type.sizeInFields();
+
+  return Random(() => {
+    let fields = Array.from({ length }, () => new Field(drawFieldVar()));
+    return type.fromFields(fields, type.toAuxiliary());
+  });
+}
+
+function instantiate<T>(type: Provable<T>, value: T) {
+  let fields = type.toFields(value).map((x) => instantiateFieldVar(x.value));
+  return type.fromFields(fields, type.toAuxiliary());
+}
+
+// Random generator for fieldvars that exercises constants, variables and combinators
+
+function drawFieldVar(): FieldVar {
+  let fieldType = drawFieldType();
+  switch (fieldType) {
+    case FieldType.Constant: {
+      return [FieldType.Constant, [0, 17n]];
+    }
+    case FieldType.Var: {
+      return [FieldType.Var, 0];
+    }
+    case FieldType.Add: {
+      let x = drawFieldVar();
+      let y = drawFieldVar();
+      return [FieldType.Add, x, y];
+    }
+    case FieldType.Scale: {
+      let x = drawFieldVar();
+      return [FieldType.Scale, [0, 3n], x];
+    }
+  }
+}
+
+function instantiateFieldVar(x: FieldVar): Field {
+  switch (x[0]) {
+    case FieldType.Constant: {
+      return new Field(x);
+    }
+    case FieldType.Var: {
+      return Provable.witness(Field, () => Field.from(0n));
+    }
+    case FieldType.Add: {
+      let a = instantiateFieldVar(x[1]);
+      let b = instantiateFieldVar(x[2]);
+      return a.add(b);
+    }
+    case FieldType.Scale: {
+      let a = instantiateFieldVar(x[2]);
+      return a.mul(x[1][1]);
+    }
+  }
+}
+
+function drawFieldType(): FieldType {
+  let oneOf8 = randomBytes(1)[0] & 0b111;
+  if (oneOf8 < 4) return FieldType.Var;
+  if (oneOf8 < 6) return FieldType.Constant;
+  if (oneOf8 === 6) return FieldType.Scale;
+  return FieldType.Add;
+}


### PR DESCRIPTION
- first version of constraint system test dsl
- properly implement fieldvar combinators
- pass inputs to cs tests, and make them combinable
- more cs tests and combinators
- replace existing test with new dsl test, which passes
- usability tweaks
- tweak error output
- replace other test and expose bug where generic gate disrupts mrc chain
- print constraint system
