### PR TITLE
Cleanups for mina-signer

### DIFF
--- a/src/mina-signer/src/rosetta.ts
+++ b/src/mina-signer/src/rosetta.ts
@@ -27,12 +27,13 @@ function fieldToHex<T extends Field | Scalar>(
 ) {
   let bytes = binable.toBytes(x);
   // set highest bit (which is empty)
-  bytes[bytes.length - 1] &= Number(paddingBit) << 7;
-  // map each byte to a hex string of length 2
+  bytes[bytes.length - 1] |= Number(paddingBit) << 7;
+  // map each byte to a 0-padded hex string of length 2
   return bytes
-    .map((byte) => byte.toString(16).split('').reverse().join(''))
+    .map((byte) => byte.toString(16).padStart(2, '0').split('').reverse().join(''))
     .join('');
 }
+
 function fieldFromHex<T extends Field | Scalar>(
   binable: Binable<T>,
   hex: string

--- a/src/mina-signer/tests/client.test.ts
+++ b/src/mina-signer/tests/client.test.ts
@@ -1,4 +1,4 @@
-import Client from '../dist/node/mina-signer/MinaSigner.js';
+import Client from '../../../dist/node/mina-signer/MinaSigner.js';
 
 describe('Client Class Initialization', () => {
   let client;

--- a/src/mina-signer/tests/keypair.test.ts
+++ b/src/mina-signer/tests/keypair.test.ts
@@ -1,4 +1,4 @@
-import Client from '../dist/node/mina-signer/MinaSigner.js';
+import Client from '../../../dist/node/mina-signer/MinaSigner.js';
 
 describe('Keypair', () => {
   let client: Client;

--- a/src/mina-signer/tests/message.test.ts
+++ b/src/mina-signer/tests/message.test.ts
@@ -1,5 +1,5 @@
-import Client from '../dist/node/mina-signer/MinaSigner.js';
-import type { PrivateKey } from '../dist/node/mina-signer/src/TSTypes.js';
+import Client from '../../../dist/node/mina-signer/MinaSigner.js';
+import type { PrivateKey } from '../../../dist/node/mina-signer/src/TSTypes.js';
 
 describe('Message', () => {
   describe('Mainnet network', () => {

--- a/src/mina-signer/tests/payment.test.ts
+++ b/src/mina-signer/tests/payment.test.ts
@@ -1,5 +1,5 @@
-import Client from '../dist/node/mina-signer/MinaSigner.js';
-import type { Keypair } from '../dist/node/mina-signer/src/TSTypes.js';
+import Client from '../../../dist/node/mina-signer/MinaSigner.js';
+import type { Keypair } from '../../../dist/node/mina-signer/src/TSTypes.js';
 
 describe('Payment', () => {
   describe('Mainnet network', () => {

--- a/src/mina-signer/tests/rosetta.test.ts
+++ b/src/mina-signer/tests/rosetta.test.ts
@@ -1,4 +1,4 @@
-import Client from '../dist/node/mina-signer/MinaSigner.js';
+import Client from '../../../dist/node/mina-signer/MinaSigner.js';
 
 describe('Rosetta', () => {
   let client: Client;

--- a/src/mina-signer/tests/stake-delegation.test.ts
+++ b/src/mina-signer/tests/stake-delegation.test.ts
@@ -1,5 +1,5 @@
-import Client from '../dist/node/mina-signer/MinaSigner.js';
-import type { Keypair } from '../dist/node/mina-signer/src/TSTypes.js';
+import Client from '../../../dist/node/mina-signer/MinaSigner.js';
+import type { Keypair } from '../../../dist/node/mina-signer/src/TSTypes.js';
 
 describe('Stake Delegation', () => {
   describe('Mainnet network', () => {


### PR DESCRIPTION
1:

*`.test.ts` files in ..`/mina-signer/tests/` would not run with their paths to the `dist` directory as-is. I noticed this when running `npm run test`. Diving in we can see the bash script just sets the NODE_OPTIONS var and executes `npx just past/to/foo.test.ts` while the `/lib/` tests all run and pass none of the tests in `/mina-signer` will compile.

you can quickly test this with ` NODE_OPTIONS=--experimental-vm-modules npx jest ./src/mina-signer/tests/client.test.ts`. It will fail in main. this fixes the relative path to correctly find the directory

there are many ways you could find that path, but this solution stays the closest to what was already in place.

this also will clear the way for my work on #1406 as i will need to write and run a few tests there

2:

this fixes some issues with `fieldToHex` that were pointed out by @mitschabaude in #1406. I placed them here as it fit with the _fixup_ theme.