### PR TITLE
Range check 8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,10 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased](https://github.com/o1-labs/o1js/compare/1ad7333e9e...HEAD)
 
+### Added
+
+- `Gadgets.rangeCheck8()` to assert that a value fits in 8 bits https://github.com/o1-labs/o1js/pull/1288
+
 ### Changed
 
 - Change precondition APIs to use "require" instead of "assert" as the verb, to distinguish them from provable assertions.

--- a/src/lib/gadgets/gadgets.ts
+++ b/src/lib/gadgets/gadgets.ts
@@ -44,7 +44,7 @@ const Gadgets = {
   /**
    * Asserts that the input value is in the range [0, 2^8).
    *
-   * See {@link Gadgets.rangeCheck8} for analogous details and usage examples.
+   * See {@link Gadgets.rangeCheck64} for analogous details and usage examples.
    */
   rangeCheck8(x: Field) {
     return rangeCheck8(x);

--- a/src/lib/gadgets/gadgets.ts
+++ b/src/lib/gadgets/gadgets.ts
@@ -5,6 +5,7 @@ import {
   compactMultiRangeCheck,
   multiRangeCheck,
   rangeCheck64,
+  rangeCheck8,
 } from './range-check.js';
 import { not, rotate, xor, and, leftShift, rightShift } from './bitwise.js';
 import { Field } from '../core.js';
@@ -39,6 +40,16 @@ const Gadgets = {
   rangeCheck64(x: Field) {
     return rangeCheck64(x);
   },
+
+  /**
+   * Asserts that the input value is in the range [0, 2^8).
+   *
+   * See {@link Gadgets.rangeCheck8} for analogous details and usage examples.
+   */
+  rangeCheck8(x: Field) {
+    return rangeCheck8(x);
+  },
+
   /**
    * A (left and right) rotation operates similarly to the shift operation (`<<` for left and `>>` for right) in JavaScript,
    * with the distinction that the bits are circulated to the opposite end of a 64-bit representation rather than being discarded.

--- a/src/lib/gadgets/range-check.ts
+++ b/src/lib/gadgets/range-check.ts
@@ -1,8 +1,8 @@
 import { Field } from '../field.js';
 import { Gates } from '../gates.js';
-import { bitSlice, exists, toVar, toVars } from './common.js';
+import { assert, bitSlice, exists, toVar, toVars } from './common.js';
 
-export { rangeCheck64, multiRangeCheck, compactMultiRangeCheck };
+export { rangeCheck64, rangeCheck8, multiRangeCheck, compactMultiRangeCheck };
 export { l, l2, l3, lMask, l2Mask };
 
 /**
@@ -206,4 +206,20 @@ function rangeCheck1Helper(inputs: {
     [z86, z74, z62, z50, z38, z36, z34, z32, z30, z28, z26, z24, z22],
     [z20, z18, z16, x76, x64, y76, y64, z14, z12, z10, z8, z6, z4, z2, z0]
   );
+}
+
+function rangeCheck8(x: Field) {
+  if (x.isConstant()) {
+    assert(
+      x.toBigInt() < 1n << 8n,
+      `rangeCheck8: expected field to fit in 8 bits, got ${x}`
+    );
+    return;
+  }
+
+  // check that x fits in 16 bits
+  x.rangeCheckHelper(16).assertEquals(x);
+  // check that 2^8 x fits in 16 bits
+  let x256 = x.mul(1 << 8).seal();
+  x256.rangeCheckHelper(16).assertEquals(x256);
 }


### PR DESCRIPTION
adds a `rangeCheck8` gadget that just uses `rangeCheckHelper` (`EndoMulScalar`) twice, to unblock https://github.com/o1-labs/o1js/pull/1284