### PR TITLE
Express Maj with 2 XORs instead of 5

### DIFF
--- a/src/lib/gadgets/arithmetic.ts
+++ b/src/lib/gadgets/arithmetic.ts
@@ -1,12 +1,13 @@
+import { Bool } from '../bool.js';
 import { provableTuple } from '../circuit_value.js';
 import { Field } from '../core.js';
 import { assert } from '../errors.js';
 import { Provable } from '../provable.js';
-import { rangeCheck32 } from './range-check.js';
+import { rangeCheck32, rangeCheckN } from './range-check.js';
 
 export { divMod32, addMod32 };
 
-function divMod32(n: Field) {
+function divMod32(n: Field, quotientBits = 32) {
   if (n.isConstant()) {
     assert(
       n.toBigInt() < 1n << 64n,
@@ -32,7 +33,11 @@ function divMod32(n: Field) {
     }
   );
 
-  rangeCheck32(quotient);
+  if (quotientBits === 1) {
+    Bool.check(Bool.Unsafe.ofField(quotient));
+  } else {
+    rangeCheckN(quotientBits, quotient);
+  }
   rangeCheck32(remainder);
 
   n.assertEquals(quotient.mul(1n << 32n).add(remainder));
@@ -44,5 +49,5 @@ function divMod32(n: Field) {
 }
 
 function addMod32(x: Field, y: Field) {
-  return divMod32(x.add(y)).remainder;
+  return divMod32(x.add(y), 1).remainder;
 }

--- a/src/lib/gadgets/common.ts
+++ b/src/lib/gadgets/common.ts
@@ -17,7 +17,6 @@ export {
   witnessSlice,
   witnessNextValue,
   divideWithRemainder,
-  toBigints,
 };
 
 function existsOne(compute: () => bigint) {
@@ -59,17 +58,6 @@ function toVars<T extends Tuple<Field | bigint>>(
   fields: T
 ): { [k in keyof T]: Field } {
   return Tuple.map(fields, toVar);
-}
-
-/**
- * Convert several Fields to bigints.
- */
-function toBigints<
-  T extends Tuple<{ toBigInt(): bigint } | { toBigint(): bigint }>
->(...fields: T) {
-  return Tuple.map(fields, (x) =>
-    'toBigInt' in x ? x.toBigInt() : x.toBigint()
-  );
 }
 
 function assert(stmt: boolean, message?: string): asserts stmt {

--- a/src/lib/gadgets/common.ts
+++ b/src/lib/gadgets/common.ts
@@ -17,6 +17,7 @@ export {
   witnessSlice,
   witnessNextValue,
   divideWithRemainder,
+  toBigints,
 };
 
 function existsOne(compute: () => bigint) {
@@ -58,6 +59,17 @@ function toVars<T extends Tuple<Field | bigint>>(
   fields: T
 ): { [k in keyof T]: Field } {
   return Tuple.map(fields, toVar);
+}
+
+/**
+ * Convert several Fields to bigints.
+ */
+function toBigints<
+  T extends Tuple<{ toBigInt(): bigint } | { toBigint(): bigint }>
+>(...fields: T) {
+  return Tuple.map(fields, (x) =>
+    'toBigInt' in x ? x.toBigInt() : x.toBigint()
+  );
 }
 
 function assert(stmt: boolean, message?: string): asserts stmt {

--- a/src/lib/gadgets/sha256.ts
+++ b/src/lib/gadgets/sha256.ts
@@ -138,7 +138,9 @@ const SHA256 = {
 function Ch(x: UInt32, y: UInt32, z: UInt32) {
   let xAndY = x.and(y);
   let xNotAndZ = x.not().and(z);
-  return xAndY.xor(xNotAndZ);
+  // because of the occurence of x and ~x, the bits of (x & y) and (~x & z) are disjoint
+  // therefore, we can use + instead of XOR which is faster in a circuit
+  return UInt32.from(xAndY.value.add(xNotAndZ.value).seal());
 }
 
 function Maj(x: UInt32, y: UInt32, z: UInt32) {

--- a/src/lib/gadgets/sha256.ts
+++ b/src/lib/gadgets/sha256.ts
@@ -2,7 +2,7 @@
 import { Field } from '../field.js';
 import { UInt32 } from '../int.js';
 import { TupleN } from '../util/types.js';
-import { bitSlice, exists, existsOne, toBigints } from './common.js';
+import { bitSlice, exists } from './common.js';
 import { Gadgets } from './gadgets.js';
 
 export { SHA256 };

--- a/src/lib/gadgets/sha256.ts
+++ b/src/lib/gadgets/sha256.ts
@@ -83,7 +83,7 @@ const SHA256 = {
           .value.add(W[t - 7].value)
           .add(DeltaZero(W[t - 15]).value.add(W[t - 16].value));
 
-        W[t] = UInt32.from(Gadgets.divMod32(unreduced).remainder);
+        W[t] = UInt32.from(Gadgets.divMod32(unreduced, 16).remainder);
       }
 
       // initialize working variables
@@ -109,12 +109,14 @@ const SHA256 = {
         h = g;
         g = f;
         f = e;
-        e = UInt32.from(Gadgets.divMod32(d.value.add(unreducedT1)).remainder);
+        e = UInt32.from(
+          Gadgets.divMod32(d.value.add(unreducedT1), 16).remainder
+        );
         d = c;
         c = b;
         b = a;
         a = UInt32.from(
-          Gadgets.divMod32(unreducedT2.add(unreducedT1)).remainder
+          Gadgets.divMod32(unreducedT2.add(unreducedT1), 16).remainder
         );
       }
 


### PR DESCRIPTION
constraints for 3 hashes: **18.8k** -> **15.8k**

speeds up `Maj` with the formula:
```
Maj(x, y, z) = (x & y) ^ (x & z) ^ (y & z) = 1/2 * (x + y + z - (x ^ y ^ z))
```
the first version is what we originally used, but needs 5 XORs, the second/new version only needs 2 XORs and also fewer generic gates.

also, speeds up `Ch` thanks to:
```
Ch(x, y, z) = (x & y) ^ (~x & z) = (x & y) + (~x & z)
```
the insight here was that we can use the second formula (`+` instead of XOR) because the terms have no overlapping 1 bits.

third speed-up comes from using faster range checks for the quotient in `divMod32` when used for addition mod 32. the existing 32 bit check (which uses 2.5 rows) is a good default because it supports all inputs up to 64 bits, for example resulting from 32x32 bit multiplication. But addition can only overflow by 1 bit, so we can use the boolean check which only uses 0.5 rows. For longer sums we can use the 16-bit check which uses 1 row.

in general, it seems reasonable to allow specifying the quotient bits as an extra argument in `divMod32`
