### PR TITLE
Fix lookup tables

### DIFF
--- a/src/lib/proof_system.ts
+++ b/src/lib/proof_system.ts
@@ -260,7 +260,10 @@ function ZkProgram<
   }
 ): {
   name: string;
-  compile: (options?: { cache: Cache }) => Promise<{ verificationKey: string }>;
+  compile: (options?: {
+    cache?: Cache;
+    forceRecompile?: boolean;
+  }) => Promise<{ verificationKey: string }>;
   verify: (
     proof: Proof<
       InferProvableOrUndefined<Get<StatementType, 'publicInput'>>,
@@ -338,7 +341,10 @@ function ZkProgram<
       }
     | undefined;
 
-  async function compile({ cache = Cache.FileSystemDefault } = {}) {
+  async function compile({
+    cache = Cache.FileSystemDefault,
+    forceRecompile = false,
+  } = {}) {
     let methodsMeta = methodIntfs.map((methodEntry, i) =>
       analyzeMethod(publicInputType, methodEntry, methodFunctions[i])
     );
@@ -351,6 +357,7 @@ function ZkProgram<
       gates,
       proofSystemTag: selfTag,
       cache,
+      forceRecompile,
       overrideWrapDomain: config.overrideWrapDomain,
     });
     compileOutput = { provers, verify };
@@ -603,6 +610,7 @@ async function compileProgram({
   gates,
   proofSystemTag,
   cache,
+  forceRecompile,
   overrideWrapDomain,
 }: {
   publicInputType: ProvablePure<any>;
@@ -612,6 +620,7 @@ async function compileProgram({
   gates: Gate[][];
   proofSystemTag: { name: string };
   cache: Cache;
+  forceRecompile: boolean;
   overrideWrapDomain?: 0 | 1 | 2;
 }) {
   let rules = methodIntfs.map((methodEntry, i) =>
@@ -630,6 +639,7 @@ async function compileProgram({
   let picklesCache: Pickles.Cache = [
     0,
     function read_(mlHeader) {
+      if (forceRecompile) return MlResult.unitError();
       let header = parseHeader(proofSystemTag.name, methodIntfs, mlHeader);
       let result = readCache(cache, header, (bytes) =>
         decodeProverKey(mlHeader, bytes)

--- a/src/lib/zkapp.ts
+++ b/src/lib/zkapp.ts
@@ -662,7 +662,10 @@ class SmartContract {
    * it so that proofs end up in the original finite field). These are fairly expensive operations, so **expect compiling to take at least 20 seconds**,
    * up to several minutes if your circuit is large or your hardware is not optimal for these operations.
    */
-  static async compile({ cache = Cache.FileSystemDefault } = {}) {
+  static async compile({
+    cache = Cache.FileSystemDefault,
+    forceRecompile = false,
+  } = {}) {
     let methodIntfs = this._methods ?? [];
     let methods = methodIntfs.map(({ methodName }) => {
       return (
@@ -690,6 +693,7 @@ class SmartContract {
       gates,
       proofSystemTag: this,
       cache,
+      forceRecompile,
     });
     let verificationKey = {
       data: verificationKey_.data,


### PR DESCRIPTION
* Add bindings for the lookup table fix in https://github.com/o1-labs/proof-systems/pull/1336
* Add a `forceRecompile` option to `compile()` to override caching for the rare cases like this change, where individual circuits not changing is not an indicator that cached keys can be used

mina: https://github.com/MinaProtocol/mina/pull/14605
bindings: https://github.com/o1-labs/o1js-bindings/pull/211