### PR TITLE
Implement Keccak sponge

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21,6 +21,7 @@
         "snarky-run": "src/build/run.js"
       },
       "devDependencies": {
+        "@noble/hashes": "^1.3.2",
         "@playwright/test": "^1.25.2",
         "@types/isomorphic-fetch": "^0.0.36",
         "@types/jest": "^27.0.0",
@@ -1484,6 +1485,18 @@
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.0.3",
         "@jridgewell/sourcemap-codec": "^1.4.10"
+      }
+    },
+    "node_modules/@noble/hashes": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.3.2.tgz",
+      "integrity": "sha512-MVC8EAQp7MvEcm30KWENFjgR+Mkmf+D189XJTkFIlwohU5hcBbn1ZkKq7KVTi2Hme3PMGF390DaL52beVrIihQ==",
+      "dev": true,
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
       }
     },
     "node_modules/@nodelib/fs.scandir": {

--- a/package.json
+++ b/package.json
@@ -72,6 +72,7 @@
   },
   "author": "O(1) Labs",
   "devDependencies": {
+    "@noble/hashes": "^1.3.2",
     "@playwright/test": "^1.25.2",
     "@types/isomorphic-fetch": "^0.0.36",
     "@types/jest": "^27.0.0",

--- a/src/lib/keccak.ts
+++ b/src/lib/keccak.ts
@@ -9,7 +9,7 @@ export { Keccak };
 const Keccak = {
   /** TODO */
   nistSha3(
-    len: number,
+    len: 224 | 256 | 384 | 512,
     message: Field[],
     inpEndian: 'Big' | 'Little' = 'Big',
     outEndian: 'Big' | 'Little' = 'Big',
@@ -28,7 +28,7 @@ const Keccak = {
   },
   /** TODO */
   preNist(
-    len: number,
+    len: 224 | 256 | 384 | 512,
     message: Field[],
     inpEndian: 'Big' | 'Little' = 'Big',
     outEndian: 'Big' | 'Little' = 'Big',
@@ -547,24 +547,13 @@ function hash(
 // Gadget for NIST SHA-3 function for output lengths 224/256/384/512.
 // Input and output endianness can be specified. Default is big endian.
 function nistSha3(
-  len: number,
+  len: 224 | 256 | 384 | 512,
   message: Field[],
   inpEndian: 'Big' | 'Little' = 'Big',
   outEndian: 'Big' | 'Little' = 'Big',
   byteChecks: boolean = false
 ): Field[] {
-  switch (len) {
-    case 224:
-      return hash(inpEndian, outEndian, byteChecks, message, 224, 448, true);
-    case 256:
-      return hash(inpEndian, outEndian, byteChecks, message, 256, 512, true);
-    case 384:
-      return hash(inpEndian, outEndian, byteChecks, message, 384, 768, true);
-    case 512:
-      return hash(inpEndian, outEndian, byteChecks, message, 512, 1024, true);
-    default:
-      throw new Error('Invalid length');
-  }
+  return hash(inpEndian, outEndian, byteChecks, message, len, 2 * len, true);
 }
 
 // Gadget for Keccak hash function for the parameters used in Ethereum.
@@ -582,22 +571,11 @@ function ethereum(
 // Input and output endianness can be specified. Default is big endian.
 // Note that when calling with output length 256 this is equivalent to the ethereum function
 function preNist(
-  len: number,
+  len: 224 | 256 | 384 | 512,
   message: Field[],
   inpEndian: 'Big' | 'Little' = 'Big',
   outEndian: 'Big' | 'Little' = 'Big',
   byteChecks: boolean = false
 ): Field[] {
-  switch (len) {
-    case 224:
-      return hash(inpEndian, outEndian, byteChecks, message, 224, 448, false);
-    case 256:
-      return ethereum(message, inpEndian, outEndian, byteChecks);
-    case 384:
-      return hash(inpEndian, outEndian, byteChecks, message, 384, 768, false);
-    case 512:
-      return hash(inpEndian, outEndian, byteChecks, message, 512, 1024, false);
-    default:
-      throw new Error('Invalid length');
-  }
+  return hash(inpEndian, outEndian, byteChecks, message, len, 2 * len, false);
 }

--- a/src/lib/keccak.ts
+++ b/src/lib/keccak.ts
@@ -415,18 +415,6 @@ function squeeze(
   rate: number,
   rc: bigint[]
 ): Field[] {
-  // Copies a section of bytes in the bytestring into the output array
-  const copy = (
-    bytestring: Field[],
-    outputArray: Field[],
-    start: number,
-    length: number
-  ) => {
-    for (let idx = 0; idx < length; idx++) {
-      outputArray[start + idx] = bytestring[idx];
-    }
-  };
-
   let newState = state;
 
   // bytes per squeeze
@@ -440,7 +428,8 @@ function squeeze(
   // first state to be squeezed
   const bytestring = keccakStateToBytes(state);
   const outputBytes = bytestring.slice(0, bytesPerSqueeze);
-  copy(outputBytes, outputArray, 0, bytesPerSqueeze);
+  // copies a section of bytes in the bytestring into the output array
+  outputArray.splice(0, bytesPerSqueeze, ...outputBytes);
 
   // for the rest of squeezes
   for (let i = 1; i < squeezes; i++) {
@@ -449,7 +438,8 @@ function squeeze(
     // append the output of the permutation function to the output
     const bytestringI = keccakStateToBytes(state);
     const outputBytesI = bytestringI.slice(0, bytesPerSqueeze);
-    copy(outputBytesI, outputArray, bytesPerSqueeze * i, bytesPerSqueeze);
+    // copies a section of bytes in the bytestring into the output array
+    outputArray.splice(bytesPerSqueeze * i, bytesPerSqueeze, ...outputBytesI);
   }
 
   // Obtain the hash selecting the first bitlength/8 bytes of the output array

--- a/src/lib/keccak.ts
+++ b/src/lib/keccak.ts
@@ -2,7 +2,6 @@ import { Field } from './field.js';
 import { Gadgets } from './gadgets/gadgets.js';
 import { assert } from './errors.js';
 import { existsOne, exists } from './gadgets/common.js';
-import { TupleN } from './util/types.js';
 import { rangeCheck8 } from './gadgets/range-check.js';
 
 export { Keccak };
@@ -359,17 +358,17 @@ function chi(state: Field[][]): Field[][] {
 
 // Fifth step of the permutation function of Keccak for 64-bit words.
 // It takes the word located at the position (0,0) of the state and XORs it with the round constant.
-function iota(state: Field[][], rc: Field): Field[][] {
+function iota(state: Field[][], rc: bigint): Field[][] {
   const stateG = state;
 
-  stateG[0][0] = Gadgets.xor(stateG[0][0], rc, KECCAK_WORD);
+  stateG[0][0] = Gadgets.xor(stateG[0][0], Field.from(rc), KECCAK_WORD);
 
   return stateG;
 }
 
 // One round of the Keccak permutation function.
 // iota o chi o pi o rho o theta
-function round(state: Field[][], rc: Field): Field[][] {
+function round(state: Field[][], rc: bigint): Field[][] {
   const stateA = state;
   const stateE = theta(stateA);
   const stateB = piRho(stateE);
@@ -379,7 +378,7 @@ function round(state: Field[][], rc: Field): Field[][] {
 }
 
 // Keccak permutation function with a constant number of rounds
-function permutation(state: Field[][], rc: Field[]): Field[][] {
+function permutation(state: Field[][], rc: bigint[]): Field[][] {
   return rc.reduce((acc, value) => round(acc, value), state);
 }
 
@@ -390,7 +389,7 @@ function absorb(
   paddedMessage: Field[],
   capacity: number,
   rate: number,
-  rc: Field[]
+  rc: bigint[]
 ): Field[][] {
   let state = getKeccakStateZeros();
 
@@ -423,7 +422,7 @@ function squeeze(
   state: Field[][],
   length: number,
   rate: number,
-  rc: Field[]
+  rc: bigint[]
 ): Field[] {
   // Copies a section of bytes in the bytestring into the output array
   const copy = (
@@ -480,8 +479,8 @@ function sponge(
     throw new Error('Invalid padded message length');
   }
 
-  // load round constants into Fields
-  const rc = exists(24, () => TupleN.fromArray(24, ROUND_CONSTANTS));
+  // load round constants
+  const rc = ROUND_CONSTANTS;
 
   // absorb
   const state = absorb(paddedMessage, capacity, rate, rc);

--- a/src/lib/keccak.ts
+++ b/src/lib/keccak.ts
@@ -1,5 +1,11 @@
 import { Field } from './field.js';
 import { Gadgets } from './gadgets/gadgets.js';
+import { assert } from './errors.js';
+import { existsOne, exists } from './gadgets/common.js';
+import { TupleN } from './util/types.js';
+import { rangeCheck8 } from './gadgets/range-check.js';
+
+export { preNist, nistSha3, ethereum };
 
 // KECCAK CONSTANTS
 
@@ -64,13 +70,152 @@ const ROUND_CONSTANTS = [
   0x8000000000008080n,
   0x0000000080000001n,
   0x8000000080008008n,
-].map(Field.from);
+];
+
+function checkBytesToWord(word: Field, wordBytes: Field[]): void {
+  let composition = wordBytes.reduce((acc, x, i) => {
+    const shift = Field.from(2n ** BigInt(8 * i));
+    return acc.add(x.mul(shift));
+  }, Field.from(0));
+
+  word.assertEquals(composition);
+}
 
 // Return a keccak state where all lanes are equal to 0
 const getKeccakStateZeros = (): Field[][] =>
   Array.from(Array(KECCAK_DIM), (_) => Array(KECCAK_DIM).fill(Field.from(0)));
 
+// Converts a list of bytes to a matrix of Field elements
+function getKeccakStateOfBytes(bytestring: Field[]): Field[][] {
+  assert(bytestring.length === 200, 'improper bytestring length');
+
+  const bytestringArray = Array.from(bytestring);
+  const state: Field[][] = getKeccakStateZeros();
+
+  for (let y = 0; y < KECCAK_DIM; y++) {
+    for (let x = 0; x < KECCAK_DIM; x++) {
+      const idx = BYTES_PER_WORD * (KECCAK_DIM * y + x);
+      // Create an array containing the 8 bytes starting on idx that correspond to the word in [x,y]
+      const wordBytes = bytestringArray.slice(idx, idx + BYTES_PER_WORD);
+
+      for (let z = 0; z < BYTES_PER_WORD; z++) {
+        // Field element containing value 2^(8*z)
+        const shift = Field.from(2n ** BigInt(8 * z));
+        state[x][y] = state[x][y].add(shift.mul(wordBytes[z]));
+      }
+    }
+  }
+
+  return state;
+}
+
+// Converts a state of cvars to a list of bytes as cvars and creates constraints for it
+function keccakStateToBytes(state: Field[][]): Field[] {
+  const stateLengthInBytes = KECCAK_STATE_LENGTH / 8;
+  const bytestring: Field[] = Array.from(
+    { length: stateLengthInBytes },
+    (_, idx) =>
+      existsOne(() => {
+        // idx = z + 8 * ((dim * y) + x)
+        const z = idx % BYTES_PER_WORD;
+        const x = Math.floor(idx / BYTES_PER_WORD) % KECCAK_DIM;
+        const y = Math.floor(idx / BYTES_PER_WORD / KECCAK_DIM);
+        // [7 6 5 4 3 2 1 0] [x=0,y=1] [x=0,y=2] [x=0,y=3] [x=0,y=4]
+        //        [x=1,y=0] [x=1,y=1] [x=1,y=2] [x=1,y=3] [x=1,y=4]
+        //        [x=2,y=0] [x=2,y=1] [x=2,y=2] [x=2,y=3] [x=2,y=4]
+        //        [x=3,y=0] [x=3,y=1] [x=3,y=2] [x=3,y=3] [x=3,y=4]
+        //        [x=4,y=0] [x=4,y=1] [x=4,y=0] [x=4,y=3] [x=4,y=4]
+        const word = state[x][y].toBigInt();
+        const byte = (word >> BigInt(8 * z)) & BigInt('0xff');
+        return byte;
+      })
+  );
+
+  // Check all words are composed correctly from bytes
+  for (let y = 0; y < KECCAK_DIM; y++) {
+    for (let x = 0; x < KECCAK_DIM; x++) {
+      const idx = BYTES_PER_WORD * (KECCAK_DIM * y + x);
+      // Create an array containing the 8 bytes starting on idx that correspond to the word in [x,y]
+      const word_bytes = bytestring.slice(idx, idx + BYTES_PER_WORD);
+      // Assert correct decomposition of bytes from state
+      checkBytesToWord(state[x][y], word_bytes);
+    }
+  }
+
+  return bytestring;
+}
+
+function keccakStateXor(a: Field[][], b: Field[][]): Field[][] {
+  assert(
+    a.length === KECCAK_DIM && a[0].length === KECCAK_DIM,
+    'Invalid input1 dimensions'
+  );
+  assert(
+    b.length === KECCAK_DIM && b[0].length === KECCAK_DIM,
+    'Invalid input2 dimensions'
+  );
+
+  return a.map((row, rowIndex) =>
+    row.map((element, columnIndex) =>
+      Gadgets.xor(element, b[rowIndex][columnIndex], 64)
+    )
+  );
+}
+
 // KECCAK HASH FUNCTION
+
+// Computes the number of required extra bytes to pad a message of length bytes
+function bytesToPad(rate: number, length: number): number {
+  return Math.floor(rate / 8) - (length % Math.floor(rate / 8));
+}
+
+// Pads a message M as:
+// M || pad[x](|M|)
+// Padding rule 0x06 ..0*..1.
+// The padded message vector will start with the message vector
+// followed by the 0*1 rule to fulfill a length that is a multiple of rate (in bytes)
+// (This means a 0110 sequence, followed with as many 0s as needed, and a final 1 bit)
+function padNist(message: Field[], rate: number): Field[] {
+  // Find out desired length of the padding in bytes
+  // If message is already rate bits, need to pad full rate again
+  const extraBytes = bytesToPad(rate, message.length);
+
+  // 0x06 0x00 ... 0x00 0x80 or 0x86
+  const lastField = BigInt(2) ** BigInt(7);
+  const last = Field.from(lastField);
+
+  // Create the padding vector
+  const pad = Array(extraBytes).fill(Field.from(0));
+  pad[0] = Field.from(6);
+  pad[extraBytes - 1] = pad[extraBytes - 1].add(last);
+
+  // Return the padded message
+  return [...message, ...pad];
+}
+
+// Pads a message M as:
+// M || pad[x](|M|)
+// Padding rule 10*1.
+// The padded message vector will start with the message vector
+// followed by the 10*1 rule to fulfill a length that is a multiple of rate (in bytes)
+// (This means a 1 bit, followed with as many 0s as needed, and a final 1 bit)
+function pad101(message: Field[], rate: number): Field[] {
+  // Find out desired length of the padding in bytes
+  // If message is already rate bits, need to pad full rate again
+  const extraBytes = bytesToPad(rate, message.length);
+
+  // 0x01 0x00 ... 0x00 0x80 or 0x81
+  const lastField = BigInt(2) ** BigInt(7);
+  const last = Field.from(lastField);
+
+  // Create the padding vector
+  const pad = Array(extraBytes).fill(Field.from(0));
+  pad[0] = Field.from(1);
+  pad[extraBytes - 1] = pad[extraBytes - 1].add(last);
+
+  // Return the padded message
+  return [...message, ...pad];
+}
 
 // ROUND TRANSFORMATION
 
@@ -209,18 +354,230 @@ function permutation(state: Field[][], rc: Field[]): Field[][] {
   );
 }
 
-// TESTING
+// Absorb padded message into a keccak state with given rate and capacity
+function absorb(
+  paddedMessage: Field[],
+  capacity: number,
+  rate: number,
+  rc: Field[]
+): Field[][] {
+  let state = getKeccakStateZeros();
 
-const blockTransformation = (state: Field[][]): Field[][] =>
-  permutation(state, ROUND_CONSTANTS);
+  // split into blocks of rate bits
+  // for each block of rate bits in the padded message -> this is rate/8 bytes
+  const chunks = [];
+  // (capacity / 8) zero bytes
+  const zeros = Array(capacity / 8).fill(Field.from(0));
 
-export {
-  KECCAK_DIM,
-  ROUND_CONSTANTS,
-  theta,
-  piRho,
-  chi,
-  iota,
-  round,
-  blockTransformation,
-};
+  for (let i = 0; i < paddedMessage.length; i += rate / 8) {
+    const block = paddedMessage.slice(i, i + rate / 8);
+    // pad the block with 0s to up to 1600 bits
+    const paddedBlock = block.concat(zeros);
+    // padded with zeros each block until they are 1600 bit long
+    assert(
+      paddedBlock.length * 8 === KECCAK_STATE_LENGTH,
+      'improper Keccak block length'
+    );
+    const blockState = getKeccakStateOfBytes(paddedBlock);
+    // xor the state with the padded block
+    const stateXor = keccakStateXor(state, blockState);
+    // apply the permutation function to the xored state
+    const statePerm = permutation(stateXor, rc);
+    state = statePerm;
+  }
+
+  return state;
+}
+
+// Squeeze state until it has a desired length in bits
+function squeeze(
+  state: Field[][],
+  length: number,
+  rate: number,
+  rc: Field[]
+): Field[] {
+  const copy = (
+    bytestring: Field[],
+    outputArray: Field[],
+    start: number,
+    length: number
+  ) => {
+    for (let i = 0; i < length; i++) {
+      outputArray[start + i] = bytestring[i];
+    }
+  };
+
+  let newState = state;
+
+  // bytes per squeeze
+  const bytesPerSqueeze = rate / 8;
+  // number of squeezes
+  const squeezes = Math.floor(length / rate) + 1;
+  // multiple of rate that is larger than output_length, in bytes
+  const outputLength = squeezes * bytesPerSqueeze;
+  // array with sufficient space to store the output
+  const outputArray = Array(outputLength).fill(Field.from(0));
+  // first state to be squeezed
+  const bytestring = keccakStateToBytes(state);
+  const outputBytes = bytestring.slice(0, bytesPerSqueeze);
+  copy(outputBytes, outputArray, 0, bytesPerSqueeze);
+  // for the rest of squeezes
+  for (let i = 1; i < squeezes; i++) {
+    // apply the permutation function to the state
+    newState = permutation(newState, rc);
+    // append the output of the permutation function to the output
+    const bytestringI = keccakStateToBytes(state);
+    const outputBytesI = bytestringI.slice(0, bytesPerSqueeze);
+    copy(outputBytesI, outputArray, bytesPerSqueeze * i, bytesPerSqueeze);
+  }
+  // Obtain the hash selecting the first bitlength/8 bytes of the output array
+  const hashed = outputArray.slice(0, length / 8);
+
+  return hashed;
+}
+
+// Keccak sponge function for 1600 bits of state width
+// Need to split the message into blocks of 1088 bits.
+function sponge(
+  paddedMessage: Field[],
+  length: number,
+  capacity: number,
+  rate: number
+): Field[] {
+  // check that the padded message is a multiple of rate
+  if ((paddedMessage.length * 8) % rate !== 0) {
+    throw new Error('Invalid padded message length');
+  }
+
+  // setup cvars for round constants
+  let rc = exists(24, () => TupleN.fromArray(24, ROUND_CONSTANTS));
+
+  // absorb
+  const state = absorb(paddedMessage, capacity, rate, rc);
+
+  // squeeze
+  const hashed = squeeze(state, length, rate, rc);
+
+  return hashed;
+}
+
+// TODO(jackryanservia): Use lookup argument once issue is resolved
+// Checks in the circuit that a list of cvars are at most 8 bits each
+function checkBytes(inputs: Field[]): void {
+  inputs.map(rangeCheck8);
+}
+
+// Keccak hash function with input message passed as list of Cvar bytes.
+// The message will be parsed as follows:
+// - the first byte of the message will be the least significant byte of the first word of the state (A[0][0])
+// - the 10*1 pad will take place after the message, until reaching the bit length rate.
+// - then, {0} pad will take place to finish the 1600 bits of the state.
+function hash(
+  inpEndian: 'Big' | 'Little' = 'Big',
+  outEndian: 'Big' | 'Little' = 'Big',
+  byteChecks: boolean = false,
+  message: Field[] = [],
+  length: number,
+  capacity: number,
+  nistVersion: boolean
+): Field[] {
+  assert(capacity > 0, 'capacity must be positive');
+  assert(capacity < KECCAK_STATE_LENGTH, 'capacity must be less than 1600');
+  assert(length > 0, 'length must be positive');
+  assert(length % 8 === 0, 'length must be a multiple of 8');
+
+  // Set input to Big Endian format
+  let messageFormatted = inpEndian === 'Big' ? message : message.reverse();
+
+  // Check each cvar input is 8 bits at most if it was not done before at creation time
+  if (byteChecks) {
+    checkBytes(messageFormatted);
+  }
+
+  const rate = KECCAK_STATE_LENGTH - capacity;
+
+  let padded;
+  if (nistVersion) {
+    padded = padNist(messageFormatted, rate);
+  } else {
+    padded = pad101(messageFormatted, rate);
+  }
+
+  const hash = sponge(padded, length, capacity, rate);
+
+  // Check each cvar output is 8 bits at most. Always because they are created here
+  checkBytes(hash);
+
+  // Set input to desired endianness
+  const hashFormatted = outEndian === 'Big' ? hash : hash.reverse();
+
+  // Check each cvar output is 8 bits at most
+  return hashFormatted;
+}
+
+// Gadget for NIST SHA-3 function for output lengths 224/256/384/512.
+// Input and output endianness can be specified. Default is big endian.
+// Note that when calling with output length 256 this is equivalent to the ethereum function
+function nistSha3(
+  len: number,
+  message: Field[],
+  inpEndian: 'Big' | 'Little' = 'Big',
+  outEndian: 'Big' | 'Little' = 'Big',
+  byteChecks: boolean = false
+): Field[] {
+  let output: Field[];
+
+  switch (len) {
+    case 224:
+      output = hash(inpEndian, outEndian, byteChecks, message, 224, 448, true);
+      break;
+    case 256:
+      output = hash(inpEndian, outEndian, byteChecks, message, 256, 512, true);
+      break;
+    case 384:
+      output = hash(inpEndian, outEndian, byteChecks, message, 384, 768, true);
+      break;
+    case 512:
+      output = hash(inpEndian, outEndian, byteChecks, message, 512, 1024, true);
+      break;
+    default:
+      throw new Error('Invalid length');
+  }
+
+  return output;
+}
+
+// Gadget for Keccak hash function for the parameters used in Ethereum.
+// Input and output endianness can be specified. Default is big endian.
+function ethereum(
+  inpEndian: 'Big' | 'Little' = 'Big',
+  outEndian: 'Big' | 'Little' = 'Big',
+  byteChecks: boolean = false,
+  message: Field[] = []
+): Field[] {
+  return hash(inpEndian, outEndian, byteChecks, message, 256, 512, false);
+}
+
+// Gadget for pre-NIST SHA-3 function for output lengths 224/256/384/512.
+// Input and output endianness can be specified. Default is big endian.
+// Note that when calling with output length 256 this is equivalent to the ethereum function
+function preNist(
+  len: number,
+  message: Field[],
+  inpEndian: 'Big' | 'Little' = 'Big',
+  outEndian: 'Big' | 'Little' = 'Big',
+  byteChecks: boolean = false
+): Field[] {
+  switch (len) {
+    case 224:
+      return hash(inpEndian, outEndian, byteChecks, message, 224, 448, false);
+    case 256:
+      return ethereum(inpEndian, outEndian, byteChecks, message);
+    case 384:
+      return hash(inpEndian, outEndian, byteChecks, message, 384, 768, false);
+    case 512:
+      return hash(inpEndian, outEndian, byteChecks, message, 512, 1024, false);
+    default:
+      throw new Error('Invalid length');
+  }
+}

--- a/src/lib/keccak.ts
+++ b/src/lib/keccak.ts
@@ -395,16 +395,10 @@ function absorb(
 }
 
 // Squeeze state until it has a desired length in bits
-function squeeze(
-  state: Field[][],
-  length: number,
-  rate: number,
-  rc: bigint[]
-): Field[] {
-  let newState = state;
-
+function squeeze(state: Field[][], length: number, rate: number): Field[] {
   // number of squeezes
   const squeezes = Math.floor(length / rate) + 1;
+  assert(squeezes === 1, 'squeezes should be 1');
   // multiple of rate that is larger than output_length, in bytes
   const outputLength = squeezes * rate;
   // array with sufficient space to store the output
@@ -414,17 +408,6 @@ function squeeze(
   const outputBytes = bytestring.slice(0, rate);
   // copies a section of bytes in the bytestring into the output array
   outputArray.splice(0, rate, ...outputBytes);
-
-  // for the rest of squeezes
-  for (let i = 1; i < squeezes; i++) {
-    // apply the permutation function to the state
-    newState = permutation(newState, rc);
-    // append the output of the permutation function to the output
-    const bytestringI = keccakStateToBytes(state);
-    const outputBytesI = bytestringI.slice(0, rate);
-    // copies a section of bytes in the bytestring into the output array
-    outputArray.splice(rate * i, rate, ...outputBytesI);
-  }
 
   // Obtain the hash selecting the first bitlength bytes of the output array
   const hashed = outputArray.slice(0, length);
@@ -450,7 +433,7 @@ function sponge(
   const state = absorb(paddedMessage, capacity, rate, rc);
 
   // squeeze
-  const hashed = squeeze(state, length, rate, rc);
+  const hashed = squeeze(state, length, rate);
 
   return hashed;
 }

--- a/src/lib/keccak.unit-test.ts
+++ b/src/lib/keccak.unit-test.ts
@@ -7,12 +7,15 @@ import { Random } from './testing/random.js';
 import { array, equivalentAsync, fieldWithRng } from './testing/equivalent.js';
 import { constraintSystem, contains } from './testing/constraint-system.js';
 
+// TODO(jackryanservia): Add test to assert fail for byte that's larger than 255
+// TODO(jackryanservia): Add random length with three runs
+
 const PREIMAGE_LENGTH = 75;
 const RUNS = 1;
 
-let uint = (length: number) => fieldWithRng(Random.biguint(length));
+const uint = (length: number) => fieldWithRng(Random.biguint(length));
 
-let Keccak256 = ZkProgram({
+const Keccak256 = ZkProgram({
   name: 'keccak256',
   publicInput: Provable.Array(Field, PREIMAGE_LENGTH),
   publicOutput: Provable.Array(Field, 32),
@@ -43,12 +46,12 @@ await equivalentAsync(
   { runs: RUNS }
 )(
   (x) => {
-    let uint8Array = new Uint8Array(x.map(Number));
-    let result = keccak_256(uint8Array);
+    const uint8Array = new Uint8Array(x.map(Number));
+    const result = keccak_256(uint8Array);
     return Array.from(result).map(BigInt);
   },
   async (x) => {
-    let proof = await Keccak256.ethereum(x);
+    const proof = await Keccak256.ethereum(x);
     return proof.publicOutput;
   }
 );
@@ -61,17 +64,17 @@ await equivalentAsync(
   { runs: RUNS }
 )(
   (x) => {
-    let thing = x.map(Number);
-    let result = sha3_256(new Uint8Array(thing));
+    const thing = x.map(Number);
+    const result = sha3_256(new Uint8Array(thing));
     return Array.from(result).map(BigInt);
   },
   async (x) => {
-    let proof = await Keccak256.nistSha3(x);
+    const proof = await Keccak256.nistSha3(x);
     return proof.publicOutput;
   }
 );
 
-// let Keccak512 = ZkProgram({
+// const Keccak512 = ZkProgram({
 //   name: 'keccak512',
 //   publicInput: Provable.Array(Field, PREIMAGE_LENGTH),
 //   publicOutput: Provable.Array(Field, 64),
@@ -101,12 +104,12 @@ await equivalentAsync(
 //   { runs: RUNS }
 // )(
 //   (x) => {
-//     let uint8Array = new Uint8Array(x.map(Number));
-//     let result = keccak_512(uint8Array);
+//     const uint8Array = new Uint8Array(x.map(Number));
+//     const result = keccak_512(uint8Array);
 //     return Array.from(result).map(BigInt);
 //   },
 //   async (x) => {
-//     let proof = await Keccak512.preNist(x);
+//     const proof = await Keccak512.preNist(x);
 //     return proof.publicOutput;
 //   }
 // );
@@ -119,12 +122,12 @@ await equivalentAsync(
 //   { runs: RUNS }
 // )(
 //   (x) => {
-//     let thing = x.map(Number);
-//     let result = sha3_512(new Uint8Array(thing));
+//     const thing = x.map(Number);
+//     const result = sha3_512(new Uint8Array(thing));
 //     return Array.from(result).map(BigInt);
 //   },
 //   async (x) => {
-//     let proof = await Keccak512.nistSha3(x);
+//     const proof = await Keccak512.nistSha3(x);
 //     return proof.publicOutput;
 //   }
 // );

--- a/src/lib/keccak.unit-test.ts
+++ b/src/lib/keccak.unit-test.ts
@@ -1,106 +1,63 @@
 import { Field } from './field.js';
 import { Provable } from './provable.js';
+import { preNist, nistSha3, ethereum } from './keccak.js';
+import { sha3_256, keccak_256 } from '@noble/hashes/sha3';
 import { ZkProgram } from './proof_system.js';
-import { constraintSystem, print } from './testing/constraint-system.js';
-import {
-  KECCAK_DIM,
-  ROUND_CONSTANTS,
-  theta,
-  piRho,
-  chi,
-  iota,
-  round,
-  blockTransformation,
-} from './keccak.js';
 
-const KECCAK_TEST_STATE = [
-  [0, 0, 0, 0, 0],
-  [0, 0, 1, 0, 0],
-  [1, 0, 0, 0, 0],
-  [0, 0, 0, 1, 0],
-  [0, 1, 0, 0, 0],
-].map((row) => row.map((elem) => Field.from(elem)));
 
-let KeccakBlockTransformation = ZkProgram({
-  name: 'KeccakBlockTransformation',
-  publicInput: Provable.Array(Provable.Array(Field, KECCAK_DIM), KECCAK_DIM),
-  publicOutput: Provable.Array(Provable.Array(Field, KECCAK_DIM), KECCAK_DIM),
-
+let Keccak = ZkProgram({
+  name: 'keccak',
+  publicInput: Provable.Array(Field, 100),
+  publicOutput: Provable.Array(Field, 32),
   methods: {
-    Theta: {
+    preNist: {
       privateInputs: [],
-      method(input: Field[][]) {
-        return theta(input);
+      method(preImage) {
+        return preNist(256, preImage);
       },
     },
-    PiRho: {
+    nistSha3: {
       privateInputs: [],
-      method(input: Field[][]) {
-        return piRho(input);
+      method(preImage) {
+        return nistSha3(256, preImage);
       },
     },
-    Chi: {
+    ethereum: {
       privateInputs: [],
-      method(input: Field[][]) {
-        return chi(input);
-      },
-    },
-    Iota: {
-      privateInputs: [],
-      method(input: Field[][]) {
-        return iota(input, ROUND_CONSTANTS[0]);
-      },
-    },
-    Round: {
-      privateInputs: [],
-      method(input: Field[][]) {
-        return round(input, ROUND_CONSTANTS[0]);
-      },
-    },
-    BlockTransformation: {
-      privateInputs: [],
-      method(input: Field[][]) {
-        return blockTransformation(input);
+      method(preImage) {
+        return ethereum(preImage);
       },
     },
   },
 });
 
-// constraintSystem.fromZkProgram(
-//   KeccakBlockTransformation,
-//   'BlockTransformation',
-//   print
-// );
+console.log("compiling keccak");
+await Keccak.compile();
+console.log("done compiling keccak");
 
-console.log('KECCAK_TEST_STATE: ', KECCAK_TEST_STATE.toString());
+const runs = 2;
 
-console.log('Compiling...');
-await KeccakBlockTransformation.compile();
-console.log('Done!');
-console.log('Generating proof...');
-let proof0 = await KeccakBlockTransformation.BlockTransformation(
-  KECCAK_TEST_STATE
-);
-console.log('Done!');
-console.log('Output:', proof0.publicOutput.toString());
-console.log('Verifying...');
-proof0.verify();
-console.log('Done!');
+let preImage = [
+  236, 185, 24, 61, 138, 249, 61, 13, 226, 103, 152, 232, 104, 234, 170, 26,
+  46, 54, 157, 146, 17, 240, 10, 193, 214, 110, 134, 47, 97, 241, 172, 198,
+  80, 95, 136, 185, 62, 156, 246, 210, 207, 129, 93, 162, 215, 77, 3, 38,
+  194, 86, 75, 100, 64, 87, 6, 18, 4, 159, 235, 53, 87, 124, 216, 241, 179,
+  201, 111, 168, 72, 181, 28, 65, 142, 243, 224, 69, 58, 178, 114, 3, 112,
+  23, 15, 208, 103, 231, 114, 64, 89, 172, 240, 81, 27, 215, 129, 3, 16,
+  173, 133, 160,
+]
 
-/*
-[RUST IMPLEMENTATION OUTPUT](https://github.com/BaldyAsh/keccak-rust)
+let preNistProof = await Keccak.preNist(preImage.map(Field.from));
+console.log(preNistProof.publicOutput.toString());
+console.log(keccak_256(new Uint8Array(preImage)));
+let nistSha3Proof = await Keccak.nistSha3(preImage.map(Field.from));
+console.log(nistSha3Proof.publicOutput.toString());
+console.log(sha3_256(new Uint8Array(preImage)));
+let ethereumProof = await Keccak.ethereum(preImage.map(Field.from));
+console.log(ethereumProof.publicOutput.toString());
 
-INPUT:
-[[0, 0, 0, 0, 0],
- [0, 0, 1, 0, 0],
- [1, 0, 0, 0, 0],
- [0, 0, 0, 1, 0],
- [0, 1, 0, 0, 0]]
-
-OUTPUT:
-[[8771753707458093707, 14139250443469741764, 11827767624278131459, 2757454755833177578, 5758014717183214102],
-[3389583698920935946, 1287099063347104936, 15030403046357116816, 17185756281681305858, 9708367831595350450],
-[1416127551095004411, 16037937966823201128, 9518790688640222300, 1997971396112921437, 4893561083608951508],
-[8048617297177300085, 10306645194383020789, 2789881727527423094, 7603160281577405588, 12935834807086847890],
-[9476112750389234330, 13193683191463706918, 4460519148532423021, 7183125267124224670, 1393214916959060614]]
-*/
+console.log('verifying');
+preNistProof.verify();
+nistSha3Proof.verify();
+ethereumProof.verify();
+console.log('done verifying');

--- a/src/lib/keccak.unit-test.ts
+++ b/src/lib/keccak.unit-test.ts
@@ -42,14 +42,17 @@ const digestLength = [224, 256, 384, 512][Math.floor(Math.random() * 4)] as
   | 384
   | 512;
 
+// Digest length in bytes
+const digestLengthBytes = digestLength / 8;
+
 // Chose a random preimage length
-const preImageLength = digestLength / Math.floor(Math.random() * 4 + 2);
+const preImageLength = Math.floor(digestLength / (Math.random() * 4 + 2));
 
 // No need to test Ethereum because it's just a special case of preNist
 const KeccakProgram = ZkProgram({
   name: 'keccak-test',
   publicInput: Provable.Array(Field, preImageLength),
-  publicOutput: Provable.Array(Field, digestLength / 8),
+  publicOutput: Provable.Array(Field, digestLengthBytes),
   methods: {
     nistSha3: {
       privateInputs: [],
@@ -72,7 +75,7 @@ await KeccakProgram.compile();
 await equivalentAsync(
   {
     from: [array(uint(8), preImageLength)],
-    to: array(uint(8), digestLength / 8),
+    to: array(uint(8), digestLengthBytes),
   },
   { runs: RUNS }
 )(
@@ -92,7 +95,7 @@ await equivalentAsync(
 await equivalentAsync(
   {
     from: [array(uint(8), preImageLength)],
-    to: array(uint(8), digestLength / 8),
+    to: array(uint(8), digestLengthBytes),
   },
   { runs: RUNS }
 )(

--- a/src/lib/keccak.unit-test.ts
+++ b/src/lib/keccak.unit-test.ts
@@ -1,139 +1,117 @@
 import { Field } from './field.js';
 import { Provable } from './provable.js';
 import { Keccak } from './keccak.js';
-import { keccak_256, sha3_256, keccak_512, sha3_512 } from '@noble/hashes/sha3';
 import { ZkProgram } from './proof_system.js';
 import { Random } from './testing/random.js';
 import { array, equivalentAsync, fieldWithRng } from './testing/equivalent.js';
 import { constraintSystem, contains } from './testing/constraint-system.js';
+import {
+  keccak_224,
+  keccak_256,
+  keccak_384,
+  keccak_512,
+  sha3_224,
+  sha3_256,
+  sha3_384,
+  sha3_512,
+} from '@noble/hashes/sha3';
 
-// TODO(jackryanservia): Add test to assert fail for byte that's larger than 255
-// TODO(jackryanservia): Add random length with three runs
-
-const PREIMAGE_LENGTH = 75;
 const RUNS = 1;
+
+const testImplementations = {
+  sha3: {
+    224: sha3_224,
+    256: sha3_256,
+    384: sha3_384,
+    512: sha3_512,
+  },
+  preNist: {
+    224: keccak_224,
+    256: keccak_256,
+    384: keccak_384,
+    512: keccak_512,
+  },
+};
 
 const uint = (length: number) => fieldWithRng(Random.biguint(length));
 
-const Keccak256 = ZkProgram({
-  name: 'keccak256',
-  publicInput: Provable.Array(Field, PREIMAGE_LENGTH),
-  publicOutput: Provable.Array(Field, 32),
+// Choose a test length at random
+const digestLength = [224, 256, 384, 512][Math.floor(Math.random() * 4)] as
+  | 224
+  | 256
+  | 384
+  | 512;
+
+// Chose a random preimage length
+const preImageLength = digestLength / Math.floor(Math.random() * 4 + 2);
+
+// No need to test Ethereum because it's just a special case of preNist
+const KeccakProgram = ZkProgram({
+  name: 'keccak-test',
+  publicInput: Provable.Array(Field, preImageLength),
+  publicOutput: Provable.Array(Field, digestLength / 8),
   methods: {
-    ethereum: {
-      privateInputs: [],
-      method(preImage) {
-        return Keccak.ethereum(preImage);
-      },
-    },
-    // No need for preNist Keccak_256 because it's identical to ethereum
     nistSha3: {
       privateInputs: [],
       method(preImage) {
-        return Keccak.nistSha3(256, preImage);
+        return Keccak.nistSha3(digestLength, preImage);
+      },
+    },
+    preNist: {
+      privateInputs: [],
+      method(preImage) {
+        return Keccak.preNist(digestLength, preImage);
       },
     },
   },
 });
 
-await Keccak256.compile();
+await KeccakProgram.compile();
 
+// SHA-3
 await equivalentAsync(
   {
-    from: [array(uint(8), PREIMAGE_LENGTH)],
-    to: array(uint(8), 32),
+    from: [array(uint(8), preImageLength)],
+    to: array(uint(8), digestLength / 8),
   },
   { runs: RUNS }
 )(
   (x) => {
-    const uint8Array = new Uint8Array(x.map(Number));
-    const result = keccak_256(uint8Array);
+    const byteArray = new Uint8Array(x.map(Number));
+    const result = testImplementations.sha3[digestLength](byteArray);
     return Array.from(result).map(BigInt);
   },
   async (x) => {
-    const proof = await Keccak256.ethereum(x);
+    const proof = await KeccakProgram.nistSha3(x);
+    await KeccakProgram.verify(proof);
     return proof.publicOutput;
   }
 );
 
+// PreNIST Keccak
 await equivalentAsync(
   {
-    from: [array(uint(8), PREIMAGE_LENGTH)],
-    to: array(uint(8), 32),
+    from: [array(uint(8), preImageLength)],
+    to: array(uint(8), digestLength / 8),
   },
   { runs: RUNS }
 )(
   (x) => {
-    const thing = x.map(Number);
-    const result = sha3_256(new Uint8Array(thing));
+    const byteArray = new Uint8Array(x.map(Number));
+    const result = testImplementations.preNist[digestLength](byteArray);
     return Array.from(result).map(BigInt);
   },
   async (x) => {
-    const proof = await Keccak256.nistSha3(x);
+    const proof = await KeccakProgram.preNist(x);
+    await KeccakProgram.verify(proof);
     return proof.publicOutput;
   }
 );
 
-// const Keccak512 = ZkProgram({
-//   name: 'keccak512',
-//   publicInput: Provable.Array(Field, PREIMAGE_LENGTH),
-//   publicOutput: Provable.Array(Field, 64),
-//   methods: {
-//     preNist: {
-//       privateInputs: [],
-//       method(preImage) {
-//         return Keccak.preNist(512, preImage, 'Big', 'Big', true);
-//       },
-//     },
-//     nistSha3: {
-//       privateInputs: [],
-//       method(preImage) {
-//         return Keccak.nistSha3(512, preImage, 'Big', 'Big', true);
-//       },
-//     },
-//   },
-// });
-
-// await Keccak512.compile();
-
-// await equivalentAsync(
-//   {
-//     from: [array(uint(8), PREIMAGE_LENGTH)],
-//     to: array(uint(8), 64),
-//   },
-//   { runs: RUNS }
-// )(
-//   (x) => {
-//     const uint8Array = new Uint8Array(x.map(Number));
-//     const result = keccak_512(uint8Array);
-//     return Array.from(result).map(BigInt);
-//   },
-//   async (x) => {
-//     const proof = await Keccak512.preNist(x);
-//     return proof.publicOutput;
-//   }
+// This takes a while and doesn't do much, so I commented it out
+// Constraint system sanity check
+// constraintSystem.fromZkProgram(
+//   KeccakTest,
+//   'preNist',
+//   contains([['Generic'], ['Xor16'], ['Zero'], ['Rot64'], ['RangeCheck0']])
 // );
-
-// await equivalentAsync(
-//   {
-//     from: [array(uint(8), PREIMAGE_LENGTH)],
-//     to: array(uint(8), 64),
-//   },
-//   { runs: RUNS }
-// )(
-//   (x) => {
-//     const thing = x.map(Number);
-//     const result = sha3_512(new Uint8Array(thing));
-//     return Array.from(result).map(BigInt);
-//   },
-//   async (x) => {
-//     const proof = await Keccak512.nistSha3(x);
-//     return proof.publicOutput;
-//   }
-// );
-
-constraintSystem.fromZkProgram(
-  Keccak256,
-  'ethereum',
-  contains([['Generic'], ['Xor16'], ['Zero'], ['Rot64'], ['RangeCheck0']])
-);


### PR DESCRIPTION
Implementation of the Keccak sponge and, preNist, ethereum, and SHA-3 hash functions.

This PR currently is using a workaround in `checkBytes` because lookup arguments are not working in pickles, but that will be updated as soon as a fix is available.