### PR TITLE
Export improvements.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "o1js",
-  "version": "0.16.1",
+  "version": "0.16.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "o1js",
-      "version": "0.16.1",
+      "version": "0.16.2",
       "license": "Apache-2.0",
       "dependencies": {
         "blakejs": "1.2.1",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "o1js",
   "description": "TypeScript framework for zk-SNARKs and zkApps",
-  "version": "0.16.1",
+  "version": "0.16.2",
   "license": "Apache-2.0",
   "homepage": "https://github.com/o1-labs/o1js/",
   "keywords": [

--- a/src/index.ts
+++ b/src/index.ts
@@ -109,6 +109,8 @@ export { ZkProgram };
 
 export { Crypto } from './lib/crypto.js';
 
+export type { NetworkId } from './mina-signer/mina-signer.js';
+
 // experimental APIs
 import { memoizeWitness } from './lib/provable.js';
 export { Experimental };

--- a/src/mina-signer/index.cjs
+++ b/src/mina-signer/index.cjs
@@ -3,3 +3,4 @@
 const Client = require('./mina-signer.js');
 
 module.exports = Client.default;
+module.exports.Client = Client.default;

--- a/src/mina-signer/index.cjs
+++ b/src/mina-signer/index.cjs
@@ -1,5 +1,5 @@
 // this file is a wrapper for supporting commonjs imports
 
-let Client = require('./mina-signer.js');
+const Client = require('./mina-signer.js');
 
 module.exports = Client.default;

--- a/src/mina-signer/index.d.ts
+++ b/src/mina-signer/index.d.ts
@@ -1,7 +1,6 @@
 // this file is a wrapper for supporting types in both commonjs and esm projects
 
-import Client from './mina-signer.ts';
-import { NetworkId } from './src/types.ts';
+import Client, { type NetworkId } from './mina-signer.ts';
 
 export default Client;
-export { Client, NetworkId };
+export { Client, type NetworkId };

--- a/src/mina-signer/mina-signer.ts
+++ b/src/mina-signer/mina-signer.ts
@@ -34,7 +34,7 @@ import {
 import { sign, Signature, verify } from './src/signature.js';
 import { createNullifier } from './src/nullifier.js';
 
-export { Client as default, type NetworkId };
+export { Client, Client as default, type NetworkId };
 
 const defaultValidUntil = '4294967295';
 

--- a/src/mina-signer/mina-signer.ts
+++ b/src/mina-signer/mina-signer.ts
@@ -34,7 +34,7 @@ import {
 import { sign, Signature, verify } from './src/signature.js';
 import { createNullifier } from './src/nullifier.js';
 
-export { Client as default };
+export { Client as default, type NetworkId };
 
 const defaultValidUntil = '4294967295';
 

--- a/src/mina-signer/package-lock.json
+++ b/src/mina-signer/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "mina-signer",
-  "version": "3.0.2",
+  "version": "3.0.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "mina-signer",
-      "version": "3.0.2",
+      "version": "3.0.3",
       "license": "Apache-2.0",
       "dependencies": {
         "blakejs": "^1.2.1",

--- a/src/mina-signer/package.json
+++ b/src/mina-signer/package.json
@@ -1,7 +1,7 @@
 {
   "name": "mina-signer",
   "description": "Node API for signing transactions on various networks for Mina Protocol",
-  "version": "3.0.2",
+  "version": "3.0.3",
   "type": "module",
   "scripts": {
     "build": "tsc -p ../../tsconfig.mina-signer.json",


### PR DESCRIPTION
- Mina signer's `Client` should now work with default or named imports for both CJS and ESM projects.
- `o1js` also exports the `NetworkId`.