### PR TITLE
Expose lookup gates

### DIFF
--- a/src/lib/gates.ts
+++ b/src/lib/gates.ts
@@ -130,3 +130,15 @@ function generic(
 function zero(a: Field, b: Field, c: Field) {
   Snarky.gates.zero(a.value, b.value, c.value);
 }
+
+function lookup(id: Field, index: Field, value: Field) {
+  Snarky.gates.lookup([id.value, index.value, value.value, index.value, value.value, index.value, value.value]);
+}
+
+function addFixedLookupTable(id: number, data: [[Field], [Field]]) {
+  Snarky.gates.addFixedLookupTable(id, [data[0].map((x) => x.value), data[1].map((x) => x.value)]);
+}
+
+function addDynamicLookupTable(id: number, data: [Field]) {
+  Snarky.gates.addRuntimeTableConfig(id, data.map((x) => x.value));
+}


### PR DESCRIPTION
This PR makes the lookup gates available from `gates.ts`. The intended usage is:
* for fixed tables
  ```ts
    let primesTable =
      [ [ new Field(0), new Field(1), new Field(2), new Field(3), new Field(4), new Field(5) ]
      , [ new Field(2), new Field(3), new Field(5), new Field(7), new Field(11), new Field(13) ] ];
    ...
    let tableId = Gates.addFixedLookupTable(primesTable);
    ...
    let index = Provable.witness(
      Field,
      () => new Field(2)
    );
    let prime = Provable.witness(
      Field,
      () => new Field(5)
    );
    Gates.lookup(tableId, index, prime);
  ```
* for dynamic tables
  ```ts
    let dynamicTable =
      [ [ new Field(0), new Field(1), new Field(2), new Field(3), new Field(4), new Field(5) ] ];
    ...
    let tableId = Gates.addDynamicLookupTable(dynamicTable);
    ...
    let index = Provable.witness(
      Field,
      () => new Field(1)
    );
    let prime = Provable.witness(
      Field,
      () => new Field(95)
    );
    Gates.lookup(tableId, index, prime);
  ```