### PR TITLE
Reducer map example

### DIFF
--- a/src/examples/zkapps/reducer/map.ts
+++ b/src/examples/zkapps/reducer/map.ts
@@ -98,14 +98,12 @@ console.log(`method size for a "mapping" contract with ${k} entries`);
 console.log('get rows:', cs['get'].rows);
 console.log('set rows:', cs['set'].rows);
 
-// a test account that pays all the fees, and puts additional funds into the zkapp
+// a test account that pays all the fees
 let feePayerKey = Local.testAccounts[0].privateKey;
 let feePayer = Local.testAccounts[0].publicKey;
 
 // the zkapp account
-let zkappKey = PrivateKey.fromBase58(
-  'EKEQc95PPQZnMY9d9p1vq1MWLeDJKtvKj4V75UDG3rjnf32BerWD'
-);
+let zkappKey = PrivateKey.random();
 let zkappAddress = zkappKey.toPublicKey();
 let zkapp = new StorageContract(zkappAddress);
 
@@ -119,19 +117,20 @@ await tx.sign([feePayerKey, zkappKey]).send();
 
 console.log('deployed');
 
-let map: { key: PublicKey; value: Field }[] = [];
-map[0] = {
-  key: PrivateKey.random().toPublicKey(),
-  value: Field(192),
-};
-map[1] = {
-  key: PrivateKey.random().toPublicKey(),
-  value: Field(151),
-};
-map[2] = {
-  key: PrivateKey.random().toPublicKey(),
-  value: Field(781),
-};
+let map: { key: PublicKey; value: Field }[] = [
+  {
+    key: PrivateKey.random().toPublicKey(),
+    value: Field(192),
+  },
+  {
+    key: PrivateKey.random().toPublicKey(),
+    value: Field(151),
+  },
+  {
+    key: PrivateKey.random().toPublicKey(),
+    value: Field(781),
+  },
+];
 
 let key = map[0].key;
 let value = map[0].value;

--- a/src/examples/zkapps/reducer/map.ts
+++ b/src/examples/zkapps/reducer/map.ts
@@ -14,6 +14,27 @@ import {
   Provable,
 } from 'o1js';
 
+/*
+
+This contract emulates a "mapping" data structure, which is a key-value store, similar to a dictionary or hash table or `new Map<K, V>()` in JavaScript.
+In this example, the keys are public keys, and the values are arbitrary field elements.
+
+This utilizes the `Reducer` as an append online list of actions, which are then looked at to find the value corresponding to a specific key.
+
+
+```ts 
+// js
+const map = new Map<PublicKey, Field>();
+map.set(key, value);
+map.get(key);
+
+// contract
+zkApp.deploy(); // ... deploy the zkapp
+zkApp.set(key, value); // ... set a key-value pair
+zkApp.get(key); // ... get a value by key
+```
+*/
+
 class Option extends Struct({
   isSome: Bool,
   value: Field,

--- a/src/examples/zkapps/reducer/map.ts
+++ b/src/examples/zkapps/reducer/map.ts
@@ -64,17 +64,11 @@ class StorageContract extends SmartContract {
     let { state: optionValue } = this.reducer.reduce(
       pendingActions,
       Option,
-      (
-        _state: Option,
-        _action: {
-          key: Field;
-          value: Field;
-        }
-      ) => {
-        let currentMatch = keyHash.equals(_action.key);
+      (state, action) => {
+        let currentMatch = keyHash.equals(action.key);
         return {
-          isSome: currentMatch.or(_state.isSome),
-          value: Provable.if(currentMatch, _action.value, _state.value),
+          isSome: currentMatch.or(state.isSome),
+          value: Provable.if(currentMatch, action.value, state.value),
         };
       },
       {


### PR DESCRIPTION
This contract emulates a "mapping" data structure, which is a key-value store, similar to a dictionary or hash table or `new Map<K, V>()` in JavaScript.
In this example, the keys are public keys, and the values are arbitrary field elements.
This utilizes the `Reducer` as an append online list of actions, which are then looked at to find the value corresponding to a specific key.
