### PR TITLE
Add a little hint to README-dev.md

### DIFF
--- a/README-dev.md
+++ b/README-dev.md
@@ -2,6 +2,14 @@
 
 This README includes information that is helpful for o1js core contributors.
 
+## Setting up the repo on your local
+
+```sh
+git clone https://github.com/o1-labs/o1js.git
+cd o1js
+git submodule update --init --recursive
+```
+
 ## Run examples using Node.js
 
 ```sh

--- a/README-dev.md
+++ b/README-dev.md
@@ -4,6 +4,8 @@ This README includes information that is helpful for o1js core contributors.
 
 ## Setting up the repo on your local
 
+After cloning the repo, you must fetch external submodules for the following examples to work. 
+
 ```sh
 git clone https://github.com/o1-labs/o1js.git
 cd o1js


### PR DESCRIPTION
I always forget to pull external git modules when I work directly with o1js. Proposing to add a tiny section to README-dev.md to save others a little time when they first get started. 