### PR TITLE
Encode how to map provables to normal values

### DIFF
--- a/src/lib/account_update.ts
+++ b/src/lib/account_update.ts
@@ -1285,6 +1285,11 @@ class AccountUpdate implements Types.AccountUpdate {
       other
     );
   }
+  static toValue = Types.AccountUpdate.toValue;
+  static fromValue(value: TypesBigint.AccountUpdate): AccountUpdate {
+    let accountUpdate = Types.AccountUpdate.fromValue(value);
+    return new AccountUpdate(accountUpdate.body, accountUpdate.authorization);
+  }
 
   static witness<T>(
     type: FlexibleProvable<T>,

--- a/src/lib/bool.ts
+++ b/src/lib/bool.ts
@@ -273,6 +273,22 @@ class Bool {
   }
 
   /**
+   * `Provable<Bool>.toValue()`
+   */
+  static toValue(x: Bool): 0n | 1n {
+    // TODO make `boolean` the value type
+    return x.toBoolean() ? 1n : 0n;
+  }
+
+  /**
+   * `Provable<Bool>.fromValue()`
+   */
+  static fromValue(x: 0n | 1n) {
+    // TODO make `boolean` the value type
+    return new Bool(x === 1n);
+  }
+
+  /**
    * Serialize a {@link Bool} to a JSON string.
    * This operation does _not_ affect the circuit and can't be used to prove anything about the string representation of the Field.
    */

--- a/src/lib/circuit.ts
+++ b/src/lib/circuit.ts
@@ -204,8 +204,8 @@ function public_(target: any, _key: string | symbol, index: number) {
 
 type CircuitData<P, W> = {
   main(publicInput: P, privateInput: W): void;
-  publicInputType: ProvablePure<P>;
-  privateInputType: ProvablePure<W>;
+  publicInputType: ProvablePure<P, any>;
+  privateInputType: ProvablePure<W, any>;
 };
 
 function mainFromCircuitData<P, W>(
@@ -266,7 +266,9 @@ function circuitMain(
 }
 
 // TODO support auxiliary data
-function provableFromTuple(typs: ProvablePure<any>[]): ProvablePure<any> {
+function provableFromTuple(
+  typs: ProvablePure<any, any>[]
+): ProvablePure<any, any> {
   return {
     sizeInFields: () => {
       return typs.reduce((acc, typ) => acc + typ.sizeInFields(), 0);
@@ -300,6 +302,14 @@ function provableFromTuple(typs: ProvablePure<any>[]): ProvablePure<any> {
 
     check(xs: Array<any>) {
       typs.forEach((typ, i) => (typ as any).check(xs[i]));
+    },
+
+    toValue(x) {
+      return typs.map((typ, i) => typ.toValue(x[i]));
+    },
+
+    fromValue(x) {
+      return typs.map((typ, i) => typ.fromValue(x[i]));
     },
   };
 }

--- a/src/lib/events.ts
+++ b/src/lib/events.ts
@@ -61,6 +61,16 @@ function createEvents<Field>({
     ...Events,
     ...dataAsHash({
       empty: Events.empty,
+      toValue(data: Field[][]) {
+        return data.map((row) => row.map((e) => BigInt(Field.toJSON(e))));
+      },
+      fromValue(value: bigint[][]) {
+        let data = value.map((row) =>
+          row.map((e) => Field.fromJSON(e.toString()))
+        );
+        let hash = Events.hash(data);
+        return { data, hash };
+      },
       toJSON(data: Field[][]) {
         return data.map((row) => row.map((e) => Field.toJSON(e)));
       },
@@ -104,10 +114,20 @@ function createEvents<Field>({
     },
   };
 
-  const SequenceEventsProvable = {
+  const ActionsProvable = {
     ...Actions,
     ...dataAsHash({
       empty: Actions.empty,
+      toValue(data: Field[][]) {
+        return data.map((row) => row.map((e) => BigInt(Field.toJSON(e))));
+      },
+      fromValue(value: bigint[][]) {
+        let data = value.map((row) =>
+          row.map((e) => Field.fromJSON(e.toString()))
+        );
+        let hash = Actions.hash(data);
+        return { data, hash };
+      },
       toJSON(data: Field[][]) {
         return data.map((row) => row.map((e) => Field.toJSON(e)));
       },
@@ -119,18 +139,22 @@ function createEvents<Field>({
     }),
   };
 
-  return { Events: EventsProvable, Actions: SequenceEventsProvable };
+  return { Events: EventsProvable, Actions: ActionsProvable };
 }
 
-function dataAsHash<T, J, Field>({
+function dataAsHash<T, V, J, Field>({
   empty,
+  toValue,
+  fromValue,
   toJSON,
   fromJSON,
 }: {
   empty: () => { data: T; hash: Field };
+  toValue: (value: T) => V;
+  fromValue: (value: V) => { data: T; hash: Field };
   toJSON: (value: T) => J;
   fromJSON: (json: J) => { data: T; hash: Field };
-}): GenericProvableExtended<{ data: T; hash: Field }, J, Field> {
+}): GenericProvableExtended<{ data: T; hash: Field }, V, J, Field> {
   return {
     empty,
     sizeInFields() {
@@ -144,6 +168,12 @@ function dataAsHash<T, J, Field>({
     },
     fromFields([hash], [data]) {
       return { data, hash };
+    },
+    toValue({ data }) {
+      return toValue(data);
+    },
+    fromValue(value) {
+      return fromValue(value);
     },
     toJSON({ data }) {
       return toJSON(data);

--- a/src/lib/field.ts
+++ b/src/lib/field.ts
@@ -1127,6 +1127,20 @@ class Field {
   static check() {}
 
   /**
+   * `Provable<Field>.toValue()`
+   */
+  static toValue(x: Field) {
+    return x.toBigInt();
+  }
+
+  /**
+   * `Provable<Field>.fromValue()`
+   */
+  static fromValue(x: bigint) {
+    return new Field(x);
+  }
+
+  /**
    * This function is the implementation of {@link Provable.toFields} for the {@link Field} type.
    *
    * The result will be always an array of length 1, where the first and only element equals the {@link Field} itself.

--- a/src/lib/field.unit-test.ts
+++ b/src/lib/field.unit-test.ts
@@ -19,8 +19,8 @@ import {
 } from './testing/equivalent.js';
 
 // types
-Field satisfies Provable<Field>;
-Field satisfies ProvablePure<Field>;
+Field satisfies Provable<Field, bigint>;
+Field satisfies ProvablePure<Field, bigint>;
 Field satisfies ProvableExtended<Field>;
 Field satisfies Binable<Field>;
 

--- a/src/lib/gadgets/foreign-field.ts
+++ b/src/lib/gadgets/foreign-field.ts
@@ -16,6 +16,7 @@ import {
   l3,
   compactMultiRangeCheck,
 } from './range-check.js';
+import { ProvablePureExtended } from '../circuit_value.js';
 
 export { ForeignField, Field3, Sign };
 
@@ -347,7 +348,15 @@ const Field3 = {
    * Note: Witnessing this creates a plain tuple of field elements without any implicit
    * range checks.
    */
-  provable: provableTuple([Field, Field, Field]),
+  provable: {
+    ...provableTuple([Field, Field, Field]),
+    toValue(x): bigint {
+      return Field3.toBigint(x);
+    },
+    fromValue(x): Field3 {
+      return Field3.from(x);
+    },
+  } satisfies ProvablePureExtended<Field3, bigint, [string, string, string]>,
 };
 
 type Field2 = [Field, Field];

--- a/src/lib/group.ts
+++ b/src/lib/group.ts
@@ -409,6 +409,14 @@ class Group {
     return 2;
   }
 
+  static toValue({ x, y }: Group) {
+    return { x: x.toBigInt(), y: y.toBigInt() };
+  }
+
+  static fromValue(g: { x: bigint; y: bigint }) {
+    return new Group(g);
+  }
+
   /**
    * Serializes a {@link Group} element to a JSON object.
    *

--- a/src/lib/hash-input.unit-test.ts
+++ b/src/lib/hash-input.unit-test.ts
@@ -31,20 +31,22 @@ type NetworkPrecondition = Body['preconditions']['network'];
 
 // provables
 let bodyLayout = jsLayout.AccountUpdate.entries.body;
-let Timing = provableFromLayout<Timing, any>(
+let Timing = provableFromLayout<Timing, any, any>(
   bodyLayout.entries.update.entries.timing.inner as any
 );
-let Permissions_ = provableFromLayout<Permissions, any>(
+let Permissions_ = provableFromLayout<Permissions, any, any>(
   bodyLayout.entries.update.entries.permissions.inner as any
 );
-let Update = provableFromLayout<Update, any>(bodyLayout.entries.update as any);
-let AccountPrecondition = provableFromLayout<AccountPrecondition, any>(
+let Update = provableFromLayout<Update, any, any>(
+  bodyLayout.entries.update as any
+);
+let AccountPrecondition = provableFromLayout<AccountPrecondition, any, any>(
   bodyLayout.entries.preconditions.entries.account as any
 );
-let NetworkPrecondition = provableFromLayout<NetworkPrecondition, any>(
+let NetworkPrecondition = provableFromLayout<NetworkPrecondition, any, any>(
   bodyLayout.entries.preconditions.entries.network as any
 );
-let Body = provableFromLayout<Body, any>(bodyLayout as any);
+let Body = provableFromLayout<Body, any, any>(bodyLayout as any);
 
 // test with random account udpates
 test(Random.json.accountUpdate, (accountUpdateJson) => {

--- a/src/lib/hash.ts
+++ b/src/lib/hash.ts
@@ -151,6 +151,7 @@ function packToFields({ fields = [], packed = [] }: HashInput) {
 
 const TokenSymbolPure: ProvableExtended<
   { symbol: string; field: Field },
+  string,
   string
 > = {
   toFields({ field }) {
@@ -168,6 +169,13 @@ const TokenSymbolPure: ProvableExtended<
   check({ field }: TokenSymbol) {
     let actual = field.rangeCheckHelper(48);
     actual.assertEquals(field);
+  },
+  toValue({ symbol }) {
+    return symbol;
+  },
+  fromValue(symbol: string) {
+    let field = prefixToField(symbol);
+    return { symbol, field };
   },
   toJSON({ symbol }) {
     return symbol;

--- a/src/lib/precondition.ts
+++ b/src/lib/precondition.ts
@@ -206,7 +206,7 @@ function preconditionSubClassWithRange<
 >(
   accountUpdate: AccountUpdate,
   longKey: K,
-  fieldType: Provable<U>,
+  fieldType: Provable<U, any>,
   context: PreconditionContext
 ) {
   return {
@@ -233,7 +233,7 @@ function preconditionSubclass<
 >(
   accountUpdate: AccountUpdate,
   longKey: K,
-  fieldType: Provable<U>,
+  fieldType: Provable<U, any>,
   context: PreconditionContext
 ) {
   if (fieldType === undefined) {
@@ -295,7 +295,7 @@ function preconditionSubclass<
 function getVariable<K extends LongKey, U extends FlatPreconditionValue[K]>(
   accountUpdate: AccountUpdate,
   longKey: K,
-  fieldType: Provable<U>
+  fieldType: Provable<U, any>
 ): U {
   return Provable.witness(fieldType, () => {
     let [accountOrNetwork, ...rest] = longKey.split('.');

--- a/src/lib/proof_system.ts
+++ b/src/lib/proof_system.ts
@@ -70,12 +70,12 @@ export {
 };
 
 type Undefined = undefined;
-const Undefined: ProvablePureExtended<undefined, null> =
+const Undefined: ProvablePureExtended<undefined, undefined, null> =
   EmptyUndefined<Field>();
 type Empty = Undefined;
 const Empty = Undefined;
 type Void = undefined;
-const Void: ProvablePureExtended<void, null> = EmptyVoid<Field>();
+const Void: ProvablePureExtended<void, void, null> = EmptyVoid<Field>();
 
 class Proof<Input, Output> {
   static publicInputType: FlexibleProvablePure<any> = undefined as any;
@@ -298,8 +298,8 @@ function ZkProgram<
   >;
 } {
   let methods = config.methods;
-  let publicInputType: ProvablePure<any> = config.publicInput ?? Undefined;
-  let publicOutputType: ProvablePure<any> = config.publicOutput ?? Void;
+  let publicInputType: ProvablePure<any, any> = config.publicInput ?? Undefined;
+  let publicOutputType: ProvablePure<any, any> = config.publicOutput ?? Void;
 
   let selfTag = { name: config.name };
   type PublicInput = InferProvableOrUndefined<
@@ -491,7 +491,7 @@ function sortMethodArguments(
   privateInputs: unknown[],
   selfProof: Subclass<typeof Proof>
 ): MethodInterface {
-  let witnessArgs: Provable<unknown>[] = [];
+  let witnessArgs: Provable<unknown, any>[] = [];
   let proofArgs: Subclass<typeof Proof>[] = [];
   let allArgs: { type: 'proof' | 'witness' | 'generic'; index: number }[] = [];
   let genericArgs: Subclass<typeof GenericArgument>[] = [];
@@ -541,7 +541,7 @@ function sortMethodArguments(
 
 function isAsFields(
   type: unknown
-): type is Provable<unknown> & ObjectConstructor {
+): type is Provable<unknown, any> & ObjectConstructor {
   return (
     (typeof type === 'function' || typeof type === 'object') &&
     type !== null &&
@@ -592,11 +592,11 @@ type MethodInterface = {
   methodName: string;
   // TODO: unify types of arguments
   // "circuit types" should be flexible enough to encompass proofs and callback arguments
-  witnessArgs: Provable<unknown>[];
+  witnessArgs: Provable<unknown, any>[];
   proofArgs: Subclass<typeof Proof>[];
   genericArgs: Subclass<typeof GenericArgument>[];
   allArgs: { type: 'witness' | 'proof' | 'generic'; index: number }[];
-  returnType?: Provable<any>;
+  returnType?: Provable<any, any>;
 };
 
 // reasonable default choice for `overrideWrapDomain`
@@ -613,8 +613,8 @@ async function compileProgram({
   forceRecompile,
   overrideWrapDomain,
 }: {
-  publicInputType: ProvablePure<any>;
-  publicOutputType: ProvablePure<any>;
+  publicInputType: ProvablePure<any, any>;
+  publicOutputType: ProvablePure<any, any>;
   methodIntfs: MethodInterface[];
   methods: ((...args: any) => void)[];
   gates: Gate[][];
@@ -713,7 +713,7 @@ async function compileProgram({
 }
 
 function analyzeMethod<T>(
-  publicInputType: ProvablePure<any>,
+  publicInputType: ProvablePure<any, any>,
   methodIntf: MethodInterface,
   method: (...args: any) => T
 ) {
@@ -727,8 +727,8 @@ function analyzeMethod<T>(
 }
 
 function picklesRuleFromFunction(
-  publicInputType: ProvablePure<unknown>,
-  publicOutputType: ProvablePure<unknown>,
+  publicInputType: ProvablePure<unknown, any>,
+  publicOutputType: ProvablePure<unknown, any>,
   func: (...args: unknown[]) => any,
   proofSystemTag: { name: string },
   { methodName, witnessArgs, proofArgs, allArgs }: MethodInterface,
@@ -867,7 +867,7 @@ function methodArgumentsToConstant(
 
 let Generic = EmptyNull<Field>();
 
-type TypeAndValue<T> = { type: Provable<T>; value: T };
+type TypeAndValue<T> = { type: Provable<T, any>; value: T };
 
 function methodArgumentTypesAndValues(
   { allArgs, proofArgs, witnessArgs }: MethodInterface,
@@ -895,7 +895,7 @@ function methodArgumentTypesAndValues(
 }
 
 function emptyValue<T>(type: FlexibleProvable<T>): T;
-function emptyValue<T>(type: Provable<T>) {
+function emptyValue<T>(type: Provable<T, any>) {
   return type.fromFields(
     Array(type.sizeInFields()).fill(Field(0)),
     type.toAuxiliary()
@@ -903,7 +903,7 @@ function emptyValue<T>(type: Provable<T>) {
 }
 
 function emptyWitness<T>(type: FlexibleProvable<T>): T;
-function emptyWitness<T>(type: Provable<T>) {
+function emptyWitness<T>(type: Provable<T, any>) {
   return Provable.witness(type, () => emptyValue(type));
 }
 
@@ -911,7 +911,7 @@ function getStatementType<
   T,
   O,
   P extends Subclass<typeof Proof> = typeof Proof
->(Proof: P): { input: ProvablePure<T>; output: ProvablePure<O> } {
+>(Proof: P): { input: ProvablePure<T, any>; output: ProvablePure<O, any> } {
   if (
     Proof.publicInputType === undefined ||
     Proof.publicOutputType === undefined
@@ -934,17 +934,20 @@ function getMaxProofsVerified(methodIntfs: MethodInterface[]) {
   ) as any as 0 | 1 | 2;
 }
 
-function fromFieldVars<T>(type: ProvablePure<T>, fields: MlFieldArray) {
+function fromFieldVars<T>(type: ProvablePure<T, any>, fields: MlFieldArray) {
   return type.fromFields(MlFieldArray.from(fields));
 }
-function toFieldVars<T>(type: ProvablePure<T>, value: T) {
+function toFieldVars<T>(type: ProvablePure<T, any>, value: T) {
   return MlFieldArray.to(type.toFields(value));
 }
 
-function fromFieldConsts<T>(type: ProvablePure<T>, fields: MlFieldConstArray) {
+function fromFieldConsts<T>(
+  type: ProvablePure<T, any>,
+  fields: MlFieldConstArray
+) {
   return type.fromFields(MlFieldConstArray.from(fields));
 }
-function toFieldConsts<T>(type: ProvablePure<T>, value: T) {
+function toFieldConsts<T>(type: ProvablePure<T, any>, value: T) {
   return MlFieldConstArray.to(type.toFields(value));
 }
 
@@ -1056,7 +1059,7 @@ type Subclass<Class extends new (...args: any) => any> = (new (
   [K in keyof Class]: Class[K];
 } & { prototype: InstanceType<Class> };
 
-type PrivateInput = Provable<any> | Subclass<typeof Proof>;
+type PrivateInput = Provable<any, any> | Subclass<typeof Proof>;
 
 type Method<
   PublicInput,

--- a/src/lib/scalar.ts
+++ b/src/lib/scalar.ts
@@ -285,6 +285,14 @@ class Scalar {
      */
   }
 
+  static toValue(x: Scalar) {
+    return x.toBigInt();
+  }
+
+  static fromValue(x: bigint) {
+    return Scalar.from(x);
+  }
+
   // ProvableExtended<Scalar>
 
   /**

--- a/src/lib/state.ts
+++ b/src/lib/state.ts
@@ -125,7 +125,7 @@ function state<A>(stateType: FlexibleProvablePure<A>) {
         if (this._?.[key]) throw Error('A @state should only be assigned once');
         v._contract = {
           key,
-          stateType: stateType as ProvablePure<A>,
+          stateType: stateType as ProvablePure<A, any>,
           instance: this,
           class: ZkappClass,
           wasConstrained: false,
@@ -185,7 +185,7 @@ function declareState<T extends typeof SmartContract>(
 // metadata defined by @state, which link state to a particular SmartContract
 type StateAttachedContract<A> = {
   key: string;
-  stateType: ProvablePure<A>;
+  stateType: ProvablePure<A, any>;
   instance: SmartContract;
   class: typeof SmartContract;
   wasRead: boolean;
@@ -399,7 +399,7 @@ function getLayout(scClass: typeof SmartContract) {
 const smartContracts = new WeakMap<
   typeof SmartContract,
   {
-    states: [string, ProvablePure<any>][];
+    states: [string, ProvablePure<any, any>][];
     layout: Map<string, { offset: number; length: number }> | undefined;
   }
 >();

--- a/src/lib/testing/constraint-system.ts
+++ b/src/lib/testing/constraint-system.ts
@@ -314,11 +314,11 @@ function toGatess(
 
 // Random generator for arbitrary provable types
 
-function provable<T>(spec: CsVarSpec<T>): Provable<T> {
+function provable<T>(spec: CsVarSpec<T>): Provable<T, any> {
   return 'provable' in spec ? spec.provable : spec;
 }
 
-function layout<T>(type: Provable<T>): Random<T> {
+function layout<T>(type: Provable<T, any>): Random<T> {
   let length = type.sizeInFields();
 
   return Random(() => {
@@ -327,7 +327,7 @@ function layout<T>(type: Provable<T>): Random<T> {
   });
 }
 
-function instantiate<T>(type: Provable<T>, value: T) {
+function instantiate<T>(type: Provable<T, any>, value: T) {
   let fields = type.toFields(value).map((x) => instantiateFieldVar(x.value));
   return type.fromFields(fields, type.toAuxiliary());
 }
@@ -385,16 +385,16 @@ function drawFieldType(): FieldType {
 
 // types
 
-type CsVarSpec<T> = Provable<T> | { provable: Provable<T> };
-type InferCsVar<T> = T extends { provable: Provable<infer U> }
+type CsVarSpec<T> = Provable<T, any> | { provable: Provable<T, any> };
+type InferCsVar<T> = T extends { provable: Provable<infer U, any> }
   ? U
-  : T extends Provable<infer U>
+  : T extends Provable<infer U, any>
   ? U
   : never;
 type CsParams<In extends Tuple<CsVarSpec<any>>> = {
   [k in keyof In]: InferCsVar<In[k]>;
 };
-type TypeAndValue<T> = { type: Provable<T>; value: T };
+type TypeAndValue<T> = { type: Provable<T, any>; value: T };
 
 // print a constraint system
 

--- a/src/lib/testing/equivalent.ts
+++ b/src/lib/testing/equivalent.ts
@@ -41,7 +41,7 @@ type FromSpec<In1, In2> = {
   // `provable` tells us how to create witnesses, to test provable code
   // note: we only allow the second function to be provable;
   // the second because it's more natural to have non-provable types as random generator output
-  provable?: Provable<In2>;
+  provable?: Provable<In2, any>;
 };
 
 type ToSpec<Out1, Out2> = {
@@ -54,7 +54,7 @@ type ToSpec<Out1, Out2> = {
 
 type Spec<T1, T2> = FromSpec<T1, T2> & ToSpec<T1, T2>;
 
-type ProvableSpec<T1, T2> = Spec<T1, T2> & { provable: Provable<T2> };
+type ProvableSpec<T1, T2> = Spec<T1, T2> & { provable: Provable<T2, any> };
 
 type FuncSpec<In1 extends Tuple<any>, Out1, In2 extends Tuple<any>, Out2> = {
   from: {

--- a/src/lib/zkapp.ts
+++ b/src/lib/zkapp.ts
@@ -96,12 +96,12 @@ function method<T extends SmartContract>(
       `@method decorator was applied to \`${methodName}\`, which is not a function.`
     );
   }
-  let paramTypes: Provable<any>[] = Reflect.getMetadata(
+  let paramTypes: Provable<any, any>[] = Reflect.getMetadata(
     'design:paramtypes',
     target,
     methodName
   );
-  let returnType: Provable<any> = Reflect.getMetadata(
+  let returnType: Provable<any, any> = Reflect.getMetadata(
     'design:returntype',
     target,
     methodName
@@ -539,7 +539,7 @@ function computeCallData(
 
 class Callback<Result> extends GenericArgument {
   instance: SmartContract;
-  methodIntf: MethodInterface & { returnType: Provable<Result> };
+  methodIntf: MethodInterface & { returnType: Provable<Result, any> };
   args: any[];
 
   result?: Result;
@@ -1060,7 +1060,7 @@ super.init();
     {
       type: string;
       event: {
-        data: ProvablePure<any>;
+        data: ProvablePure<any, any>;
         transactionInfo: {
           transactionHash: string;
           transactionStatus: string;
@@ -1276,7 +1276,7 @@ type ReducerReturn<Action> = {
    */
   reduce<State>(
     actions: Action[][],
-    stateType: Provable<State>,
+    stateType: Provable<State, any>,
     reduce: (state: State, action: Action) => State,
     initial: { state: State; actionState: Field },
     options?: {
@@ -1353,7 +1353,7 @@ class ${contract.constructor.name} extends SmartContract {
 
     reduce<S>(
       actionLists: A[][],
-      stateType: Provable<S>,
+      stateType: Provable<S, any>,
       reduce: (state: S, action: A) => S,
       { state, actionState }: { state: S; actionState: Field },
       {
@@ -1458,7 +1458,7 @@ Use the optional \`maxTransactionsWithActions\` argument to increase this number
         actionsForAccount = actions.map((event) =>
           // putting our string-Fields back into the original action type
           event.actions.map((action) =>
-            (reducer.actionType as ProvablePure<A>).fromFields(
+            (reducer.actionType as ProvablePure<A, any>).fromFields(
               action.map(Field)
             )
           )
@@ -1481,7 +1481,9 @@ Use the optional \`maxTransactionsWithActions\` argument to increase this number
       return result.map((event) =>
         // putting our string-Fields back into the original action type
         event.actions.map((action) =>
-          (reducer.actionType as ProvablePure<A>).fromFields(action.map(Field))
+          (reducer.actionType as ProvablePure<A, any>).fromFields(
+            action.map(Field)
+          )
         )
       );
     },
@@ -1545,7 +1547,7 @@ function Account(address: PublicKey, tokenId?: Field) {
  */
 function declareMethods<T extends typeof SmartContract>(
   SmartContract: T,
-  methodArguments: Record<string, Provable<unknown>[]>
+  methodArguments: Record<string, Provable<unknown, any>[]>
 ) {
   for (let key in methodArguments) {
     let argumentTypes = methodArguments[key];

--- a/src/snarky.d.ts
+++ b/src/snarky.d.ts
@@ -47,7 +47,7 @@ export {
  *
  * The properties and methods on the provable type exist in all base o1js types as well (aka. {@link Field}, {@link Bool}, etc.). In most cases, a zkApp developer does not need these functions to create zkApps.
  */
-declare interface Provable<T> {
+declare interface Provable<T, TValue> {
   /**
    * A function that takes `value`, an element of type `T`, as argument and returns an array of {@link Field} elements that make up the provable data of `value`.
    *
@@ -96,6 +96,16 @@ declare interface Provable<T> {
    * @param value - the element of type `T` to put assertions on.
    */
   check: (value: T) => void;
+
+  /**
+   * Convert provable type to a normal JS type.
+   */
+  toValue: (x: T) => TValue;
+
+  /**
+   * Convert provable type from a normal JS type.
+   */
+  fromValue: (x: TValue) => T;
 }
 
 /**
@@ -106,16 +116,7 @@ declare interface Provable<T> {
  *
  * It includes the same properties and methods as the {@link Provable} interface.
  */
-declare interface ProvablePure<T> extends Provable<T> {
-  /**
-   * A function that takes `value`, an element of type `T`, as argument and returns an array of {@link Field} elements that make up the provable data of `value`.
-   *
-   * @param value - the element of type `T` to generate the {@link Field} array from.
-   *
-   * @return A {@link Field} array describing how this `T` element is made up of {@link Field} elements.
-   */
-  toFields: (value: T) => Field[];
-
+declare interface ProvablePure<T, TValue> extends Provable<T, TValue> {
   /**
    * A function that takes `value` (optional), an element of type `T`, as argument and returns an array of any type that make up the "auxiliary" (non-provable) data of `value`.
    * As any element of the interface `ProvablePure<T>` includes no "auxiliary" data by definition, this function always returns a default value.
@@ -136,25 +137,6 @@ declare interface ProvablePure<T> extends Provable<T> {
    * @return An element of type `T` generated from the given provable data.
    */
   fromFields: (fields: Field[]) => T;
-
-  /**
-   * Return the size of the `T` type in terms of {@link Field} type, as {@link Field} is the primitive type.
-   *
-   * **Warning**: This function returns a `number`, so you cannot use it to prove something on chain. You can use it during debugging or to understand the memory complexity of some type.
-   *
-   * @return A `number` representing the size of the `T` type in terms of {@link Field} type.
-   */
-  sizeInFields(): number;
-
-  /**
-   * Add assertions to the proof to check if `value` is a valid member of type `T`.
-   * This function does not return anything, rather creates any number of assertions on the proof to prove `value` is a valid member of the type `T`.
-   *
-   * For instance, calling check function on the type {@link Bool} asserts that the value of the element is either 1 or 0.
-   *
-   * @param value - the element of type `T` to put assertions on.
-   */
-  check: (value: T) => void;
 }
 
 type MlGroup = MlPair<FieldVar, FieldVar>;


### PR DESCRIPTION
- add toValue impls in most places
- fixup events, scalar, group
- get compilation working
- bindings
- fix test compilation
- a non-trivial value type
