### PR TITLE
:hammer: Updating state.ts to deprecate existing precondition apis and updating them with new

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,13 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased](https://github.com/o1-labs/o1js/compare/1ad7333e9e...HEAD)
 
-> No unreleased changes yet
+### Changed
+
+- Preconditioned asset* in state have been renamed to require* :
+  For example:
+  - `this.x.getAndAssertEquals()` is now `this.x.getAndRequireEquals()` https://github.com/o1-labs/o1js/pull/1263
+  - `this.x.assertEquals(x)` is now `this.x.requireEquals(x)` https://github.com/o1-labs/o1js/pull/1263
+  - `this.x.assertNothing()` is now `this.x.requireNothing()` https://github.com/o1-labs/o1js/pull/1263
 
 ## [0.14.2](https://github.com/o1-labs/o1js/compare/26363465d...1ad7333e9e)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,8 +21,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ### Changed
 
-- Preconditioned asset* in state have been renamed to require* :
-  For example:
+- Change precondition APIs to use "require" instead of "assert" as the verb, to distinguish them from provable assertions.
   - `this.x.getAndAssertEquals()` is now `this.x.getAndRequireEquals()` https://github.com/o1-labs/o1js/pull/1263
   - `this.x.assertEquals(x)` is now `this.x.requireEquals(x)` https://github.com/o1-labs/o1js/pull/1263
   - `this.x.assertNothing()` is now `this.x.requireNothing()` https://github.com/o1-labs/o1js/pull/1263

--- a/src/lib/state.ts
+++ b/src/lib/state.ts
@@ -233,20 +233,7 @@ function createState<T>(): InternalStateType<T> {
     },
 
     assertEquals(state: T) {
-      if (this._contract === undefined)
-        throw Error(
-          'assertEquals can only be called when the State is assigned to a SmartContract @state.'
-        );
-      let layout = getLayoutPosition(this._contract);
-      let stateAsFields = this._contract.stateType.toFields(state);
-      let accountUpdate = this._contract.instance.self;
-      stateAsFields.forEach((x, i) => {
-        AccountUpdate.assertEquals(
-          accountUpdate.body.preconditions.account.state[layout.offset + i],
-          x
-        );
-      });
-      this._contract.wasConstrained = true;
+      this.requireEquals(state);
     },
 
     requireNothing() {
@@ -258,11 +245,7 @@ function createState<T>(): InternalStateType<T> {
     },
 
     assertNothing() {
-      if (this._contract === undefined)
-        throw Error(
-          'assertNothing can only be called when the State is assigned to a SmartContract @state.'
-        );
-      this._contract.wasConstrained = true;
+      this.requireNothing();
     },
 
     get() {
@@ -331,16 +314,14 @@ function createState<T>(): InternalStateType<T> {
       return state;
     },
 
-    getAndRequireEquals(){
+    getAndRequireEquals() {
       let state = this.get();
       this.requireEquals(state);
       return state;
     },
 
     getAndAssertEquals() {
-      let state = this.get();
-      this.assertEquals(state);
-      return state;
+      return this.getAndRequireEquals();
     },
 
     async fetch() {


### PR DESCRIPTION
Hi @mitschabaude ,
As discussed in issue #1247 , I have replaced old api by deprecating them rather than removing.  
Question:
> Do we need to update this `assertStatePrecondition` too ?

Please review and let know if any changes are required.
