### PR TITLE
🔎 Expose lookup gates

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -24,6 +24,7 @@ export { UInt32, UInt64, Int64, Sign } from './lib/int.js';
 export { Gadgets } from './lib/gadgets/gadgets.js';
 export { Types } from './bindings/mina-transaction/types.js';
 
+export * as Gates from './lib/gates.js';
 export * as Mina from './lib/mina.js';
 export type { DeployArgs } from './lib/zkapp.js';
 export {

--- a/src/lib/gates.ts
+++ b/src/lib/gates.ts
@@ -1,9 +1,9 @@
 import { Snarky } from '../snarky.js';
-import { FieldConst, type Field } from './field.js';
+import { FieldConst, Field, FieldVar } from './field.js';
 import { MlArray, MlTuple } from './ml/base.js';
 import { TupleN } from './util/types.js';
 
-export { rangeCheck0, rangeCheck1, xor, zero, rotate, generic };
+export { rangeCheck0, rangeCheck1, xor, zero, lookup, addFixedLookupTable, addDynamicLookupTable, rotate, generic };
 
 function rangeCheck0(
   x: Field,
@@ -131,14 +131,19 @@ function zero(a: Field, b: Field, c: Field) {
   Snarky.gates.zero(a.value, b.value, c.value);
 }
 
-function lookup(id: Field, index: Field, value: Field) {
-  Snarky.gates.lookup([id.value, index.value, value.value, index.value, value.value, index.value, value.value]);
+function lookup(id: Field, index: Field, value: Field) {  
+  Snarky.gates.lookup([0, id.value, index.value, value.value, index.value, value.value, index.value, value.value]);
 }
 
-function addFixedLookupTable(id: number, data: [[Field], [Field]]) {
-  Snarky.gates.addFixedLookupTable(id, [data[0].map((x) => x.value), data[1].map((x) => x.value)]);
+function addFixedLookupTable(id: number, indices: Field[], data: Field[]) {
+  Snarky.gates.addFixedLookupTable(
+    id, 
+    MlArray.to([
+      MlArray.to(indices.map((x) => FieldConst.fromBigint(x.toBigInt()))),
+      MlArray.to(data.map((x) => FieldConst.fromBigint(x.toBigInt())))
+    ]))  
 }
 
-function addDynamicLookupTable(id: number, data: [Field]) {
-  Snarky.gates.addRuntimeTableConfig(id, data.map((x) => x.value));
+function addDynamicLookupTable(id: number, data: Field[]) {
+  Snarky.gates.addRuntimeTableConfig(id, MlArray.to(data.map((x) => FieldConst.fromBigint(x.toBigInt()))));
 }


### PR DESCRIPTION
This PR makes lookup gates available from [`gates.ts`](https://github.com/o1-labs/o1js/blob/2e71ab0fcc0eb014d0af47c476be37d583507d0f/src/lib/gates.ts). The intended usage is:

- For fixed lookup tables:
```js
  import { Gates } from 'o1js';
  ...
  let indices = [Field(0), Field(1), Field(2), Field(3), Field(4), Field(5)];
  let data = [Field(2), Field(3), Field(5), Field(7), Field(11), Field(13)];
  
  // Adding lookup table with ID = 1
  Gates.addFixedLookupTable(1, indices, data);

  // Valid lookup ✔️: at index 2 value is 5, where 1 is our table ID
  Gates.lookup(Field(1), Field(2), Field(5));

  // Invalid lookup ❌: at index 5 value is 13, not 69
  // This would raise an error—proof cannot be generated
  Gates.lookup(Field(1), Field(5), Field(69);
```

- For dynamic lookup tables:
```js
  import { Gates } from 'o1js';
  ...
  let indices = [Field(0), Field(1), Field(2), Field(3), Field(4), Field(5)];
  
  // Creating a dynamic lookup table with ID = 1
  Gates.addDynamicLookupTable(1, indices);

  // Filling in a value of 10 for index 2
 Gates.lookup(Field(1), Field(2), Field(10));

  // Valid lookup ✔️: at index 2 value is 10 (as was filled in), where 1 is our table ID
  Gates.lookup(Field(1), Field(2), Field(10));

  // Invalid lookup ❌: at index 2 value is not 69, cannot be overwritten
  // This would raise an error—proof cannot be generated
  Gates.lookup(Field(1), Field(2), Field(69);
```

### Dynamic Tables: Issue
Although exposed, dynamic tables are not fully functional, which might be due to an error in some underlying dependency. Trying to compile a circuit making use of them results in an error, the stack trace being:
> Error: Pickles cannot handle point at infinity. Commitments must be representable in affine coordinates
    at Class.<computed> [as compile] (o1js/dist/node/bindings/js/proxy.js:21:62)
    at file:/node_modules/o1js/dist/node/lib/proof_system.js:329:30
    at withThreadPool (o1js/dist/node/bindings/js/node/node-backend.js:47:24)
    at async prettifyStacktracePromise (o1js/dist/node/lib/errors.js:104:16)
    at async compileProgram (o1js/dist/node/lib/proof_system.js:324:53)
    at async Object.compile (o1js/dist/node/lib/proof_system.js:144:52)
    at async testStatic (file:/build/src/lookup-tests.js:38:33)