### PR TITLE
Fix import cycles in account_update.ts

### DIFF
--- a/src/lib/account_update.ts
+++ b/src/lib/account_update.ts
@@ -1783,7 +1783,7 @@ function addMissingSignatures(
     let signature = signFieldElement(
       fullCommitment,
       privateKey.toBigInt(),
-      Mina.getNetworkId()
+      activeInstance.getNetworkId()
     );
     return { body, authorization: Signature.toBase58(signature) };
   }
@@ -1816,7 +1816,7 @@ function addMissingSignatures(
     let signature = signFieldElement(
       transactionCommitment,
       privateKey.toBigInt(),
-      Mina.getNetworkId()
+      activeInstance.getNetworkId()
     );
     Authorization.setSignature(accountUpdate, Signature.toBase58(signature));
     return accountUpdate as AccountUpdate & { lazyAuthorization: undefined };

--- a/src/lib/account_update.ts
+++ b/src/lib/account_update.ts
@@ -15,9 +15,17 @@ import {
 } from '../bindings/mina-transaction/types.js';
 import { PrivateKey, PublicKey } from './signature.js';
 import { UInt64, UInt32, Int64, Sign } from './int.js';
-import * as Mina from './mina.js';
-import { SmartContract } from './zkapp.js';
-import * as Precondition from './precondition.js';
+import type { SmartContract } from './zkapp.js';
+import {
+  Preconditions,
+  Account,
+  Network,
+  CurrentSlot,
+  preconditions,
+  OrIgnore,
+  ClosedInterval,
+  getAccountPreconditions,
+} from './precondition.js';
 import { dummyBase64Proof, Empty, Proof, Prover } from './proof_system.js';
 import { Memo } from '../mina-signer/src/memo.js';
 import {
@@ -28,11 +36,13 @@ import { TokenId as Base58TokenId } from './base58-encodings.js';
 import { hashWithPrefix, packToFields } from './hash.js';
 import { mocks, prefixes } from '../bindings/crypto/constants.js';
 import { Context } from './global-context.js';
-import { assert } from './errors.js';
 import { MlArray } from './ml/base.js';
 import { Signature, signFieldElement } from '../mina-signer/src/signature.js';
 import { MlFieldConstArray } from './ml/fields.js';
 import { transactionCommitments } from '../mina-signer/src/sign-zkapp-command.js';
+import { currentTransaction } from './mina/transaction-context.js';
+import { isSmartContract } from './mina/smart-contract-base.js';
+import { activeInstance } from './mina/mina-instance.js';
 
 // external API
 export { AccountUpdate, Permissions, ZkappPublicInput };
@@ -59,6 +69,7 @@ export {
   zkAppProver,
   SmartContractContext,
   dummySignature,
+  LazyProof,
 };
 
 const ZkappStateLength = 8;
@@ -85,11 +96,6 @@ type AccountUpdateBody = Types.AccountUpdate['body'];
 type Update = AccountUpdateBody['update'];
 
 type MayUseToken = AccountUpdateBody['mayUseToken'];
-
-/**
- * Preconditions for the network and accounts
- */
-type Preconditions = AccountUpdateBody['preconditions'];
 
 /**
  * Either set a value or keep it the same.
@@ -483,107 +489,6 @@ type FeePayerUnsigned = FeePayer & {
   lazyAuthorization?: LazySignature | undefined;
 };
 
-/**
- * Either check a value or ignore it.
- *
- * Used within [[ AccountPredicate ]]s and [[ ProtocolStatePredicate ]]s.
- */
-type OrIgnore<T> = { isSome: Bool; value: T };
-
-/**
- * An interval representing all the values between `lower` and `upper` inclusive
- * of both the `lower` and `upper` values.
- *
- * @typeParam A something with an ordering where one can quantify a lower and
- *            upper bound.
- */
-type ClosedInterval<T> = { lower: T; upper: T };
-
-type NetworkPrecondition = Preconditions['network'];
-let NetworkPrecondition = {
-  ignoreAll(): NetworkPrecondition {
-    let stakingEpochData = {
-      ledger: { hash: ignore(Field(0)), totalCurrency: ignore(uint64()) },
-      seed: ignore(Field(0)),
-      startCheckpoint: ignore(Field(0)),
-      lockCheckpoint: ignore(Field(0)),
-      epochLength: ignore(uint32()),
-    };
-    let nextEpochData = cloneCircuitValue(stakingEpochData);
-    return {
-      snarkedLedgerHash: ignore(Field(0)),
-      blockchainLength: ignore(uint32()),
-      minWindowDensity: ignore(uint32()),
-      totalCurrency: ignore(uint64()),
-      globalSlotSinceGenesis: ignore(uint32()),
-      stakingEpochData,
-      nextEpochData,
-    };
-  },
-};
-
-/**
- * Ignores a `dummy`
- *
- * @param dummy The value to ignore
- * @returns Always an ignored value regardless of the input.
- */
-function ignore<T>(dummy: T): OrIgnore<T> {
-  return { isSome: Bool(false), value: dummy };
-}
-
-/**
- * Ranges between all uint32 values
- */
-const uint32 = () => ({ lower: UInt32.from(0), upper: UInt32.MAXINT() });
-
-/**
- * Ranges between all uint64 values
- */
-const uint64 = () => ({ lower: UInt64.from(0), upper: UInt64.MAXINT() });
-
-type AccountPrecondition = Preconditions['account'];
-const AccountPrecondition = {
-  ignoreAll(): AccountPrecondition {
-    let appState: Array<OrIgnore<Field>> = [];
-    for (let i = 0; i < ZkappStateLength; ++i) {
-      appState.push(ignore(Field(0)));
-    }
-    return {
-      balance: ignore(uint64()),
-      nonce: ignore(uint32()),
-      receiptChainHash: ignore(Field(0)),
-      delegate: ignore(PublicKey.empty()),
-      state: appState,
-      actionState: ignore(Actions.emptyActionState()),
-      provedState: ignore(Bool(false)),
-      isNew: ignore(Bool(false)),
-    };
-  },
-  nonce(nonce: UInt32): AccountPrecondition {
-    let p = AccountPrecondition.ignoreAll();
-    AccountUpdate.assertEquals(p.nonce, nonce);
-    return p;
-  },
-};
-
-type GlobalSlotPrecondition = Preconditions['validWhile'];
-const GlobalSlotPrecondition = {
-  ignoreAll(): GlobalSlotPrecondition {
-    return ignore(uint32());
-  },
-};
-
-const Preconditions = {
-  ignoreAll(): Preconditions {
-    return {
-      account: AccountPrecondition.ignoreAll(),
-      network: NetworkPrecondition.ignoreAll(),
-      validWhile: GlobalSlotPrecondition.ignoreAll(),
-    };
-  },
-};
-
 type Control = Types.AccountUpdate['authorization'];
 type LazyNone = {
   kind: 'lazy-none';
@@ -664,9 +569,9 @@ class AccountUpdate implements Types.AccountUpdate {
   authorization: Control;
   lazyAuthorization: LazySignature | LazyProof | LazyNone | undefined =
     undefined;
-  account: Precondition.Account;
-  network: Precondition.Network;
-  currentSlot: Precondition.CurrentSlot;
+  account: Account;
+  network: Network;
+  currentSlot: CurrentSlot;
   children: {
     callsType:
       | { type: 'None' }
@@ -688,10 +593,7 @@ class AccountUpdate implements Types.AccountUpdate {
     this.id = Math.random();
     this.body = body;
     this.authorization = authorization;
-    let { account, network, currentSlot } = Precondition.preconditions(
-      this,
-      isSelf
-    );
+    let { account, network, currentSlot } = preconditions(this, isSelf);
     this.account = account;
     this.network = network;
     this.currentSlot = currentSlot;
@@ -730,7 +632,7 @@ class AccountUpdate implements Types.AccountUpdate {
       accountLike: PublicKey | AccountUpdate | SmartContract,
       label: string
     ) {
-      if (accountLike instanceof SmartContract) {
+      if (isSmartContract(accountLike)) {
         accountLike = accountLike.self;
       }
       if (accountLike instanceof AccountUpdate) {
@@ -842,7 +744,7 @@ class AccountUpdate implements Types.AccountUpdate {
     if (to instanceof AccountUpdate) {
       receiver = to;
       receiver.body.tokenId.assertEquals(this.body.tokenId);
-    } else if (to instanceof SmartContract) {
+    } else if (isSmartContract(to)) {
       receiver = to.self;
       receiver.body.tokenId.assertEquals(this.body.tokenId);
     } else {
@@ -1032,13 +934,11 @@ class AccountUpdate implements Types.AccountUpdate {
     let publicKey = update.body.publicKey;
     let tokenId =
       update instanceof AccountUpdate ? update.body.tokenId : TokenId.default;
-    let nonce = Number(
-      Precondition.getAccountPreconditions(update.body).nonce.toString()
-    );
+    let nonce = Number(getAccountPreconditions(update.body).nonce.toString());
     // if the fee payer is the same account update as this one, we have to start
     // the nonce predicate at one higher, bc the fee payer already increases its
     // nonce
-    let isFeePayer = Mina.currentTransaction()?.sender?.equals(publicKey);
+    let isFeePayer = currentTransaction()?.sender?.equals(publicKey);
     let isSameAsFeePayer = !!isFeePayer
       ?.and(tokenId.equals(TokenId.default))
       .toBoolean();
@@ -1046,7 +946,7 @@ class AccountUpdate implements Types.AccountUpdate {
     // now, we check how often this account update already updated its nonce in
     // this tx, and increase nonce from `getAccount` by that amount
     CallForest.forEachPredecessor(
-      Mina.currentTransaction.get().accountUpdates,
+      currentTransaction.get().accountUpdates,
       update as AccountUpdate,
       (otherUpdate) => {
         let shouldIncreaseNonce = otherUpdate.publicKey
@@ -1163,7 +1063,7 @@ class AccountUpdate implements Types.AccountUpdate {
         self.label || 'Unlabeled'
       } > AccountUpdate.create()`;
     } else {
-      Mina.currentTransaction()?.accountUpdates.push(accountUpdate);
+      currentTransaction()?.accountUpdates.push(accountUpdate);
       accountUpdate.label = `Mina.transaction > AccountUpdate.create()`;
     }
     return accountUpdate;
@@ -1182,8 +1082,8 @@ class AccountUpdate implements Types.AccountUpdate {
       if (selfUpdate === accountUpdate) return;
       insideContract.this.self.approve(accountUpdate);
     } else {
-      if (!Mina.currentTransaction.has()) return;
-      let updates = Mina.currentTransaction.get().accountUpdates;
+      if (!currentTransaction.has()) return;
+      let updates = currentTransaction.get().accountUpdates;
       if (!updates.find((update) => update.id === accountUpdate.id)) {
         updates.push(accountUpdate);
       }
@@ -1195,7 +1095,7 @@ class AccountUpdate implements Types.AccountUpdate {
   static unlink(accountUpdate: AccountUpdate) {
     let siblings =
       accountUpdate.parent?.children.accountUpdates ??
-      Mina.currentTransaction()?.accountUpdates;
+      currentTransaction()?.accountUpdates;
     if (siblings === undefined) return;
     let i = siblings?.findIndex((update) => update.id === accountUpdate.id);
     if (i !== undefined && i !== -1) {
@@ -1273,7 +1173,7 @@ class AccountUpdate implements Types.AccountUpdate {
   ) {
     let accountUpdate = AccountUpdate.createSigned(feePayer as PrivateKey);
     accountUpdate.label = 'AccountUpdate.fundNewAccount()';
-    let fee = Mina.getNetworkConstants().accountCreationFee;
+    let fee = activeInstance.getNetworkConstants().accountCreationFee;
     numberOfAccounts ??= 1;
     if (typeof numberOfAccounts === 'number') fee = fee.mul(numberOfAccounts);
     else fee = fee.add(UInt64.from(numberOfAccounts.initialBalance ?? 0));
@@ -1841,57 +1741,6 @@ const Authorization = {
     );
     accountUpdate.authorization = {};
     accountUpdate.lazyAuthorization = { ...signature, kind: 'lazy-signature' };
-  },
-  setProofAuthorizationKind(
-    { body, id }: AccountUpdate,
-    priorAccountUpdates?: AccountUpdate[]
-  ) {
-    body.authorizationKind.isSigned = Bool(false);
-    body.authorizationKind.isProved = Bool(true);
-    let hash = Provable.witness(Field, () => {
-      let proverData = zkAppProver.getData();
-      let isProver = proverData !== undefined;
-      assert(
-        isProver || priorAccountUpdates !== undefined,
-        'Called `setProofAuthorizationKind()` outside the prover without passing in `priorAccountUpdates`.'
-      );
-      let myAccountUpdateId = isProver ? proverData.accountUpdate.id : id;
-      priorAccountUpdates ??= proverData.transaction.accountUpdates;
-      priorAccountUpdates = priorAccountUpdates.filter(
-        (a) => a.id !== myAccountUpdateId
-      );
-      let priorAccountUpdatesFlat = CallForest.toFlatList(
-        priorAccountUpdates,
-        false
-      );
-      let accountUpdate = [...priorAccountUpdatesFlat]
-        .reverse()
-        .find((body_) =>
-          body_.update.verificationKey.isSome
-            .and(body_.tokenId.equals(body.tokenId))
-            .and(body_.publicKey.equals(body.publicKey))
-            .toBoolean()
-        );
-      if (accountUpdate !== undefined) {
-        return accountUpdate.body.update.verificationKey.value.hash;
-      }
-      try {
-        let account = Mina.getAccount(body.publicKey, body.tokenId);
-        return account.zkapp?.verificationKey?.hash ?? Field(0);
-      } catch {
-        return Field(0);
-      }
-    });
-    body.authorizationKind.verificationKeyHash = hash;
-  },
-  setLazyProof(
-    accountUpdate: AccountUpdate,
-    proof: Omit<LazyProof, 'kind'>,
-    priorAccountUpdates: AccountUpdate[]
-  ) {
-    Authorization.setProofAuthorizationKind(accountUpdate, priorAccountUpdates);
-    accountUpdate.authorization = {};
-    accountUpdate.lazyAuthorization = { ...proof, kind: 'lazy-proof' };
   },
   setLazyNone(accountUpdate: AccountUpdate) {
     accountUpdate.body.authorizationKind.isSigned = Bool(false);

--- a/src/lib/hash.ts
+++ b/src/lib/hash.ts
@@ -118,10 +118,6 @@ const Poseidon = {
     return Poseidon.hash(packed);
   },
 
-  initialState(): [Field, Field, Field] {
-    return [Field(0), Field(0), Field(0)];
-  },
-
   Sponge,
 };
 

--- a/src/lib/hash.ts
+++ b/src/lib/hash.ts
@@ -118,6 +118,10 @@ const Poseidon = {
     return Poseidon.hash(packed);
   },
 
+  initialState(): [Field, Field, Field] {
+    return [Field(0), Field(0), Field(0)];
+  },
+
   Sponge,
 };
 

--- a/src/lib/mina.ts
+++ b/src/lib/mina.ts
@@ -19,8 +19,7 @@ import {
 import * as Fetch from './fetch.js';
 import { assertPreconditionInvariants, NetworkValue } from './precondition.js';
 import { cloneCircuitValue, toConstant } from './circuit_value.js';
-import { Empty, Proof, verify } from './proof_system.js';
-import { SmartContract } from './zkapp.js';
+import { Empty, JsonProof, Proof, verify } from './proof_system.js';
 import { invalidTransactionError } from './mina/errors.js';
 import { Types, TypesBigint } from '../bindings/mina-transaction/types.js';
 import { Account } from './mina/account.js';
@@ -38,11 +37,11 @@ import {
   activeInstance,
   setActiveInstance,
   Mina,
-  FeePayerSpec,
-  DeprecatedFeePayerSpec,
-  ActionStates,
   defaultNetworkConstants,
-  NetworkConstants,
+  type FeePayerSpec,
+  type DeprecatedFeePayerSpec,
+  type ActionStates,
+  type NetworkConstants,
 } from './mina/mina-instance.js';
 
 export {
@@ -1233,15 +1232,15 @@ async function verifyAccountUpdate(
       let publicInput = accountUpdate.toPublicInput();
       let publicInputFields = ZkappPublicInput.toFields(publicInput);
 
-      const proof = SmartContract.Proof().fromJSON({
+      let proof: JsonProof = {
         maxProofsVerified: 2,
         proof: accountUpdate.authorization.proof!,
         publicInput: publicInputFields.map((f) => f.toString()),
         publicOutput: [],
-      });
+      };
 
       let verificationKey = account.zkapp?.verificationKey?.data!;
-      isValidProof = await verify(proof.toJSON(), verificationKey);
+      isValidProof = await verify(proof, verificationKey);
       if (!isValidProof) {
         throw Error(
           `Invalid proof for account update\n${JSON.stringify(update)}`

--- a/src/lib/mina.ts
+++ b/src/lib/mina.ts
@@ -41,6 +41,8 @@ import {
   FeePayerSpec,
   DeprecatedFeePayerSpec,
   ActionStates,
+  defaultNetworkConstants,
+  NetworkConstants,
 } from './mina/mina-instance.js';
 
 export {

--- a/src/lib/mina.ts
+++ b/src/lib/mina.ts
@@ -297,13 +297,6 @@ function newTransaction(transaction: ZkappCommand, proofsEnabled?: boolean) {
   return self;
 }
 
-const defaultAccountCreationFee = 1_000_000_000;
-const defaultNetworkConstants: NetworkConstants = {
-  genesisTimestamp: UInt64.from(0),
-  slotTime: UInt64.from(3 * 60 * 1000),
-  accountCreationFee: UInt64.from(defaultAccountCreationFee),
-};
-
 /**
  * A mock Mina blockchain running locally and useful for testing.
  */

--- a/src/lib/mina.ts
+++ b/src/lib/mina.ts
@@ -79,6 +79,14 @@ export {
   type NetworkConstants,
 };
 
+// patch active instance so that we can still create basic transactions without giving Mina network details
+setActiveInstance({
+  ...activeInstance,
+  async transaction(sender: DeprecatedFeePayerSpec, f: () => void) {
+    return createTransaction(sender, f, 0);
+  },
+});
+
 interface TransactionId {
   isSuccess: boolean;
   wait(options?: { maxAttempts?: number; interval?: number }): Promise<void>;

--- a/src/lib/mina/mina-instance.ts
+++ b/src/lib/mina/mina-instance.ts
@@ -1,0 +1,123 @@
+/**
+ * This module holds the global Mina instance and its interface.
+ */
+import type { Field } from '../field.js';
+import { UInt64, UInt32 } from '../int.js';
+import type { PublicKey, PrivateKey } from '../signature.js';
+import type { Transaction, TransactionId } from '../mina.js';
+import type { Account } from './account.js';
+import type { NetworkValue } from '../precondition.js';
+import type * as Fetch from '../fetch.js';
+
+export {
+  Mina,
+  FeePayerSpec,
+  DeprecatedFeePayerSpec,
+  ActionStates,
+  activeInstance,
+  setActiveInstance,
+  ZkappStateLength,
+};
+
+const defaultAccountCreationFee = 1_000_000_000;
+const ZkappStateLength = 8;
+
+/**
+ * Allows you to specify information about the fee payer account and the transaction.
+ */
+type FeePayerSpec =
+  | PublicKey
+  | {
+      sender: PublicKey;
+      fee?: number | string | UInt64;
+      memo?: string;
+      nonce?: number;
+    }
+  | undefined;
+
+type DeprecatedFeePayerSpec =
+  | PublicKey
+  | PrivateKey
+  | ((
+      | {
+          feePayerKey: PrivateKey;
+          sender?: PublicKey;
+        }
+      | {
+          feePayerKey?: PrivateKey;
+          sender: PublicKey;
+        }
+    ) & {
+      fee?: number | string | UInt64;
+      memo?: string;
+      nonce?: number;
+    })
+  | undefined;
+
+type ActionStates = {
+  fromActionState?: Field;
+  endActionState?: Field;
+};
+
+interface Mina {
+  transaction(
+    sender: DeprecatedFeePayerSpec,
+    f: () => void
+  ): Promise<Transaction>;
+  currentSlot(): UInt32;
+  hasAccount(publicKey: PublicKey, tokenId?: Field): boolean;
+  getAccount(publicKey: PublicKey, tokenId?: Field): Account;
+  getNetworkState(): NetworkValue;
+  getNetworkConstants(): {
+    genesisTimestamp: UInt64;
+    /**
+     * Duration of 1 slot in millisecondw
+     */
+    slotTime: UInt64;
+    accountCreationFee: UInt64;
+  };
+  accountCreationFee(): UInt64;
+  sendTransaction(transaction: Transaction): Promise<TransactionId>;
+  fetchEvents: (
+    publicKey: PublicKey,
+    tokenId?: Field,
+    filterOptions?: Fetch.EventActionFilterOptions
+  ) => ReturnType<typeof Fetch.fetchEvents>;
+  fetchActions: (
+    publicKey: PublicKey,
+    actionStates?: ActionStates,
+    tokenId?: Field
+  ) => ReturnType<typeof Fetch.fetchActions>;
+  getActions: (
+    publicKey: PublicKey,
+    actionStates?: ActionStates,
+    tokenId?: Field
+  ) => { hash: string; actions: string[][] }[];
+  proofsEnabled: boolean;
+}
+
+let activeInstance: Mina = {
+  accountCreationFee: () => UInt64.from(defaultAccountCreationFee),
+  getNetworkConstants: noActiveInstance,
+  currentSlot: noActiveInstance,
+  hasAccount: noActiveInstance,
+  getAccount: noActiveInstance,
+  getNetworkState: noActiveInstance,
+  sendTransaction: noActiveInstance,
+  transaction: noActiveInstance,
+  fetchEvents: noActiveInstance,
+  fetchActions: noActiveInstance,
+  getActions: noActiveInstance,
+  proofsEnabled: true,
+};
+
+/**
+ * Set the currently used Mina instance.
+ */
+function setActiveInstance(m: Mina) {
+  activeInstance = m;
+}
+
+function noActiveInstance(): never {
+  throw Error('Must call Mina.setActiveInstance first');
+}

--- a/src/lib/mina/smart-contract-base.ts
+++ b/src/lib/mina/smart-contract-base.ts
@@ -1,0 +1,13 @@
+/**
+ * This file exists to avoid an import cycle between code that just needs access
+ * to a smart contract base class, and the code that implements `SmartContract`.
+ */
+import type { SmartContract } from '../zkapp.js';
+
+export { isSmartContract, SmartContractBase };
+
+class SmartContractBase {}
+
+function isSmartContract(object: unknown): object is SmartContract {
+  return object instanceof SmartContractBase;
+}

--- a/src/lib/mina/transaction-context.ts
+++ b/src/lib/mina/transaction-context.ts
@@ -1,0 +1,16 @@
+import type { AccountUpdate } from '../account_update.js';
+import type { PublicKey } from '../signature.js';
+import { Context } from '../global-context.js';
+
+export { currentTransaction, CurrentTransaction, FetchMode };
+
+type FetchMode = 'fetch' | 'cached' | 'test';
+type CurrentTransaction = {
+  sender?: PublicKey;
+  accountUpdates: AccountUpdate[];
+  fetchMode: FetchMode;
+  isFinalRunOutsideCircuit: boolean;
+  numberOfRuns: 0 | 1 | undefined;
+};
+
+let currentTransaction = Context.create<CurrentTransaction>();

--- a/src/lib/precondition.ts
+++ b/src/lib/precondition.ts
@@ -1,14 +1,19 @@
 import { Bool, Field } from './core.js';
-import { circuitValueEquals } from './circuit_value.js';
+import { circuitValueEquals, cloneCircuitValue } from './circuit_value.js';
 import { Provable } from './provable.js';
-import * as Mina from './mina.js';
-import { Actions, AccountUpdate, Preconditions } from './account_update.js';
+import { activeInstance as Mina } from './mina/mina-instance.js';
+import type { AccountUpdate } from './account_update.js';
 import { Int64, UInt32, UInt64 } from './int.js';
 import { Layout } from '../bindings/mina-transaction/gen/transaction.js';
 import { jsLayout } from '../bindings/mina-transaction/gen/js-layout.js';
 import { emptyReceiptChainHash, TokenSymbol } from './hash.js';
 import { PublicKey } from './signature.js';
-import { ZkappUri } from '../bindings/mina-transaction/transaction-leaves.js';
+import {
+  Actions,
+  ZkappUri,
+} from '../bindings/mina-transaction/transaction-leaves.js';
+import type { Types } from '../bindings/mina-transaction/types.js';
+import { ZkappStateLength } from './mina/mina-instance.js';
 
 export {
   preconditions,
@@ -20,6 +25,145 @@ export {
   AccountValue,
   NetworkValue,
   getAccountPreconditions,
+  Preconditions,
+  OrIgnore,
+  ClosedInterval,
+};
+
+type AccountUpdateBody = Types.AccountUpdate['body'];
+
+/**
+ * Preconditions for the network and accounts
+ */
+type Preconditions = AccountUpdateBody['preconditions'];
+
+/**
+ * Either check a value or ignore it.
+ *
+ * Used within [[ AccountPredicate ]]s and [[ ProtocolStatePredicate ]]s.
+ */
+type OrIgnore<T> = { isSome: Bool; value: T };
+
+/**
+ * An interval representing all the values between `lower` and `upper` inclusive
+ * of both the `lower` and `upper` values.
+ *
+ * @typeParam A something with an ordering where one can quantify a lower and
+ *            upper bound.
+ */
+type ClosedInterval<T> = { lower: T; upper: T };
+
+type NetworkPrecondition = Preconditions['network'];
+let NetworkPrecondition = {
+  ignoreAll(): NetworkPrecondition {
+    let stakingEpochData = {
+      ledger: { hash: ignore(Field(0)), totalCurrency: ignore(uint64()) },
+      seed: ignore(Field(0)),
+      startCheckpoint: ignore(Field(0)),
+      lockCheckpoint: ignore(Field(0)),
+      epochLength: ignore(uint32()),
+    };
+    let nextEpochData = cloneCircuitValue(stakingEpochData);
+    return {
+      snarkedLedgerHash: ignore(Field(0)),
+      blockchainLength: ignore(uint32()),
+      minWindowDensity: ignore(uint32()),
+      totalCurrency: ignore(uint64()),
+      globalSlotSinceGenesis: ignore(uint32()),
+      stakingEpochData,
+      nextEpochData,
+    };
+  },
+};
+
+/**
+ * Ignores a `dummy`
+ *
+ * @param dummy The value to ignore
+ * @returns Always an ignored value regardless of the input.
+ */
+function ignore<T>(dummy: T): OrIgnore<T> {
+  return { isSome: Bool(false), value: dummy };
+}
+
+/**
+ * Ranges between all uint32 values
+ */
+const uint32 = () => ({ lower: UInt32.from(0), upper: UInt32.MAXINT() });
+
+/**
+ * Ranges between all uint64 values
+ */
+const uint64 = () => ({ lower: UInt64.from(0), upper: UInt64.MAXINT() });
+
+/**
+ * Fix a property to a certain value.
+ *
+ * @param property The property to constrain
+ * @param value The value it is fixed to
+ *
+ * Example: To fix the account nonce of a SmartContract to 0, you can use
+ *
+ * ```ts
+ * \@method onlyRunsWhenNonceIsZero() {
+ *   AccountUpdate.assertEquals(this.self.body.preconditions.account.nonce, UInt32.zero);
+ *   // ...
+ * }
+ * ```
+ */
+function assertEquals<T extends object>(
+  property: OrIgnore<ClosedInterval<T> | T>,
+  value: T
+) {
+  property.isSome = Bool(true);
+  if ('lower' in property.value && 'upper' in property.value) {
+    property.value.lower = value;
+    property.value.upper = value;
+  } else {
+    property.value = value;
+  }
+}
+
+type AccountPrecondition = Preconditions['account'];
+const AccountPrecondition = {
+  ignoreAll(): AccountPrecondition {
+    let appState: Array<OrIgnore<Field>> = [];
+    for (let i = 0; i < ZkappStateLength; ++i) {
+      appState.push(ignore(Field(0)));
+    }
+    return {
+      balance: ignore(uint64()),
+      nonce: ignore(uint32()),
+      receiptChainHash: ignore(Field(0)),
+      delegate: ignore(PublicKey.empty()),
+      state: appState,
+      actionState: ignore(Actions.emptyActionState()),
+      provedState: ignore(Bool(false)),
+      isNew: ignore(Bool(false)),
+    };
+  },
+  nonce(nonce: UInt32): AccountPrecondition {
+    let p = AccountPrecondition.ignoreAll();
+    assertEquals(p.nonce, nonce);
+    return p;
+  },
+};
+
+type GlobalSlotPrecondition = Preconditions['validWhile'];
+const GlobalSlotPrecondition = {
+  ignoreAll(): GlobalSlotPrecondition {
+    return ignore(uint32());
+  },
+};
+
+const Preconditions = {
+  ignoreAll(): Preconditions {
+    return {
+      account: AccountPrecondition.ignoreAll(),
+      network: NetworkPrecondition.ignoreAll(),
+      validWhile: GlobalSlotPrecondition.ignoreAll(),
+    };
+  },
 };
 
 function preconditions(accountUpdate: AccountUpdate, isSelf: boolean) {
@@ -57,8 +201,7 @@ function Network(accountUpdate: AccountUpdate): Network {
       return this.getAndRequireEquals();
     },
     requireEquals(value: UInt64) {
-      let { genesisTimestamp, slotTime } =
-        Mina.getNetworkConstants();
+      let { genesisTimestamp, slotTime } = Mina.getNetworkConstants();
       let slot = timestampToGlobalSlot(
         value,
         `Timestamp precondition unsatisfied: the timestamp can only equal numbers of the form ${genesisTimestamp} + k*${slotTime},\n` +
@@ -318,13 +461,11 @@ function getVariable<K extends LongKey, U extends FlatPreconditionValue[K]>(
 }
 
 function globalSlotToTimestamp(slot: UInt32) {
-  let { genesisTimestamp, slotTime } =
-    Mina.getNetworkConstants();
+  let { genesisTimestamp, slotTime } = Mina.getNetworkConstants();
   return UInt64.from(slot).mul(slotTime).add(genesisTimestamp);
 }
 function timestampToGlobalSlot(timestamp: UInt64, message: string) {
-  let { genesisTimestamp, slotTime } =
-    Mina.getNetworkConstants();
+  let { genesisTimestamp, slotTime } = Mina.getNetworkConstants();
   let { quotient: slot, rest } = timestamp
     .sub(genesisTimestamp)
     .divMod(slotTime);
@@ -339,8 +480,7 @@ function timestampToGlobalSlotRange(
   // we need `slotLower <= current slot <= slotUpper` to imply `tsLower <= current timestamp <= tsUpper`
   // so we have to make the range smaller -- round up `tsLower` and round down `tsUpper`
   // also, we should clamp to the UInt32 max range [0, 2**32-1]
-  let { genesisTimestamp, slotTime } =
-    Mina.getNetworkConstants();
+  let { genesisTimestamp, slotTime } = Mina.getNetworkConstants();
   let tsLowerInt = Int64.from(tsLower)
     .sub(genesisTimestamp)
     .add(slotTime)
@@ -452,7 +592,6 @@ const preconditionContexts = new WeakMap<AccountUpdate, PreconditionContext>();
 
 // exported types
 
-type NetworkPrecondition = Preconditions['network'];
 type NetworkValue = PreconditionBaseTypes<NetworkPrecondition>;
 type RawNetwork = PreconditionClassType<NetworkPrecondition>;
 type Network = RawNetwork & {
@@ -461,9 +600,9 @@ type Network = RawNetwork & {
 
 // TODO: should we add account.state?
 // then can just use circuitArray(Field, 8) as the type
-type AccountPrecondition = Omit<Preconditions['account'], 'state'>;
-type AccountValue = PreconditionBaseTypes<AccountPrecondition>;
-type Account = PreconditionClassType<AccountPrecondition> & Update;
+type AccountPreconditionNoState = Omit<Preconditions['account'], 'state'>;
+type AccountValue = PreconditionBaseTypes<AccountPreconditionNoState>;
+type Account = PreconditionClassType<AccountPreconditionNoState> & Update;
 
 type CurrentSlotPrecondition = Preconditions['validWhile'];
 type CurrentSlot = {
@@ -552,7 +691,7 @@ type PreconditionFlatEntry<T> = T extends RangeCondition<infer V>
 type FlatPreconditionValue = {
   [S in PreconditionFlatEntry<NetworkPrecondition> as `network.${S[0]}`]: S[2];
 } & {
-  [S in PreconditionFlatEntry<AccountPrecondition> as `account.${S[0]}`]: S[2];
+  [S in PreconditionFlatEntry<AccountPreconditionNoState> as `account.${S[0]}`]: S[2];
 } & { validWhile: PreconditionFlatEntry<CurrentSlotPrecondition>[2] };
 
 type LongKey = keyof FlatPreconditionValue;

--- a/src/lib/zkapp.ts
+++ b/src/lib/zkapp.ts
@@ -58,8 +58,8 @@ import {
   snarkContext,
 } from './provable-context.js';
 import { Cache } from './proof-system/cache.js';
-import { SmartContractBase } from './mina/smart-contract-base.js';
 import { assert } from './gadgets/common.js';
+import { SmartContractBase } from './mina/smart-contract-base.js';
 
 // external API
 export {

--- a/src/lib/zkapp.ts
+++ b/src/lib/zkapp.ts
@@ -16,6 +16,8 @@ import {
   ZkappPublicInput,
   ZkappStateLength,
   SmartContractContext,
+  LazyProof,
+  CallForest,
 } from './account_update.js';
 import {
   cloneCircuitValue,
@@ -56,6 +58,8 @@ import {
   snarkContext,
 } from './provable-context.js';
 import { Cache } from './proof-system/cache.js';
+import { SmartContractBase } from './mina/smart-contract-base.js';
+import { assert } from './gadgets/common.js';
 
 // external API
 export {
@@ -209,7 +213,7 @@ function wrapMethod(
               blindingValue
             );
             accountUpdate.body.callData = Poseidon.hash(callDataFields);
-            Authorization.setProofAuthorizationKind(accountUpdate);
+            ProofAuthorization.setKind(accountUpdate);
 
             // TODO: currently commented out, but could come back in some form when we add caller to the public input
             // // compute `caller` field from `isDelegateCall` and a context determined by the transaction
@@ -331,7 +335,7 @@ function wrapMethod(
           accountUpdate.body.callData = Poseidon.hash(callDataFields);
 
           if (!Authorization.hasAny(accountUpdate)) {
-            Authorization.setLazyProof(
+            ProofAuthorization.setLazyProof(
               accountUpdate,
               {
                 methodName: methodIntf.methodName,
@@ -425,7 +429,7 @@ function wrapMethod(
         accountUpdate.body.callData = hashConstant(callDataFields);
 
         if (!Authorization.hasAny(accountUpdate)) {
-          Authorization.setLazyProof(
+          ProofAuthorization.setLazyProof(
             accountUpdate,
             {
               methodName: methodIntf.methodName,
@@ -597,7 +601,7 @@ class Callback<Result> extends GenericArgument {
  * ```
  *
  */
-class SmartContract {
+class SmartContract extends SmartContractBase {
   address: PublicKey;
   tokenId: Field;
 
@@ -635,6 +639,7 @@ class SmartContract {
   }
 
   constructor(address: PublicKey, tokenId?: Field) {
+    super();
     this.address = address;
     this.tokenId = tokenId ?? TokenId.default;
     Object.defineProperty(this, 'reducer', {
@@ -1557,6 +1562,57 @@ const Reducer: (<
   'initialActionState',
   { get: Actions.emptyActionState }
 ) as any;
+
+const ProofAuthorization = {
+  setKind({ body, id }: AccountUpdate, priorAccountUpdates?: AccountUpdate[]) {
+    body.authorizationKind.isSigned = Bool(false);
+    body.authorizationKind.isProved = Bool(true);
+    let hash = Provable.witness(Field, () => {
+      let proverData = zkAppProver.getData();
+      let isProver = proverData !== undefined;
+      assert(
+        isProver || priorAccountUpdates !== undefined,
+        'Called `setProofAuthorizationKind()` outside the prover without passing in `priorAccountUpdates`.'
+      );
+      let myAccountUpdateId = isProver ? proverData.accountUpdate.id : id;
+      priorAccountUpdates ??= proverData.transaction.accountUpdates;
+      priorAccountUpdates = priorAccountUpdates.filter(
+        (a) => a.id !== myAccountUpdateId
+      );
+      let priorAccountUpdatesFlat = CallForest.toFlatList(
+        priorAccountUpdates,
+        false
+      );
+      let accountUpdate = [...priorAccountUpdatesFlat]
+        .reverse()
+        .find((body_) =>
+          body_.update.verificationKey.isSome
+            .and(body_.tokenId.equals(body.tokenId))
+            .and(body_.publicKey.equals(body.publicKey))
+            .toBoolean()
+        );
+      if (accountUpdate !== undefined) {
+        return accountUpdate.body.update.verificationKey.value.hash;
+      }
+      try {
+        let account = Mina.getAccount(body.publicKey, body.tokenId);
+        return account.zkapp?.verificationKey?.hash ?? Field(0);
+      } catch {
+        return Field(0);
+      }
+    });
+    body.authorizationKind.verificationKeyHash = hash;
+  },
+  setLazyProof(
+    accountUpdate: AccountUpdate,
+    proof: Omit<LazyProof, 'kind'>,
+    priorAccountUpdates: AccountUpdate[]
+  ) {
+    this.setKind(accountUpdate, priorAccountUpdates);
+    accountUpdate.authorization = {};
+    accountUpdate.lazyAuthorization = { ...proof, kind: 'lazy-proof' };
+  },
+};
 
 /**
  * this is useful to debug a very common error: when the consistency check between


### PR DESCRIPTION
On `main`, there was a knot of import cycles between the different files involved in transaction construction:
* `account_update.ts` depended on `zkapp.ts`, `mina.ts` and `precondition.ts`, all of which in turn depended on `account_update.ts`
* `zkapp.ts` and `mina.ts` depended on each other
* `precondition.ts` depended on `mina.ts` which depended on `precondition.ts` indirectly via `account_update.ts`

This PR resolves all of the above import cycles and achieves a clean import graph:
```
zkapp.ts <-- mina.ts <-- account_update.ts <-- precondition.ts
```
(where the arrow means "direction of import")

This is done by
* Moving the "current Mina instance" from `mina.ts` to a lower-level module
* Moving the global transaction context to a lower-level module
* Introducing a base class for `SmartContract` which lives in a lower level module
