### PR TITLE
Remove experimental callback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
   - Adds `AccountUpdateTree` and `AccountUpdateForest`, new classes that represent a layout of account updates explicitly
   - Both of the new types are now accepted as inputs to `approve()`
   - `accountUpdate.extractTree()` to obtain the tree associated with an account update in the current transaction context.
+- Remove `Experimental.Callback` API https://github.com/o1-labs/o1js/pull/1430
 
 ### Added
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -110,18 +110,12 @@ export { ZkProgram };
 export { Crypto } from './lib/crypto.js';
 
 // experimental APIs
-import { Callback } from './lib/zkapp.js';
-import { createChildAccountUpdate } from './lib/account_update.js';
 import { memoizeWitness } from './lib/provable.js';
 export { Experimental };
 
 const Experimental_ = {
-  Callback,
-  createChildAccountUpdate,
   memoizeWitness,
 };
-
-type Callback_<Result> = Callback<Result>;
 
 /**
  * This module exposes APIs that are unstable, in the sense that the API surface is expected to change.
@@ -132,10 +126,7 @@ namespace Experimental {
    * The old `Experimental.ZkProgram` API has been deprecated in favor of the new `ZkProgram` top-level import.
    */
   export let ZkProgram = ExperimentalZkProgram;
-  export let createChildAccountUpdate = Experimental_.createChildAccountUpdate;
   export let memoizeWitness = Experimental_.memoizeWitness;
-  export let Callback = Experimental_.Callback;
-  export type Callback<Result> = Callback_<Result>;
 }
 
 Error.stackTraceLimit = 100000;

--- a/src/lib/account_update.ts
+++ b/src/lib/account_update.ts
@@ -91,7 +91,6 @@ export {
   TokenId,
   Token,
   CallForest,
-  createChildAccountUpdate,
   zkAppProver,
   dummySignature,
   LazyProof,
@@ -1886,18 +1885,6 @@ class AccountUpdateLayout {
   toConstantInPlace() {
     this.root.children.toConstantInPlace();
   }
-}
-
-// TODO remove
-function createChildAccountUpdate(
-  parent: AccountUpdate,
-  childAddress: PublicKey,
-  tokenId?: Field
-) {
-  let child = AccountUpdate.defaultAccountUpdate(childAddress, tokenId);
-  child.body.callDepth = parent.body.callDepth + 1;
-  AccountUpdate.unlink(child);
-  return child;
 }
 
 // authorization

--- a/src/lib/circuit_value.ts
+++ b/src/lib/circuit_value.ts
@@ -626,10 +626,6 @@ function cloneCircuitValue<T>(obj: T): T {
   // primitive JS types and functions aren't cloned
   if (typeof obj !== 'object' || obj === null) return obj;
 
-  // HACK: callbacks
-  if (obj.constructor?.name.includes('GenericArgument')) {
-    return obj;
-  }
   // classes that define clone() are cloned using that method
   if (obj.constructor !== undefined && 'clone' in obj.constructor) {
     return (obj as any).constructor.clone(obj);

--- a/src/lib/circuit_value.ts
+++ b/src/lib/circuit_value.ts
@@ -627,10 +627,7 @@ function cloneCircuitValue<T>(obj: T): T {
   if (typeof obj !== 'object' || obj === null) return obj;
 
   // HACK: callbacks
-  if (
-    obj.constructor?.name.includes('GenericArgument') ||
-    obj.constructor?.name.includes('Callback')
-  ) {
+  if (obj.constructor?.name.includes('GenericArgument')) {
     return obj;
   }
   // classes that define clone() are cloned using that method

--- a/src/lib/mina/token/token-contract.ts
+++ b/src/lib/mina/token/token-contract.ts
@@ -108,7 +108,7 @@ abstract class TokenContract extends SmartContract {
   transfer(
     from: PublicKey | AccountUpdate,
     to: PublicKey | AccountUpdate,
-    amount: UInt64
+    amount: UInt64 | number | bigint
   ) {
     // coerce the inputs to AccountUpdate and pass to `approveUpdates()`
     let tokenId = this.token.id;

--- a/src/lib/proof_system.ts
+++ b/src/lib/proof_system.ts
@@ -58,7 +58,6 @@ export {
   sortMethodArguments,
   getPreviousProofsForProver,
   MethodInterface,
-  GenericArgument,
   picklesRuleFromFunction,
   compileProgram,
   analyzeMethod,
@@ -504,8 +503,7 @@ function sortMethodArguments(
 ): MethodInterface {
   let witnessArgs: Provable<unknown>[] = [];
   let proofArgs: Subclass<typeof Proof>[] = [];
-  let allArgs: { type: 'proof' | 'witness' | 'generic'; index: number }[] = [];
-  let genericArgs: Subclass<typeof GenericArgument>[] = [];
+  let allArgs: { type: 'proof' | 'witness'; index: number }[] = [];
   for (let i = 0; i < privateInputs.length; i++) {
     let privateInput = privateInputs[i];
     if (isProof(privateInput)) {
@@ -527,9 +525,6 @@ function sortMethodArguments(
     } else if (isAsFields((privateInput as any)?.provable)) {
       allArgs.push({ type: 'witness', index: witnessArgs.length });
       witnessArgs.push((privateInput as any).provable);
-    } else if (isGeneric(privateInput)) {
-      allArgs.push({ type: 'generic', index: genericArgs.length });
-      genericArgs.push(privateInput);
     } else {
       throw Error(
         `Argument ${
@@ -544,13 +539,7 @@ function sortMethodArguments(
         `Suggestion: You can merge more than two proofs by merging two at a time in a binary tree.`
     );
   }
-  return {
-    methodName,
-    witnessArgs,
-    proofArgs,
-    allArgs,
-    genericArgs,
-  };
+  return { methodName, witnessArgs, proofArgs, allArgs };
 }
 
 function isAsFields(
@@ -572,22 +561,6 @@ function isProof(type: unknown): type is typeof Proof {
   );
 }
 
-class GenericArgument {
-  isEmpty: boolean;
-  constructor(isEmpty = false) {
-    this.isEmpty = isEmpty;
-  }
-}
-let emptyGeneric = () => new GenericArgument(true);
-
-function isGeneric(type: unknown): type is typeof GenericArgument {
-  // the second case covers subclasses
-  return (
-    type === GenericArgument ||
-    (typeof type === 'function' && type.prototype instanceof GenericArgument)
-  );
-}
-
 function getPreviousProofsForProver(
   methodArgs: any[],
   { allArgs }: MethodInterface
@@ -605,11 +578,10 @@ function getPreviousProofsForProver(
 type MethodInterface = {
   methodName: string;
   // TODO: unify types of arguments
-  // "circuit types" should be flexible enough to encompass proofs and callback arguments
+  // proofs should just be `Provable<T>` as well
   witnessArgs: Provable<unknown>[];
   proofArgs: Subclass<typeof Proof>[];
-  genericArgs: Subclass<typeof GenericArgument>[];
-  allArgs: { type: 'witness' | 'proof' | 'generic'; index: number }[];
+  allArgs: { type: 'witness' | 'proof'; index: number }[];
   returnType?: Provable<any>;
 };
 
@@ -778,8 +750,6 @@ function picklesRuleFromFunction(
         let input = toFieldVars(type.input, publicInput);
         let output = toFieldVars(type.output, publicOutput);
         previousStatements.push(MlPair(input, output));
-      } else if (arg.type === 'generic') {
-        finalArgs[i] = argsWithoutPublicInput?.[i] ?? emptyGeneric();
       }
     }
     let result: any;
@@ -847,8 +817,6 @@ function synthesizeMethodArguments(
       let publicInput = empty(type.input);
       let publicOutput = empty(type.output);
       args.push(new Proof({ publicInput, publicOutput, proof: undefined }));
-    } else if (arg.type === 'generic') {
-      args.push(emptyGeneric());
     }
   }
   return args;
@@ -872,8 +840,6 @@ function methodArgumentsToConstant(
       constArgs.push(
         new Proof({ publicInput, publicOutput, proof: arg.proof })
       );
-    } else if (type === 'generic') {
-      constArgs.push(arg);
     }
   }
   return constArgs;
@@ -901,8 +867,6 @@ function methodArgumentTypesAndValues(
       let type = provablePure({ input: types.input, output: types.output });
       let value = { input: proof.publicInput, output: proof.publicOutput };
       typesAndValues.push({ type, value });
-    } else if (type === 'generic') {
-      typesAndValues.push({ type: Generic, value: arg });
     }
   }
   return typesAndValues;

--- a/src/lib/proof_system.unit-test.ts
+++ b/src/lib/proof_system.unit-test.ts
@@ -49,7 +49,6 @@ it('pickles rule creation', async () => {
       { type: 'proof', index: 0 },
       { type: 'witness', index: 0 },
     ],
-    genericArgs: [],
   });
 
   // store compiled tag

--- a/src/lib/zkapp.ts
+++ b/src/lib/zkapp.ts
@@ -38,7 +38,6 @@ import {
   compileProgram,
   Empty,
   emptyValue,
-  GenericArgument,
   getPreviousProofsForProver,
   isAsFields,
   methodArgumentsToConstant,


### PR DESCRIPTION
This follows up with removing `Experiment.Callback` and `Experimental.createChildAccountUpdate` as planned in #1402 

closes https://github.com/o1-labs/o1js/issues/1347