### PR TITLE
Fix struct after recent generic type changes

### DIFF
--- a/src/lib/circuit_value.ts
+++ b/src/lib/circuit_value.ts
@@ -384,6 +384,7 @@ function Struct<
     };
     toJSON: (x: T) => J;
     fromJSON: (x: J) => T;
+    empty: () => T;
   } {
   class Struct_ {
     static type = provable<A>(type);

--- a/src/lib/hash.ts
+++ b/src/lib/hash.ts
@@ -184,10 +184,6 @@ const TokenSymbolPure: ProvableExtended<
   },
 };
 class TokenSymbol extends Struct(TokenSymbolPure) {
-  static get empty() {
-    return { symbol: '', field: Field(0) };
-  }
-
   static from(symbol: string): TokenSymbol {
     let bytesLength = new TextEncoder().encode(symbol).length;
     if (bytesLength > 6)


### PR DESCRIPTION
this omission was causing some weird type errors for me when working on #1271, because struct wasn't implementing `ProvableExtended`