### PR TITLE
Error feedback on compile-prover discrepancies

### DIFF
--- a/src/examples/simple_zkapp.ts
+++ b/src/examples/simple_zkapp.ts
@@ -91,6 +91,8 @@ if (doProofs) {
   console.time('compile');
   await SimpleZkapp.compile();
   console.timeEnd('compile');
+} else {
+  SimpleZkapp.analyzeMethods();
 }
 
 console.log('deploy');

--- a/src/examples/zkapps/dex/dex.ts
+++ b/src/examples/zkapps/dex/dex.ts
@@ -441,16 +441,16 @@ class TokenContract extends SmartContract {
     amount: UInt64
   ) {
     // TODO: THIS IS INSECURE. The proper version has a prover error (compile != prove) that must be fixed
-    this.approve(zkappUpdate, AccountUpdate.Layout.AnyChildren);
+    // this.approve(zkappUpdate, AccountUpdate.Layout.AnyChildren);
 
     // THIS IS HOW IT SHOULD BE DONE:
-    // // approve a layout of two grandchildren, both of which can't inherit the token permission
-    // let { StaticChildren, AnyChildren } = AccountUpdate.Layout;
-    // this.approve(zkappUpdate, StaticChildren(AnyChildren, AnyChildren));
-    // zkappUpdate.body.mayUseToken.parentsOwnToken.assertTrue();
-    // let [grandchild1, grandchild2] = zkappUpdate.children.accountUpdates;
-    // grandchild1.body.mayUseToken.inheritFromParent.assertFalse();
-    // grandchild2.body.mayUseToken.inheritFromParent.assertFalse();
+    // approve a layout of two grandchildren, both of which can't inherit the token permission
+    let { StaticChildren, AnyChildren } = AccountUpdate.Layout;
+    this.approve(zkappUpdate, StaticChildren(AnyChildren, AnyChildren));
+    zkappUpdate.body.mayUseToken.parentsOwnToken.assertTrue();
+    let [grandchild1, grandchild2] = zkappUpdate.children.accountUpdates;
+    grandchild1.body.mayUseToken.inheritFromParent.assertFalse();
+    grandchild2.body.mayUseToken.inheritFromParent.assertFalse();
 
     // see if balance change cancels the amount sent
     let balanceChange = Int64.fromObject(zkappUpdate.body.balanceChange);

--- a/src/examples/zkapps/dex/dex.ts
+++ b/src/examples/zkapps/dex/dex.ts
@@ -440,10 +440,6 @@ class TokenContract extends SmartContract {
     to: PublicKey,
     amount: UInt64
   ) {
-    // TODO: THIS IS INSECURE. The proper version has a prover error (compile != prove) that must be fixed
-    // this.approve(zkappUpdate, AccountUpdate.Layout.AnyChildren);
-
-    // THIS IS HOW IT SHOULD BE DONE:
     // approve a layout of two grandchildren, both of which can't inherit the token permission
     let { StaticChildren, AnyChildren } = AccountUpdate.Layout;
     this.approve(zkappUpdate, StaticChildren(AnyChildren, AnyChildren));

--- a/src/index.ts
+++ b/src/index.ts
@@ -48,9 +48,6 @@ export {
 } from './lib/zkapp.js';
 export { state, State, declareState } from './lib/state.js';
 
-// TODO expose this in a cleaner way
-export { runAsIfProver } from './lib/mina/zkapp-proof.js';
-
 export type { JsonProof } from './lib/proof_system.js';
 export {
   Proof,

--- a/src/index.ts
+++ b/src/index.ts
@@ -48,6 +48,9 @@ export {
 } from './lib/zkapp.js';
 export { state, State, declareState } from './lib/state.js';
 
+// TODO expose this in a cleaner way
+export { runAsIfProver } from './lib/mina/zkapp-proof.js';
+
 export type { JsonProof } from './lib/proof_system.js';
 export {
   Proof,

--- a/src/lib/account_update.ts
+++ b/src/lib/account_update.ts
@@ -47,7 +47,6 @@ export {
   FeePayerUnsigned,
   ZkappCommand,
   addMissingSignatures,
-  addMissingProofs,
   ZkappStateLength,
   Events,
   Actions,
@@ -57,8 +56,11 @@ export {
   createChildAccountUpdate,
   AccountUpdatesLayout,
   zkAppProver,
+  ZkappProverData,
   SmartContractContext,
   dummySignature,
+  LazySignature,
+  LazyProof,
 };
 
 const ZkappStateLength = 8;
@@ -1748,11 +1750,6 @@ type ZkappCommandSigned = {
   accountUpdates: (AccountUpdate & { lazyAuthorization?: LazyProof })[];
   memo: string;
 };
-type ZkappCommandProved = {
-  feePayer: FeePayerUnsigned;
-  accountUpdates: (AccountUpdate & { lazyAuthorization?: LazySignature })[];
-  memo: string;
-};
 
 const ZkappCommand = {
   toPretty(transaction: ZkappCommand) {
@@ -1976,127 +1973,3 @@ type ZkappPublicInput = {
   calls: Field;
 };
 let ZkappPublicInput = provablePure({ accountUpdate: Field, calls: Field });
-
-async function addMissingProofs(
-  zkappCommand: ZkappCommand,
-  { proofsEnabled = true }
-): Promise<{
-  zkappCommand: ZkappCommandProved;
-  proofs: (Proof<ZkappPublicInput, Empty> | undefined)[];
-}> {
-  let { feePayer, accountUpdates, memo } = zkappCommand;
-  // compute proofs serially. in parallel would clash with our global variable
-  // hacks
-  let accountUpdatesProved: AccountUpdateProved[] = [];
-  let proofs: (Proof<ZkappPublicInput, Empty> | undefined)[] = [];
-  for (let i = 0; i < accountUpdates.length; i++) {
-    let { accountUpdateProved, proof } = await addProof(
-      zkappCommand,
-      i,
-      proofsEnabled
-    );
-    accountUpdatesProved.push(accountUpdateProved);
-    proofs.push(proof);
-  }
-  return {
-    zkappCommand: { feePayer, accountUpdates: accountUpdatesProved, memo },
-    proofs,
-  };
-}
-
-async function addProof(
-  transaction: ZkappCommand,
-  index: number,
-  proofsEnabled: boolean
-) {
-  let accountUpdate = transaction.accountUpdates[index];
-  accountUpdate = AccountUpdate.clone(accountUpdate);
-
-  if (accountUpdate.lazyAuthorization?.kind !== 'lazy-proof') {
-    return {
-      accountUpdateProved: accountUpdate as AccountUpdateProved,
-      proof: undefined,
-    };
-  }
-  if (!proofsEnabled) {
-    Authorization.setProof(accountUpdate, await dummyBase64Proof());
-    return {
-      accountUpdateProved: accountUpdate as AccountUpdateProved,
-      proof: undefined,
-    };
-  }
-
-  let lazyProof: LazyProof = accountUpdate.lazyAuthorization;
-  let prover = getZkappProver(lazyProof);
-  let proverData = { transaction, accountUpdate, index };
-  let proof = await createZkappProof(prover, lazyProof, proverData);
-
-  let accountUpdateProved = Authorization.setProof(
-    accountUpdate,
-    Pickles.proofToBase64Transaction(proof.proof)
-  );
-  return { accountUpdateProved, proof };
-}
-
-async function createZkappProof(
-  prover: Pickles.Prover,
-  {
-    methodName,
-    args,
-    previousProofs,
-    ZkappClass,
-    memoized,
-    blindingValue,
-  }: LazyProof,
-  { transaction, accountUpdate, index }: ZkappProverData
-): Promise<Proof<ZkappPublicInput, Empty>> {
-  let publicInput = accountUpdate.toPublicInput();
-  let publicInputFields = MlFieldConstArray.to(
-    ZkappPublicInput.toFields(publicInput)
-  );
-
-  let [, , proof] = await zkAppProver.run(
-    [accountUpdate.publicKey, accountUpdate.tokenId, ...args],
-    { transaction, accountUpdate, index },
-    async () => {
-      let id = memoizationContext.enter({
-        memoized,
-        currentIndex: 0,
-        blindingValue,
-      });
-      try {
-        return await prover(publicInputFields, MlArray.to(previousProofs));
-      } catch (err) {
-        console.error(`Error when proving ${ZkappClass.name}.${methodName}()`);
-        throw err;
-      } finally {
-        memoizationContext.leave(id);
-      }
-    }
-  );
-
-  let maxProofsVerified = ZkappClass._maxProofsVerified!;
-  const Proof = ZkappClass.Proof();
-  return new Proof({
-    publicInput,
-    publicOutput: undefined,
-    proof,
-    maxProofsVerified,
-  });
-}
-
-function getZkappProver({ methodName, ZkappClass }: LazyProof) {
-  if (ZkappClass._provers === undefined)
-    throw Error(
-      `Cannot prove execution of ${methodName}(), no prover found. ` +
-        `Try calling \`await ${ZkappClass.name}.compile()\` first, this will cache provers in the background.`
-    );
-  let provers = ZkappClass._provers;
-  let methodError =
-    `Error when computing proofs: Method ${methodName} not found. ` +
-    `Make sure your environment supports decorators, and annotate with \`@method ${methodName}\`.`;
-  if (ZkappClass._methods === undefined) throw Error(methodError);
-  let i = ZkappClass._methods.findIndex((m) => m.methodName === methodName);
-  if (i === -1) throw Error(methodError);
-  return provers[i];
-}

--- a/src/lib/account_update.ts
+++ b/src/lib/account_update.ts
@@ -1347,6 +1347,7 @@ class AccountUpdate implements Types.AccountUpdate {
       accountUpdate.body.mayUseToken.inheritFromParent.assertFalse();
       return;
     }
+    accountUpdate.children.callsType = { type: 'None' };
     let childArray: AccountUpdatesLayout[] =
       typeof childLayout === 'number'
         ? Array(childLayout).fill(AccountUpdate.Layout.NoChildren)

--- a/src/lib/account_update.ts
+++ b/src/lib/account_update.ts
@@ -1096,11 +1096,37 @@ class AccountUpdate implements Types.AccountUpdate {
     return { accountUpdate, calls };
   }
 
+  toPrettyLayout() {
+    let indent = 0;
+    let layout = '';
+    let i = 0;
+
+    let print = (a: AccountUpdate) => {
+      layout +=
+        ' '.repeat(indent) +
+        `AccountUpdate(${i}, ${a.label || '<no label>'}, ${
+          a.children.callsType.type
+        })` +
+        '\n';
+      i++;
+      indent += 2;
+      for (let child of a.children.accountUpdates) {
+        print(child);
+      }
+      indent -= 2;
+    };
+
+    print(this);
+    return layout;
+  }
+
   static defaultAccountUpdate(address: PublicKey, tokenId?: Field) {
     return new AccountUpdate(Body.keepAll(address, tokenId));
   }
   static dummy() {
-    return new AccountUpdate(Body.dummy());
+    let dummy = new AccountUpdate(Body.dummy());
+    dummy.label = 'Dummy';
+    return dummy;
   }
   isDummy() {
     return this.body.publicKey.isEmpty();

--- a/src/lib/account_update.ts
+++ b/src/lib/account_update.ts
@@ -4,7 +4,7 @@ import {
   provable,
   provablePure,
 } from './circuit_value.js';
-import { memoizationContext, memoizeWitness, Provable } from './provable.js';
+import { memoizeWitness, Provable } from './provable.js';
 import { Field, Bool } from './core.js';
 import { Pickles, Test } from '../snarky.js';
 import { jsLayout } from '../bindings/mina-transaction/gen/js-layout.js';
@@ -18,7 +18,7 @@ import { UInt64, UInt32, Int64, Sign } from './int.js';
 import * as Mina from './mina.js';
 import { SmartContract } from './zkapp.js';
 import * as Precondition from './precondition.js';
-import { dummyBase64Proof, Empty, Proof, Prover } from './proof_system.js';
+import { Proof, Prover } from './proof_system.js';
 import { Memo } from '../mina-signer/src/memo.js';
 import {
   Events,
@@ -29,9 +29,7 @@ import { hashWithPrefix, packToFields } from './hash.js';
 import { mocks, prefixes } from '../bindings/crypto/constants.js';
 import { Context } from './global-context.js';
 import { assert } from './errors.js';
-import { MlArray } from './ml/base.js';
 import { Signature, signFieldElement } from '../mina-signer/src/signature.js';
-import { MlFieldConstArray } from './ml/fields.js';
 import { transactionCommitments } from '../mina-signer/src/sign-zkapp-command.js';
 
 // external API
@@ -98,8 +96,8 @@ type Preconditions = AccountUpdateBody['preconditions'];
  */
 type SetOrKeep<T> = { isSome: Bool; value: T };
 
-const True = () => Bool(true);
-const False = () => Bool(false);
+const True = Bool(true);
+const False = Bool(false);
 
 /**
  * One specific permission value.
@@ -116,45 +114,45 @@ let Permission = {
    * Modification is impossible.
    */
   impossible: (): Permission => ({
-    constant: True(),
-    signatureNecessary: True(),
-    signatureSufficient: False(),
+    constant: True,
+    signatureNecessary: True,
+    signatureSufficient: False,
   }),
 
   /**
    * Modification is always permitted
    */
   none: (): Permission => ({
-    constant: True(),
-    signatureNecessary: False(),
-    signatureSufficient: True(),
+    constant: True,
+    signatureNecessary: False,
+    signatureSufficient: True,
   }),
 
   /**
    * Modification is permitted by zkapp proofs only
    */
   proof: (): Permission => ({
-    constant: False(),
-    signatureNecessary: False(),
-    signatureSufficient: False(),
+    constant: False,
+    signatureNecessary: False,
+    signatureSufficient: False,
   }),
 
   /**
    * Modification is permitted by signatures only, using the private key of the zkapp account
    */
   signature: (): Permission => ({
-    constant: False(),
-    signatureNecessary: True(),
-    signatureSufficient: True(),
+    constant: False,
+    signatureNecessary: True,
+    signatureSufficient: True,
   }),
 
   /**
    * Modification is permitted by zkapp proofs or signatures
    */
   proofOrSignature: (): Permission => ({
-    constant: False(),
-    signatureNecessary: False(),
-    signatureSufficient: True(),
+    constant: False,
+    signatureNecessary: False,
+    signatureSufficient: True,
   }),
 };
 

--- a/src/lib/gates.ts
+++ b/src/lib/gates.ts
@@ -15,6 +15,8 @@ export {
   foreignFieldAdd,
   foreignFieldMul,
   KimchiGateType,
+  KimchiGateTypeString,
+  gateTypeToString,
 };
 
 const Gates = {
@@ -265,3 +267,31 @@ enum KimchiGateType {
   Xor16,
   Rot64,
 }
+
+function gateTypeToString(gate: KimchiGateType) {
+  return KimchiGateTypeToString[gate];
+}
+
+type KimchiGateTypeString =
+  (typeof KimchiGateTypeToString)[keyof typeof KimchiGateTypeToString];
+
+const KimchiGateTypeToString = {
+  [KimchiGateType.Zero]: 'Zero',
+  [KimchiGateType.Generic]: 'Generic',
+  [KimchiGateType.Poseidon]: 'Poseidon',
+  [KimchiGateType.CompleteAdd]: 'CompleteAdd',
+  [KimchiGateType.VarBaseMul]: 'VarBaseMul',
+  [KimchiGateType.EndoMul]: 'EndoMul',
+  [KimchiGateType.EndoMulScalar]: 'EndoMulScalar',
+  [KimchiGateType.Lookup]: 'Lookup',
+  [KimchiGateType.CairoClaim]: 'CairoClaim',
+  [KimchiGateType.CairoInstruction]: 'CairoInstruction',
+  [KimchiGateType.CairoFlags]: 'CairoFlags',
+  [KimchiGateType.CairoTransition]: 'CairoTransition',
+  [KimchiGateType.RangeCheck0]: 'RangeCheck0',
+  [KimchiGateType.RangeCheck1]: 'RangeCheck1',
+  [KimchiGateType.ForeignFieldAdd]: 'ForeignFieldAdd',
+  [KimchiGateType.ForeignFieldMul]: 'ForeignFieldMul',
+  [KimchiGateType.Xor16]: 'Xor16',
+  [KimchiGateType.Rot64]: 'Rot64',
+} as const;

--- a/src/lib/mina.ts
+++ b/src/lib/mina.ts
@@ -3,7 +3,6 @@ import { Field } from './core.js';
 import { UInt32, UInt64 } from './int.js';
 import { PrivateKey, PublicKey } from './signature.js';
 import {
-  addMissingProofs,
   addMissingSignatures,
   FeePayerUnsigned,
   ZkappCommand,
@@ -33,6 +32,7 @@ import {
   transactionCommitments,
   verifyAccountUpdateSignature,
 } from '../mina-signer/src/sign-zkapp-command.js';
+import { addMissingProofs } from './mina/zkapp-proof.js';
 
 export {
   createTransaction,

--- a/src/lib/mina/zkapp-proof.ts
+++ b/src/lib/mina/zkapp-proof.ts
@@ -1,0 +1,152 @@
+import { Pickles } from '../../snarky.js';
+import {
+  AccountUpdate,
+  Authorization,
+  FeePayerUnsigned,
+  LazyProof,
+  LazySignature,
+  ZkappCommand,
+  ZkappProverData,
+  ZkappPublicInput,
+  zkAppProver,
+} from '../account_update.js';
+import { MlArray } from '../ml/base.js';
+import { MlFieldConstArray } from '../ml/fields.js';
+import { Empty, Proof, dummyBase64Proof } from '../proof_system.js';
+import { memoizationContext } from '../provable.js';
+
+export { addMissingProofs };
+
+type AccountUpdateProved = AccountUpdate & {
+  lazyAuthorization?: LazySignature;
+};
+
+type ZkappCommandProved = {
+  feePayer: FeePayerUnsigned;
+  accountUpdates: AccountUpdateProved[];
+  memo: string;
+};
+
+async function addMissingProofs(
+  zkappCommand: ZkappCommand,
+  { proofsEnabled = true }
+): Promise<{
+  zkappCommand: ZkappCommandProved;
+  proofs: (Proof<ZkappPublicInput, Empty> | undefined)[];
+}> {
+  let { feePayer, accountUpdates, memo } = zkappCommand;
+  // compute proofs serially. in parallel would clash with our global variable
+  // hacks
+  let accountUpdatesProved: AccountUpdateProved[] = [];
+  let proofs: (Proof<ZkappPublicInput, Empty> | undefined)[] = [];
+  for (let i = 0; i < accountUpdates.length; i++) {
+    let { accountUpdateProved, proof } = await addProof(
+      zkappCommand,
+      i,
+      proofsEnabled
+    );
+    accountUpdatesProved.push(accountUpdateProved);
+    proofs.push(proof);
+  }
+  return {
+    zkappCommand: { feePayer, accountUpdates: accountUpdatesProved, memo },
+    proofs,
+  };
+}
+
+async function addProof(
+  transaction: ZkappCommand,
+  index: number,
+  proofsEnabled: boolean
+) {
+  let accountUpdate = transaction.accountUpdates[index];
+  accountUpdate = AccountUpdate.clone(accountUpdate);
+
+  if (accountUpdate.lazyAuthorization?.kind !== 'lazy-proof') {
+    return {
+      accountUpdateProved: accountUpdate as AccountUpdateProved,
+      proof: undefined,
+    };
+  }
+  if (!proofsEnabled) {
+    Authorization.setProof(accountUpdate, await dummyBase64Proof());
+    return {
+      accountUpdateProved: accountUpdate as AccountUpdateProved,
+      proof: undefined,
+    };
+  }
+
+  let lazyProof: LazyProof = accountUpdate.lazyAuthorization;
+  let prover = getZkappProver(lazyProof);
+  let proverData = { transaction, accountUpdate, index };
+  let proof = await createZkappProof(prover, lazyProof, proverData);
+
+  let accountUpdateProved = Authorization.setProof(
+    accountUpdate,
+    Pickles.proofToBase64Transaction(proof.proof)
+  );
+  return { accountUpdateProved, proof };
+}
+
+async function createZkappProof(
+  prover: Pickles.Prover,
+  {
+    methodName,
+    args,
+    previousProofs,
+    ZkappClass,
+    memoized,
+    blindingValue,
+  }: LazyProof,
+  { transaction, accountUpdate, index }: ZkappProverData
+): Promise<Proof<ZkappPublicInput, Empty>> {
+  let publicInput = accountUpdate.toPublicInput();
+  let publicInputFields = MlFieldConstArray.to(
+    ZkappPublicInput.toFields(publicInput)
+  );
+
+  let [, , proof] = await zkAppProver.run(
+    [accountUpdate.publicKey, accountUpdate.tokenId, ...args],
+    { transaction, accountUpdate, index },
+    async () => {
+      let id = memoizationContext.enter({
+        memoized,
+        currentIndex: 0,
+        blindingValue,
+      });
+      try {
+        return await prover(publicInputFields, MlArray.to(previousProofs));
+      } catch (err) {
+        console.error(`Error when proving ${ZkappClass.name}.${methodName}()`);
+        throw err;
+      } finally {
+        memoizationContext.leave(id);
+      }
+    }
+  );
+
+  let maxProofsVerified = ZkappClass._maxProofsVerified!;
+  const Proof = ZkappClass.Proof();
+  return new Proof({
+    publicInput,
+    publicOutput: undefined,
+    proof,
+    maxProofsVerified,
+  });
+}
+
+function getZkappProver({ methodName, ZkappClass }: LazyProof) {
+  if (ZkappClass._provers === undefined)
+    throw Error(
+      `Cannot prove execution of ${methodName}(), no prover found. ` +
+        `Try calling \`await ${ZkappClass.name}.compile()\` first, this will cache provers in the background.`
+    );
+  let provers = ZkappClass._provers;
+  let methodError =
+    `Error when computing proofs: Method ${methodName} not found. ` +
+    `Make sure your environment supports decorators, and annotate with \`@method ${methodName}\`.`;
+  if (ZkappClass._methods === undefined) throw Error(methodError);
+  let i = ZkappClass._methods.findIndex((m) => m.methodName === methodName);
+  if (i === -1) throw Error(methodError);
+  return provers[i];
+}

--- a/src/lib/mina/zkapp-proof.ts
+++ b/src/lib/mina/zkapp-proof.ts
@@ -233,7 +233,7 @@ function debugInconsistentConstraint(transaction: ZkappCommand, index: number) {
     },
     {
       withWitness: true,
-      snarkContext: { proverData, inAnalyze: true },
+      snarkContext: { proverData, inProver: true },
       expectedConstraints,
       unexpectedConstraintMessage:
         'Constraint generated during prove() was different than the constraint generated at this location in compile().\n' +

--- a/src/lib/proof_system.ts
+++ b/src/lib/proof_system.ts
@@ -66,6 +66,7 @@ export {
   analyzeMethod,
   emptyValue,
   emptyWitness,
+  methodArgumentsToVars,
   synthesizeMethodArguments,
   methodArgumentsToConstant,
   methodArgumentTypesAndValues,
@@ -743,7 +744,7 @@ function analyzeMethod<T>(
         method(publicInput, ...args);
       }
     },
-    { withWitness: false }
+    { withWitness: false, snarkContext: { inAnalyze: true } }
   );
   let digest = Snarky.lowLevel.constraintSystem.digest(system);
   let csJson = Snarky.lowLevel.constraintSystem.toJson(system);
@@ -841,6 +842,46 @@ function picklesRuleFromFunction(
     featureFlags,
     proofsToVerify: MlArray.to(proofsToVerify),
   };
+}
+
+// TODO share logic with picklesRuleFromFunction
+
+function methodArgumentsToVars(
+  argsWithoutPublicInput: any[],
+  { allArgs, proofArgs, witnessArgs }: MethodInterface
+) {
+  let finalArgs = [];
+  let proofs: Proof<any, any>[] = [];
+  let previousStatements: Pickles.Statement<FieldVar>[] = [];
+  for (let i = 0; i < allArgs.length; i++) {
+    let arg = allArgs[i];
+    if (arg.type === 'witness') {
+      let type = witnessArgs[arg.index];
+      finalArgs[i] = Provable.witness(type, () => {
+        return argsWithoutPublicInput?.[i] ?? emptyValue(type);
+      });
+    } else if (arg.type === 'proof') {
+      let Proof = proofArgs[arg.index];
+      let type = getStatementType(Proof);
+      let proof_ = (argsWithoutPublicInput?.[i] as Proof<any, any>) ?? {
+        proof: undefined,
+        publicInput: emptyValue(type.input),
+        publicOutput: emptyValue(type.output),
+      };
+      let { proof, publicInput, publicOutput } = proof_;
+      publicInput = Provable.witness(type.input, () => publicInput);
+      publicOutput = Provable.witness(type.output, () => publicOutput);
+      let proofInstance = new Proof({ publicInput, publicOutput, proof });
+      finalArgs[i] = proofInstance;
+      proofs.push(proofInstance);
+      let input = toFieldVars(type.input, publicInput);
+      let output = toFieldVars(type.output, publicOutput);
+      previousStatements.push(MlPair(input, output));
+    } else if (arg.type === 'generic') {
+      finalArgs[i] = argsWithoutPublicInput?.[i] ?? emptyGeneric();
+    }
+  }
+  return { args: finalArgs, proofs, previousStatements };
 }
 
 function synthesizeMethodArguments(

--- a/src/lib/provable-context-debug.ts
+++ b/src/lib/provable-context-debug.ts
@@ -1,0 +1,175 @@
+import { FieldVector } from '../bindings/crypto/bindings/vector.js';
+import { Snarky, SnarkyState } from '../snarky.js';
+import { prettifyStacktrace } from './errors.js';
+import { FieldConst, FieldVar } from './field.js';
+import { assert } from './gadgets/common.js';
+import {
+  KimchiGateType,
+  KimchiGateTypeString,
+  gateTypeToString,
+} from './gates.js';
+import { MlArray, MlBool, MlOption, MlString, MlTuple } from './ml/base.js';
+import { snarkContext } from './provable-context.js';
+import { assertDeepEqual } from './util/nested.js';
+
+export { runCircuit, SnarkyConstraint };
+
+function runCircuit(
+  main: () => void,
+  {
+    withWitness,
+    evalConstraints,
+    expectedConstraints,
+  }: {
+    withWitness: boolean;
+    evalConstraints?: boolean;
+    expectedConstraints?: ConstraintLog[];
+  }
+) {
+  const snarkyState = Snarky.lowLevel.state;
+  let numInputs = 0;
+
+  let constraints: ConstraintLog[] = [];
+
+  let [, state, input, aux, system] = Snarky.lowLevel.createState(
+    numInputs,
+    MlBool(evalConstraints ?? true),
+    MlBool(withWitness),
+    MlOption((_label, maybeConstraint) => {
+      let mlConstraint = MlOption.from(maybeConstraint);
+      if (mlConstraint === undefined) return;
+      let constraintLog = getGateTypeAndData(mlConstraint);
+      if (expectedConstraints !== undefined) {
+        let expected = expectedConstraints[constraints.length];
+        assertDeepEqual(constraintLog, expected, 'constraint mismatch');
+      }
+      constraints.push(constraintLog);
+    })
+  );
+
+  let id = snarkContext.enter({ inCheckedComputation: true });
+  let [, oldState] = snarkyState;
+  snarkyState[1] = state;
+  let counters = Snarky.lowLevel.pushActiveCounter();
+  try {
+    main();
+  } catch (error) {
+    throw prettifyStacktrace(error);
+  } finally {
+    Snarky.lowLevel.resetActiveCounter(counters);
+    snarkyState[1] = oldState;
+    snarkContext.leave(id);
+  }
+
+  let witness = MlArray.mapFrom(aux, FieldConst.toBigint);
+
+  return { constraints, witness };
+}
+
+type ConstraintLog = { type: ConstraintType; data: any };
+
+type ConstraintType =
+  | KimchiGateTypeString
+  | 'Boolean'
+  | 'Equal'
+  | 'Square'
+  | 'R1CS';
+
+function getGateTypeAndData(constraint: SnarkyConstraint): ConstraintLog {
+  let [, basic] = constraint;
+  switch (basic[1][1].c) {
+    case SnarkyConstraintType.Boolean:
+      return { type: 'Boolean', data: basic[2] };
+    case SnarkyConstraintType.Equal:
+      return { type: 'Equal', data: basic[2] };
+    case SnarkyConstraintType.Square:
+      return { type: 'Square', data: basic[2] };
+    case SnarkyConstraintType.R1CS:
+      return { type: 'R1CS', data: basic[2] };
+    case SnarkyConstraintType.Added:
+      // why can't TS narrow this?
+      let [plonkConstraint, ...data] = basic[2] as [PlonkConstraint, ...any];
+      let kimchiGateType = plonkConstraintToKimchiGateType[plonkConstraint];
+      assert(kimchiGateType !== undefined, 'unimplemented');
+      return { type: gateTypeToString(kimchiGateType), data };
+    default:
+      assert(false);
+  }
+}
+
+type SnarkyConstraint = [
+  _: 0,
+  basic: SnarkyConstraintBasic,
+  annotation: MlOption<MlString>
+];
+
+// types that are defined by `type t = ..`, `type t += <some type>`, etc
+type MlIncrementalTypeEnum<T extends string> = [
+  248,
+  { t: number; c: T; l: number },
+  number
+];
+
+// matches Snarky_backendless.Constraint.basic
+type SnarkyConstraintBasic =
+  | [0, MlIncrementalTypeEnum<SnarkyConstraintType.Boolean>, FieldVar]
+  | [0, MlIncrementalTypeEnum<SnarkyConstraintType.Equal>, MlTuple<FieldVar, 2>]
+  | [
+      0,
+      MlIncrementalTypeEnum<SnarkyConstraintType.Square>,
+      MlTuple<FieldVar, 2>
+    ]
+  | [0, MlIncrementalTypeEnum<SnarkyConstraintType.R1CS>, MlTuple<FieldVar, 3>]
+  | [
+      0,
+      MlIncrementalTypeEnum<'Snarky_backendless__Constraint.Add_kind(C).T'>,
+      [PlonkConstraint, ...any]
+    ];
+
+enum SnarkyConstraintType {
+  Boolean = 'Snarky_backendless__Constraint.Boolean',
+  Equal = 'Snarky_backendless__Constraint.Equal',
+  Square = 'Snarky_backendless__Constraint.Square',
+  R1CS = 'Snarky_backendless__Constraint.R1CS',
+  Added = 'Snarky_backendless__Constraint.Add_kind(C).T',
+}
+
+// matches Plonk_constraint_system.Plonk_constraint.t
+enum PlonkConstraint {
+  Basic,
+  Poseidon,
+  EC_add_complete,
+  EC_scale,
+  EC_endoscale,
+  EC_endoscalar,
+  Lookup,
+  RangeCheck0,
+  RangeCheck1,
+  Xor,
+  ForeignFieldAdd,
+  ForeignFieldMul,
+  Rot64,
+  AddFixedLookupTable,
+  AddRuntimeTableCfg,
+  Raw,
+}
+
+const plonkConstraintToKimchiGateType = {
+  [PlonkConstraint.Basic]: KimchiGateType.Generic,
+  [PlonkConstraint.Poseidon]: KimchiGateType.Poseidon,
+  [PlonkConstraint.EC_add_complete]: KimchiGateType.CompleteAdd,
+  [PlonkConstraint.EC_scale]: KimchiGateType.VarBaseMul,
+  [PlonkConstraint.EC_endoscale]: KimchiGateType.EndoMul,
+  [PlonkConstraint.EC_endoscalar]: KimchiGateType.EndoMulScalar,
+  [PlonkConstraint.Lookup]: KimchiGateType.Lookup,
+  [PlonkConstraint.RangeCheck0]: KimchiGateType.RangeCheck0,
+  [PlonkConstraint.RangeCheck1]: KimchiGateType.RangeCheck1,
+  [PlonkConstraint.Xor]: KimchiGateType.Xor16,
+  [PlonkConstraint.ForeignFieldAdd]: KimchiGateType.ForeignFieldAdd,
+  [PlonkConstraint.ForeignFieldMul]: KimchiGateType.ForeignFieldMul,
+  [PlonkConstraint.Rot64]: KimchiGateType.Rot64,
+  [PlonkConstraint.AddFixedLookupTable]: undefined,
+  [PlonkConstraint.AddRuntimeTableCfg]: undefined,
+  // isn't used for other stuff
+  [PlonkConstraint.Raw]: KimchiGateType.Zero,
+} as const;

--- a/src/lib/provable-context-debug.ts
+++ b/src/lib/provable-context-debug.ts
@@ -41,21 +41,9 @@ function runCircuit(
       let constraintLog = getGateTypeAndData(mlConstraint);
       constraints.push(constraintLog);
 
-      // TODO remove
-      if (constraints.length < 5)
-        console.log(prettifyStacktrace(Error(constraintLog.type)));
-      // console.log(constraintLog);
       if (expectedConstraints !== undefined) {
         let expected = expectedConstraints[constraints.length - 1];
-        // assertDeepEqual(constraintLog, expected, 'constraint mismatch');
-        if (!deepEqual(constraintLog, expected)) {
-          console.log('actual', constraints);
-          console.log(
-            'expected',
-            expectedConstraints.slice(0, constraints.length)
-          );
-          throw Error('constraint mismatch');
-        }
+        assertDeepEqual(constraintLog, expected, 'constraint mismatch');
       }
     })
   );
@@ -97,13 +85,13 @@ function getGateTypeAndData(constraint: SnarkyConstraint): ConstraintLog {
   let [, basic] = constraint;
   switch (basic[1][1].c) {
     case SnarkyConstraintType.Boolean:
-      return { type: 'Boolean', data: basic[2] };
+      return { type: 'Boolean', data: basic.slice(2) };
     case SnarkyConstraintType.Equal:
-      return { type: 'Equal', data: basic[2] };
+      return { type: 'Equal', data: basic.slice(2) };
     case SnarkyConstraintType.Square:
-      return { type: 'Square', data: basic[2] };
+      return { type: 'Square', data: basic.slice(2) };
     case SnarkyConstraintType.R1CS:
-      return { type: 'R1CS', data: basic[2] };
+      return { type: 'R1CS', data: basic.slice(2) };
     case SnarkyConstraintType.Added:
       // why can't TS narrow this?
       let [plonkConstraint, ...data] = basic[2] as [PlonkConstraint, ...any];

--- a/src/lib/provable-context-debug.unit-test.ts
+++ b/src/lib/provable-context-debug.unit-test.ts
@@ -10,7 +10,7 @@ let cs = runCircuit(
     Gadgets.rangeCheck16(y);
     Gadgets.rangeCheck64(y);
   },
-  { withWitness: true }
+  { withWitness: false }
 );
 
 console.log(cs);

--- a/src/lib/provable-context-debug.unit-test.ts
+++ b/src/lib/provable-context-debug.unit-test.ts
@@ -1,0 +1,16 @@
+import { Field } from './core.js';
+import { Gadgets } from './gadgets/gadgets.js';
+import { runCircuit } from './provable-context-debug.js';
+import { Provable } from './provable.js';
+
+let cs = runCircuit(
+  () => {
+    let x = Provable.witness(Field, () => Field(5));
+    let y = x.mul(x);
+    Gadgets.rangeCheck16(y);
+    Gadgets.rangeCheck64(y);
+  },
+  { withWitness: true }
+);
+
+console.log(cs);

--- a/src/lib/provable-context.ts
+++ b/src/lib/provable-context.ts
@@ -95,17 +95,13 @@ function runUnchecked(f: () => void) {
   }
 }
 
-function constraintSystem<T>(f: () => T) {
+function constraintSystem(f: () => void) {
   let id = snarkContext.enter({ inAnalyze: true, inCheckedComputation: true });
   try {
-    let result: T;
-    let { rows, digest, json } = Snarky.run.constraintSystem(() => {
-      result = f();
-    });
+    let { rows, digest, json } = Snarky.run.constraintSystem(f);
     return {
       rows,
       digest,
-      result: result! as T,
       ...constraintSystemFromJson(json),
     };
   } catch (error) {

--- a/src/lib/util/nested.ts
+++ b/src/lib/util/nested.ts
@@ -1,0 +1,44 @@
+export { assertDeepEqual, deepEqual };
+
+type Nested =
+  | number
+  | bigint
+  | string
+  | boolean
+  | null
+  | undefined
+  | Nested[]
+  | { [key: string]: Nested };
+
+function assertDeepEqual(a: Nested, b: Nested, message?: string) {
+  if (!deepEqual(a, b)) {
+    let fullMessage = `assertDeepEqual failed: ${message ?? ''}
+    
+Inputs:
+${JSON.stringify(a)}
+${JSON.stringify(b)}
+`;
+    throw Error(fullMessage);
+  }
+}
+
+function deepEqual(a: Nested, b: Nested): boolean {
+  if (a === b) return true;
+  if (typeof a !== typeof b) return false;
+  if (typeof a !== 'object' || typeof b !== 'object') return false;
+  if (a === null || b === null) return false;
+  if (Array.isArray(a)) {
+    if (!Array.isArray(b)) return false;
+    if (a.length !== b.length) return false;
+    for (let i = 0; i < a.length; i++) {
+      if (!deepEqual(a[i], b[i])) return false;
+    }
+    return true;
+  }
+  if (Array.isArray(b)) return false;
+  if (Object.keys(a).length !== Object.keys(b).length) return false;
+  for (const key in a) {
+    if (!deepEqual(a[key], b[key])) return false;
+  }
+  return true;
+}

--- a/src/lib/util/nested.ts
+++ b/src/lib/util/nested.ts
@@ -10,13 +10,16 @@ type Nested =
   | Nested[]
   | { [key: string]: Nested };
 
-function assertDeepEqual(a: Nested, b: Nested, message?: string) {
-  if (!deepEqual(a, b)) {
+function assertDeepEqual(actual: Nested, expected: Nested, message?: string) {
+  if (!deepEqual(actual, expected)) {
+    (BigInt.prototype as any).toJSON = function () {
+      return this.toString();
+    };
     let fullMessage = `assertDeepEqual failed: ${message ?? ''}
     
 Inputs:
-${JSON.stringify(a)}
-${JSON.stringify(b)}
+actual:   ${JSON.stringify(actual)}
+expected: ${JSON.stringify(expected)}
 `;
     throw Error(fullMessage);
   }

--- a/src/lib/util/nested.ts
+++ b/src/lib/util/nested.ts
@@ -15,9 +15,8 @@ function assertDeepEqual(actual: Nested, expected: Nested, message?: string) {
     (BigInt.prototype as any).toJSON = function () {
       return this.toString();
     };
-    let fullMessage = `assertDeepEqual failed: ${message ?? ''}
-    
-Inputs:
+    let fullMessage = `${message ? `${message}\n\n` : ''}Deep equality failed:
+
 actual:   ${JSON.stringify(actual)}
 expected: ${JSON.stringify(expected)}
 `;

--- a/src/lib/zkapp.ts
+++ b/src/lib/zkapp.ts
@@ -1186,7 +1186,8 @@ super.init();
       try {
         for (let methodIntf of methodIntfs) {
           let accountUpdate: AccountUpdate;
-          let { rows, digest, result, gates } = analyzeMethod(
+          let hasReturn = false;
+          let { rows, digest, gates } = analyzeMethod(
             ZkappPublicInput,
             methodIntf,
             (publicInput, publicKey, tokenId, ...args) => {
@@ -1195,15 +1196,15 @@ super.init();
                 publicInput,
                 ...args
               );
+              hasReturn = result !== undefined;
               accountUpdate = instance.#executionState!.accountUpdate;
-              return result;
             }
           );
           methodMetadata[methodIntf.methodName] = {
             actions: accountUpdate!.body.actions.data.length,
             rows,
             digest,
-            hasReturn: result !== undefined,
+            hasReturn,
             gates,
           };
         }

--- a/src/lib/zkapp.ts
+++ b/src/lib/zkapp.ts
@@ -56,6 +56,7 @@ import {
   snarkContext,
 } from './provable-context.js';
 import { Cache } from './proof-system/cache.js';
+import type { ConstraintLog } from './provable-context-debug.js';
 
 // external API
 export {
@@ -616,6 +617,7 @@ class SmartContract {
       digest: string;
       hasReturn: boolean;
       gates: Gate[];
+      expectedConstraints?: ConstraintLog[];
     }
   >; // keyed by method name
   static _provers?: Pickles.Prover[];
@@ -1187,7 +1189,7 @@ super.init();
         for (let methodIntf of methodIntfs) {
           let accountUpdate: AccountUpdate;
           let hasReturn = false;
-          let { rows, digest, gates } = analyzeMethod(
+          let { rows, digest, gates, constraints } = analyzeMethod(
             ZkappPublicInput,
             methodIntf,
             (publicInput, publicKey, tokenId, ...args) => {
@@ -1206,6 +1208,7 @@ super.init();
             digest,
             hasReturn,
             gates,
+            expectedConstraints: constraints,
           };
         }
       } finally {

--- a/src/snarky.d.ts
+++ b/src/snarky.d.ts
@@ -26,7 +26,10 @@ import type {
   WasmFqSrs,
 } from './bindings/compiled/node_bindings/plonk_wasm.cjs';
 import type { KimchiGateType } from './lib/gates.ts';
-import type { SnarkyConstraint } from './lib/provable-context-debug.js';
+import type {
+  SnarkyConstraint,
+  MlConstraintSystem,
+} from './lib/provable-context-debug.js';
 import type { FieldVector } from './bindings/crypto/bindings/vector.ts';
 
 export { ProvablePure, Provable, Ledger, Pickles, Gate, GateType, getWasm };
@@ -41,6 +44,7 @@ export {
   FeatureFlags,
   MlFeatureFlags,
   SnarkyState,
+  JsonConstraintSystem,
 };
 
 /**
@@ -561,11 +565,17 @@ declare const Snarky: {
       state: SnarkyState,
       input: FieldVector,
       aux: FieldVector,
-      system: ConstraintSystem
+      system: MlConstraintSystem
     ];
 
     pushActiveCounter(): MlList<number>;
     resetActiveCounter(counters: MlList<number>): void;
+
+    constraintSystem: {
+      getRows(system: MlConstraintSystem): number;
+      digest(system: MlConstraintSystem): string;
+      toJson(system: MlConstraintSystem): JsonConstraintSystem;
+    };
   };
 };
 

--- a/src/snarky.d.ts
+++ b/src/snarky.d.ts
@@ -26,6 +26,7 @@ import type {
   WasmFqSrs,
 } from './bindings/compiled/node_bindings/plonk_wasm.cjs';
 import type { KimchiGateType } from './lib/gates.ts';
+import type { SnarkyConstraint } from './lib/provable-context-debug.js';
 import type { FieldVector } from './bindings/crypto/bindings/vector.ts';
 
 export { ProvablePure, Provable, Ledger, Pickles, Gate, GateType, getWasm };
@@ -40,7 +41,6 @@ export {
   FeatureFlags,
   MlFeatureFlags,
   SnarkyState,
-  SnarkyConstraint,
 };
 
 /**
@@ -588,12 +588,6 @@ type SnarkyState = [
   is_running: MlBool,
   as_prover: MlRef<MlBool>,
   log_constraint: unknown
-];
-
-type SnarkyConstraint = [
-  _: 0,
-  basic: [number, unknown], // actually this is an enum
-  annotation: MlOption<MlString>
 ];
 
 type GateType =

--- a/src/snarky.d.ts
+++ b/src/snarky.d.ts
@@ -39,6 +39,8 @@ export {
   MlPublicKeyVar,
   FeatureFlags,
   MlFeatureFlags,
+  SnarkyState,
+  SnarkyConstraint,
 };
 
 /**
@@ -543,8 +545,7 @@ declare const Snarky: {
   };
 
   lowLevel: {
-    state: Ref<SnarkyState>;
-    setState(state: SnarkyState): void;
+    state: MlRef<SnarkyState>;
     createState(
       numInputs: number,
       evalConstraints: MlBool,
@@ -562,10 +563,13 @@ declare const Snarky: {
       aux: FieldVector,
       system: ConstraintSystem
     ];
+
+    pushActiveCounter(): MlList<number>;
+    resetActiveCounter(counters: MlList<number>): void;
   };
 };
 
-type Ref<T> = [_: 0, contents: T];
+type MlRef<T> = [_: 0, contents: T];
 
 type SnarkyVector = [0, [unknown, number, FieldVector]];
 type ConstraintSystem = unknown;
@@ -577,10 +581,12 @@ type SnarkyState = [
   aux: SnarkyVector,
   eval_constraints: MlBool,
   num_inputs: number,
-  next_auxiliary: Ref<number>,
+  next_auxiliary: MlRef<number>,
   has_witness: MlBool,
   stack: MlList<MlString>,
+  handler: unknown,
   is_running: MlBool,
+  as_prover: MlRef<MlBool>,
   log_constraint: unknown
 ];
 

--- a/src/snarky.d.ts
+++ b/src/snarky.d.ts
@@ -26,6 +26,7 @@ import type {
   WasmFqSrs,
 } from './bindings/compiled/node_bindings/plonk_wasm.cjs';
 import type { KimchiGateType } from './lib/gates.ts';
+import type { FieldVector } from './bindings/crypto/bindings/vector.ts';
 
 export { ProvablePure, Provable, Ledger, Pickles, Gate, GateType, getWasm };
 
@@ -542,20 +543,38 @@ declare const Snarky: {
   };
 
   lowLevel: {
-    fieldVec(): unknown;
-    getState(): SnarkyState;
+    state: Ref<SnarkyState>;
+    setState(state: SnarkyState): void;
+    createState(
+      numInputs: number,
+      evalConstraints: MlBool,
+      withWitness: MlBool,
+      logConstraint: MlOption<
+        (
+          atLabelBoundary: MlOption<unknown>,
+          constraint: MlOption<SnarkyConstraint>
+        ) => void
+      >
+    ): [
+      _: 0,
+      state: SnarkyState,
+      input: FieldVector,
+      aux: FieldVector,
+      system: ConstraintSystem
+    ];
   };
 };
 
-type Ref<T> = [0, T];
+type Ref<T> = [_: 0, contents: T];
 
-type Vector = unknown;
+type SnarkyVector = [0, [unknown, number, FieldVector]];
+type ConstraintSystem = unknown;
 
 type SnarkyState = [
   _: 0,
-  system: MlOption<unknown>,
-  input: Vector,
-  aux: Vector,
+  system: MlOption<ConstraintSystem>,
+  input: SnarkyVector,
+  aux: SnarkyVector,
   eval_constraints: MlBool,
   num_inputs: number,
   next_auxiliary: Ref<number>,
@@ -563,6 +582,12 @@ type SnarkyState = [
   stack: MlList<MlString>,
   is_running: MlBool,
   log_constraint: unknown
+];
+
+type SnarkyConstraint = [
+  _: 0,
+  basic: [number, unknown], // actually this is an enum
+  annotation: MlOption<MlString>
 ];
 
 type GateType =

--- a/src/snarky.d.ts
+++ b/src/snarky.d.ts
@@ -540,7 +540,30 @@ declare const Snarky: {
       squeeze(sponge: unknown): FieldVar;
     };
   };
+
+  lowLevel: {
+    fieldVec(): unknown;
+    getState(): SnarkyState;
+  };
 };
+
+type Ref<T> = [0, T];
+
+type Vector = unknown;
+
+type SnarkyState = [
+  _: 0,
+  system: MlOption<unknown>,
+  input: Vector,
+  aux: Vector,
+  eval_constraints: MlBool,
+  num_inputs: number,
+  next_auxiliary: Ref<number>,
+  has_witness: MlBool,
+  stack: MlList<MlString>,
+  is_running: MlBool,
+  log_constraint: unknown
+];
 
 type GateType =
   | 'Zero'


### PR DESCRIPTION
- start debugging dex example
- start adding types for low level snarky intf
- iterate on types
- iterate on api and fix type error
- runner that can compare circuit constraints against a previous run
- expose more flexible cs processing
- revert returning result
- don't return result from constraint system
- use runCircuit in analyzeMethods
- move zkapp proving logic to separate file
- minor
- WIP: compare constraints in zkapp proof to the ones created in analyzeMethods
- remove debugging, fix basic constraint data
- add memoized witnesses to avoid failing constraints
- hook prover consistency check into prover when detecting a relevant problem
- show traces to constraints in both versions
- seems more correct but I'm not sure
- helper to print account update layout
- fix the damn bug
- [dex] remove obsolete scare comments
- minor example tweak
- submodules
