### PR TITLE
Add automated version bump workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,66 @@
+# Purpose:
+# Automatically bumps the project's patch version bi-weekly on Fridays.
+#
+# Details:
+# - Triggered at 00:00 UTC every Friday; runs on even weeks of the year.
+# - Sets up the environment by checking out the repo and setting up Node.js.
+# - Bumps patch version using `npm version patch`, then creates a new branch 'release/x.x.x'.
+# - Pushes changes and creates a PR to `main` using GitHub CLI.
+# - Can also be triggered manually via `workflow_dispatch`.
+name: Version Bump
+
+on:
+  workflow_dispatch: # Allow to manually trigger the workflow
+  schedule:
+    - cron: "0 0 * * 5" # At 00:00 UTC every Friday
+
+jobs:
+  version-bump:
+    runs-on: ubuntu-latest
+
+    steps:
+      # Since cronjob syntax doesn't support bi-weekly schedule, we need to check if it's an even week or not
+      - name: Check if it's an even week
+        id: check-week
+        run: |
+          WEEK_NUM=$(date +'%V')
+          if [ $((WEEK_NUM % 2)) -eq 0 ]; then
+            echo "RUN_JOB=true" >> $GITHUB_ENV
+          else
+            echo "RUN_JOB=false" >> $GITHUB_ENV
+          fi
+
+      - name: Check out the repository
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "18"
+
+      - name: Configure Git
+        run: |
+          git config --local user.email "action@github.com"
+          git config --local user.name "GitHub Action"
+
+      - name: Bump patch version
+        id: version-bump
+        if: ${{ env.RUN_JOB }} == 'true'
+        run: |
+          git fetch --prune --unshallow
+          NEW_VERSION=$(npm version patch)
+          echo "New version: $NEW_VERSION"
+          echo "NEW_VERSION=$NEW_VERSION" >> $GITHUB_ENV
+
+      - name: Install npm dependencies
+        run: npm install
+
+      - name: Create new release branch
+        run: |
+          NEW_BRANCH="release/${NEW_VERSION}"
+          git checkout -b $NEW_BRANCH
+          git push -u origin $NEW_BRANCH
+          git push --tags
+          gh pr create --base main --head $NEW_BRANCH --title "Release $NEW_VERSION" --body "This is an automated PR to update to version $NEW_VERSION"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN}}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,7 +21,6 @@ jobs:
     steps:
       # Since cronjob syntax doesn't support bi-weekly schedule, we need to check if it's an even week or not
       - name: Check if it's an even week
-        id: check-week
         run: |
           WEEK_NUM=$(date +'%V')
           if [ $((WEEK_NUM % 2)) -eq 0 ]; then
@@ -44,7 +43,6 @@ jobs:
           git config --local user.name "GitHub Action"
 
       - name: Bump patch version
-        id: version-bump
         if: ${{ env.RUN_JOB }} == 'true'
         run: |
           git fetch --prune --unshallow


### PR DESCRIPTION
This PR introduces a new GitHub Actions workflow that automatically bumps the project's patch version bi-weekly on Fridays. 

The workflow also creates a new branch and a PR to `main` for the new version. This automation will help in maintaining a regular release cycle and reduce manual effort.

**Note:** This PR only bumps the patch version by default and does not make any edits to the CHANGELOG. Those edits can be made in this Github Action, but was left out since I wasn't sure if we wanted to include that or just let the human reviewer make those changes manually. Should this be changed?