### PR TITLE
Fix hash example

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,10 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased](https://github.com/o1-labs/o1js/compare/19115a159...HEAD)
 
+### Fixed
+
+- Fix bug in `Hash.hash()` which always resulted in an error https://github.com/o1-labs/o1js/pull/1346
+
 ## [0.15.1](https://github.com/o1-labs/o1js/compare/1ad7333e9e...19115a159)
 
 ### Breaking changes

--- a/src/examples/zkapps/hashing/hash.ts
+++ b/src/examples/zkapps/hashing/hash.ts
@@ -9,7 +9,8 @@ import {
   Bytes,
 } from 'o1js';
 
-let initialCommitment: Field = Field(0);
+let initialCommitment = Field(0);
+class Bytes32 extends Bytes(32) {}
 
 export class HashStorage extends SmartContract {
   @state(Field) commitment = State<Field>();
@@ -23,25 +24,25 @@ export class HashStorage extends SmartContract {
     this.commitment.set(initialCommitment);
   }
 
-  @method SHA256(xs: Bytes) {
+  @method SHA256(xs: Bytes32) {
     const shaHash = Hash.SHA3_256.hash(xs);
     const commitment = Hash.hash(shaHash.toFields());
     this.commitment.set(commitment);
   }
 
-  @method SHA384(xs: Bytes) {
+  @method SHA384(xs: Bytes32) {
     const shaHash = Hash.SHA3_384.hash(xs);
     const commitment = Hash.hash(shaHash.toFields());
     this.commitment.set(commitment);
   }
 
-  @method SHA512(xs: Bytes) {
+  @method SHA512(xs: Bytes32) {
     const shaHash = Hash.SHA3_512.hash(xs);
     const commitment = Hash.hash(shaHash.toFields());
     this.commitment.set(commitment);
   }
 
-  @method Keccak256(xs: Bytes) {
+  @method Keccak256(xs: Bytes32) {
     const shaHash = Hash.Keccak256.hash(xs);
     const commitment = Hash.hash(shaHash.toFields());
     this.commitment.set(commitment);

--- a/src/examples/zkapps/hashing/run.ts
+++ b/src/examples/zkapps/hashing/run.ts
@@ -9,7 +9,7 @@ Mina.setActiveInstance(Local);
 
 if (proofsEnabled) {
   console.log('Proofs enabled');
-  HashStorage.compile();
+  await HashStorage.compile();
 }
 
 // test accounts that pays all the fees, and puts additional funds into the zkapp
@@ -20,7 +20,7 @@ const zkAppPrivateKey = PrivateKey.random();
 const zkAppAddress = zkAppPrivateKey.toPublicKey();
 const zkAppInstance = new HashStorage(zkAppAddress);
 
-// 0, 1, 2, 3, ..., 32
+// 0, 1, 2, 3, ..., 31
 const hashData = Bytes.from(Array.from({ length: 32 }, (_, i) => i));
 
 console.log('Deploying Hash Example....');

--- a/src/lib/hash.ts
+++ b/src/lib/hash.ts
@@ -7,6 +7,7 @@ import { MlFieldArray } from './ml/fields.js';
 import { Poseidon as PoseidonBigint } from '../bindings/crypto/poseidon.js';
 import { assert } from './errors.js';
 import { rangeCheckN } from './gadgets/range-check.js';
+import { TupleN } from './util/types.js';
 
 // external API
 export { Poseidon, TokenSymbol };
@@ -45,13 +46,13 @@ const Poseidon = {
     if (isConstant(input)) {
       return Field(PoseidonBigint.hash(toBigints(input)));
     }
-    return Poseidon.update(this.initialState(), input)[0];
+    return Poseidon.update(Poseidon.initialState(), input)[0];
   },
 
   update(state: [Field, Field, Field], input: Field[]) {
     if (isConstant(state) && isConstant(input)) {
       let newState = PoseidonBigint.update(toBigints(state), toBigints(input));
-      return newState.map(Field);
+      return TupleN.fromArray(3, newState.map(Field));
     }
 
     let newState = Snarky.poseidon.update(


### PR DESCRIPTION
Bugs in the example were reported on discord. 
* improper use of `Bytes`
* `Hash.hash()` was throwing with `this.initialState is not a function`

Also fixes the type returned by `Poseidon.update()`.