### PR TITLE
fix(docs): Add backtick annotations to generic type comments

### DIFF
--- a/src/lib/gadgets/foreign-field.ts
+++ b/src/lib/gadgets/foreign-field.ts
@@ -464,7 +464,7 @@ const Field3 = {
   },
 
   /**
-   * Provable<T> interface for `Field3 = [Field, Field, Field]`.
+   * `Provable<T>` interface for `Field3 = [Field, Field, Field]`.
    *
    * Note: Witnessing this creates a plain tuple of field elements without any implicit
    * range checks.

--- a/src/lib/provable-types/packed.ts
+++ b/src/lib/provable-types/packed.ts
@@ -13,7 +13,7 @@ import { fields, modifiedField } from './fields.js';
 export { Packed, Hashed };
 
 /**
- * Packed<T> is a "packed" representation of any type T.
+ * `Packed<T>` is a "packed" representation of any type `T`.
  *
  * "Packed" means that field elements which take up fewer than 254 bits are packed together into
  * as few field elements as possible.
@@ -141,7 +141,7 @@ function countFields(input: HashInput) {
 }
 
 /**
- * Hashed<T> represents a type T by its hash.
+ * `Hashed<T>` represents a type `T` by its hash.
  *
  * Since a hash is only a single field element, this can be more efficient in provable code
  * where the number of constraints depends on the number of field elements per value.


### PR DESCRIPTION
Without the backtick annotations, the API reference docs are broken due to an error in how the HTML is rendered. This fixes the docs API reference to properly display