### PR TITLE
Add verification key hash to the return type of ZkProgram compile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ### Breaking changes
 
-- `ZkProgram.compile()` now returns the verification key and its hash, to be consistent with `SmartContract.compile()` https://github.com/o1-labs/o1js/pull/1240
+- `ZkProgram.compile()` now returns the verification key and its hash, to be consistent with `SmartContract.compile()` https://github.com/o1-labs/o1js/pull/1292 [@rpanic](https://github.com/rpanic)
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,10 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased](https://github.com/o1-labs/o1js/compare/1ad7333e9e...HEAD)
 
+### Breaking changes
+
+- `ZkProgram.compile()` now returns the verification key and its hash, to be consistent with `SmartContract.compile()` https://github.com/o1-labs/o1js/pull/1240
+
 ### Added
 
 - **Foreign field arithmetic** exposed through the `createForeignField()` class factory https://github.com/o1-labs/snarkyjs/pull/985

--- a/src/lib/proof_system.ts
+++ b/src/lib/proof_system.ts
@@ -263,7 +263,7 @@ function ZkProgram<
   compile: (options?: {
     cache?: Cache;
     forceRecompile?: boolean;
-  }) => Promise<{ verificationKey: string }>;
+  }) => Promise<{ verificationKey: { data: string, hash: Field } }>;
   verify: (
     proof: Proof<
       InferProvableOrUndefined<Get<StatementType, 'publicInput'>>,
@@ -361,7 +361,7 @@ function ZkProgram<
       overrideWrapDomain: config.overrideWrapDomain,
     });
     compileOutput = { provers, verify };
-    return { verificationKey: verificationKey.data };
+    return { verificationKey };
   }
 
   function toProver<K extends keyof Types & string>(

--- a/src/lib/proof_system.ts
+++ b/src/lib/proof_system.ts
@@ -260,10 +260,9 @@ function ZkProgram<
   }
 ): {
   name: string;
-  compile: (options?: {
-    cache?: Cache;
-    forceRecompile?: boolean;
-  }) => Promise<{ verificationKey: { data: string, hash: Field } }>;
+  compile: (options?: { cache?: Cache; forceRecompile?: boolean }) => Promise<{
+    verificationKey: { data: string; hash: Field } 
+  }>;
   verify: (
     proof: Proof<
       InferProvableOrUndefined<Get<StatementType, 'publicInput'>>,


### PR DESCRIPTION
Previously, ZkProgram and Smartcontract had different return types for `compile()`. This PR fixes this by adding in the hash to ZkProgram's function