### PR TITLE
Enable custom network signing 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,6 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 ### Added
 
 - Support for custom network identifiers other than `mainnet` or `testnet` https://github.com/o1-labs/o1js/pull/1444
-  - New optional argument `networkId?: string` to `Signature.create()` and `Signature.verify()` to reflect support for custom network identifiers.
 
 ## [0.16.1](https://github.com/o1-labs/o1js/compare/834a44002...3b5f7c7)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 ### Added
 
 - Support for custom network identifiers other than `mainnet` or `testnet` https://github.com/o1-labs/o1js/pull/1444
-  - New optional argument `networkId?: string` toin `Signature.create()` and `Signature.verify()` to reflect support for custom network identifiers.
+  - New optional argument `networkId?: string` to `Signature.create()` and `Signature.verify()` to reflect support for custom network identifiers.
 
 ## [0.16.1](https://github.com/o1-labs/o1js/compare/834a44002...3b5f7c7)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,11 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased](https://github.com/o1-labs/o1js/compare/3b5f7c7...HEAD)
 
+### Added
+
+- Support for custom network identifiers other than `mainnet` or `testnet` https://github.com/o1-labs/o1js/pull/1444
+  - New optional argument `networkId?: string` in `Signature.create(privKey: PrivateKey, msg: Field[], networkId?: string)` to reflect support for custom network identifiers.
+
 ## [0.16.1](https://github.com/o1-labs/o1js/compare/834a44002...3b5f7c7)
 
 ### Breaking changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 ### Added
 
 - Support for custom network identifiers other than `mainnet` or `testnet` https://github.com/o1-labs/o1js/pull/1444
-  - New optional argument `networkId?: string` in `Signature.create(privKey: PrivateKey, msg: Field[], networkId?: string)` to reflect support for custom network identifiers.
+  - New optional argument `networkId?: string` toin `Signature.create()` and `Signature.verify()` to reflect support for custom network identifiers.
 
 ## [0.16.1](https://github.com/o1-labs/o1js/compare/834a44002...3b5f7c7)
 

--- a/src/lib/account-update.ts
+++ b/src/lib/account-update.ts
@@ -69,6 +69,7 @@ import {
 } from './mina/smart-contract-context.js';
 import { assert } from './util/assert.js';
 import { RandomId } from './provable-types/auxiliary.js';
+import { NetworkId } from '../mina-signer/src/types.js';
 
 // external API
 export {
@@ -1028,7 +1029,7 @@ class AccountUpdate implements Types.AccountUpdate {
       return Field(
         Test.hashFromJson.accountUpdate(
           JSON.stringify(json),
-          typeof networkId === 'string' ? networkId : networkId.custom
+          NetworkId.toString(networkId)
         )
       );
     }

--- a/src/lib/account-update.ts
+++ b/src/lib/account-update.ts
@@ -41,7 +41,11 @@ import {
   protocolVersions,
 } from '../bindings/crypto/constants.js';
 import { MlArray } from './ml/base.js';
-import { Signature, signFieldElement } from '../mina-signer/src/signature.js';
+import {
+  Signature,
+  signFieldElement,
+  zkAppBodyPrefix,
+} from '../mina-signer/src/signature.js';
 import { MlFieldConstArray } from './ml/fields.js';
 import {
   accountUpdatesToCallForest,
@@ -102,32 +106,6 @@ export {
 
 const TransactionVersion = {
   current: () => UInt32.from(protocolVersions.txnVersion),
-};
-
-// TODO FIX ME PLS
-
-const createCustomBodyPrefix = (prefix: string) => {
-  const maxLength = 20;
-  const paddingChar = '*';
-  let length = prefix.length;
-
-  if (length <= maxLength) {
-    let diff = maxLength - length;
-    return prefix + paddingChar.repeat(diff);
-  } else {
-    return prefix.substring(0, maxLength);
-  }
-};
-
-const zkAppBodyPrefix = (network: string) => {
-  switch (network) {
-    case 'mainnet':
-      return prefixes.zkappBodyMainnet;
-    case 'testnet':
-      return prefixes.zkappBodyTestnet;
-    default:
-      return createCustomBodyPrefix(network + 'ZkappBody');
-  }
 };
 
 type ZkappProverData = {

--- a/src/lib/account-update.ts
+++ b/src/lib/account-update.ts
@@ -1019,18 +1019,16 @@ class AccountUpdate implements Types.AccountUpdate {
     // consistency between JS & OCaml hashing on *every single account update
     // proof* we create. It will give us 100% confidence that the two
     // implementations are equivalent, and catch regressions quickly
+    let networkId = activeInstance.getNetworkId();
     if (Provable.inCheckedComputation()) {
       let input = Types.AccountUpdate.toInput(this);
-      return hashWithPrefix(
-        zkAppBodyPrefix(activeInstance.getNetworkId()),
-        packToFields(input)
-      );
+      return hashWithPrefix(zkAppBodyPrefix(networkId), packToFields(input));
     } else {
       let json = Types.AccountUpdate.toJSON(this);
       return Field(
         Test.hashFromJson.accountUpdate(
           JSON.stringify(json),
-          activeInstance.getNetworkId()
+          typeof networkId === 'string' ? networkId : networkId.custom
         )
       );
     }

--- a/src/lib/account-update.ts
+++ b/src/lib/account-update.ts
@@ -1020,16 +1020,18 @@ class AccountUpdate implements Types.AccountUpdate {
     // consistency between JS & OCaml hashing on *every single account update
     // proof* we create. It will give us 100% confidence that the two
     // implementations are equivalent, and catch regressions quickly
-    let networkId = activeInstance.getNetworkId();
     if (Provable.inCheckedComputation()) {
       let input = Types.AccountUpdate.toInput(this);
-      return hashWithPrefix(zkAppBodyPrefix(networkId), packToFields(input));
+      return hashWithPrefix(
+        zkAppBodyPrefix(activeInstance.getNetworkId()),
+        packToFields(input)
+      );
     } else {
       let json = Types.AccountUpdate.toJSON(this);
       return Field(
         Test.hashFromJson.accountUpdate(
           JSON.stringify(json),
-          NetworkId.toString(networkId)
+          NetworkId.toString(activeInstance.getNetworkId())
         )
       );
     }

--- a/src/lib/account-update.ts
+++ b/src/lib/account-update.ts
@@ -65,7 +65,6 @@ import {
 } from './mina/smart-contract-context.js';
 import { assert } from './util/assert.js';
 import { RandomId } from './provable-types/auxiliary.js';
-import { max } from 'src/bindings/crypto/bigint-helpers.js';
 
 // external API
 export {

--- a/src/lib/signature.ts
+++ b/src/lib/signature.ts
@@ -236,11 +236,7 @@ class Signature extends CircuitValue {
    * Signs a message using a {@link PrivateKey}.
    * @returns a {@link Signature}
    */
-  static create(
-    privKey: PrivateKey,
-    msg: Field[],
-    networkId?: string
-  ): Signature {
+  static create(privKey: PrivateKey, msg: Field[]): Signature {
     const publicKey = PublicKey.fromPrivateKey(privKey).toGroup();
     const d = privKey.s;
     // we chose an arbitrary prefix for the signature, and it happened to be 'testnet'
@@ -271,7 +267,7 @@ class Signature extends CircuitValue {
    * Verifies the {@link Signature} using a message and the corresponding {@link PublicKey}.
    * @returns a {@link Bool}
    */
-  verify(publicKey: PublicKey, msg: Field[], networkId?: string): Bool {
+  verify(publicKey: PublicKey, msg: Field[]): Bool {
     const point = publicKey.toGroup();
     // we chose an arbitrary prefix for the signature, and it happened to be 'testnet'
     // there's no consequences in practice and the signatures can be used with any network

--- a/src/lib/signature.ts
+++ b/src/lib/signature.ts
@@ -235,7 +235,11 @@ class Signature extends CircuitValue {
    * Signs a message using a {@link PrivateKey}.
    * @returns a {@link Signature}
    */
-  static create(privKey: PrivateKey, msg: Field[]): Signature {
+  static create(
+    privKey: PrivateKey,
+    msg: Field[],
+    networkId?: string
+  ): Signature {
     const publicKey = PublicKey.fromPrivateKey(privKey).toGroup();
     const d = privKey.s;
     const kPrime = Scalar.fromBigInt(
@@ -243,7 +247,7 @@ class Signature extends CircuitValue {
         { fields: msg.map((f) => f.toBigInt()) },
         { x: publicKey.x.toBigInt(), y: publicKey.y.toBigInt() },
         BigInt(d.toJSON()),
-        'testnet'
+        networkId ?? 'testnet'
       )
     );
     let { x: r, y: ry } = Group.generator.scale(kPrime);

--- a/src/lib/signature.ts
+++ b/src/lib/signature.ts
@@ -4,6 +4,7 @@ import { hashWithPrefix } from './hash.js';
 import {
   deriveNonce,
   Signature as SignatureBigint,
+  signaturePrefix,
 } from '../mina-signer/src/signature.js';
 import { Bool as BoolBigint } from '../provable/field-bigint.js';
 import {
@@ -253,7 +254,7 @@ class Signature extends CircuitValue {
     let { x: r, y: ry } = Group.generator.scale(kPrime);
     const k = ry.toBits()[0].toBoolean() ? kPrime.neg() : kPrime;
     let h = hashWithPrefix(
-      prefixes.signatureTestnet,
+      signaturePrefix(networkId ?? 'testnet'),
       msg.concat([publicKey.x, publicKey.y, r])
     );
     // TODO: Scalar.fromBits interprets the input as a "shifted scalar"
@@ -267,10 +268,10 @@ class Signature extends CircuitValue {
    * Verifies the {@link Signature} using a message and the corresponding {@link PublicKey}.
    * @returns a {@link Bool}
    */
-  verify(publicKey: PublicKey, msg: Field[]): Bool {
+  verify(publicKey: PublicKey, msg: Field[], networkId?: string): Bool {
     const point = publicKey.toGroup();
     let h = hashWithPrefix(
-      prefixes.signatureTestnet,
+      signaturePrefix(networkId ?? 'testnet'),
       msg.concat([point.x, point.y, this.r])
     );
     // TODO: Scalar.fromBits interprets the input as a "shifted scalar"

--- a/src/lib/signature.ts
+++ b/src/lib/signature.ts
@@ -243,18 +243,21 @@ class Signature extends CircuitValue {
   ): Signature {
     const publicKey = PublicKey.fromPrivateKey(privKey).toGroup();
     const d = privKey.s;
+    // we chose an arbitrary prefix for the signature, and it happened to be 'testnet'
+    // there's no consequences in practice and the signatures can be used with any network
+    // if there needs to be a custom nonce, include it in the message itself
     const kPrime = Scalar.fromBigInt(
       deriveNonce(
         { fields: msg.map((f) => f.toBigInt()) },
         { x: publicKey.x.toBigInt(), y: publicKey.y.toBigInt() },
         BigInt(d.toJSON()),
-        networkId ?? 'testnet'
+        'testnet'
       )
     );
     let { x: r, y: ry } = Group.generator.scale(kPrime);
     const k = ry.toBits()[0].toBoolean() ? kPrime.neg() : kPrime;
     let h = hashWithPrefix(
-      signaturePrefix(networkId ?? 'testnet'),
+      signaturePrefix('testnet'),
       msg.concat([publicKey.x, publicKey.y, r])
     );
     // TODO: Scalar.fromBits interprets the input as a "shifted scalar"
@@ -270,8 +273,11 @@ class Signature extends CircuitValue {
    */
   verify(publicKey: PublicKey, msg: Field[], networkId?: string): Bool {
     const point = publicKey.toGroup();
+    // we chose an arbitrary prefix for the signature, and it happened to be 'testnet'
+    // there's no consequences in practice and the signatures can be used with any network
+    // if there needs to be a custom nonce, include it in the message itself
     let h = hashWithPrefix(
-      signaturePrefix(networkId ?? 'testnet'),
+      signaturePrefix('testnet'),
       msg.concat([point.x, point.y, this.r])
     );
     // TODO: Scalar.fromBits interprets the input as a "shifted scalar"

--- a/src/mina-signer/mina-signer.ts
+++ b/src/mina-signer/mina-signer.ts
@@ -41,13 +41,8 @@ const defaultValidUntil = '4294967295';
 class Client {
   private network: NetworkId;
 
-  constructor(options: { network: NetworkId }) {
-    if (!options?.network) {
-      throw Error('Invalid Specified Network');
-    }
-    const specifiedNetwork = options.network.toLowerCase();
-
-    this.network = specifiedNetwork;
+  constructor({ network }: { network: NetworkId }) {
+    this.network = network;
   }
 
   /**
@@ -120,13 +115,9 @@ class Client {
    * @param privateKey The private key used for signing
    * @returns The signed field elements
    */
-  signFields(
-    fields: bigint[],
-    privateKey: Json.PrivateKey,
-    network?: NetworkId
-  ): Signed<bigint[]> {
+  signFields(fields: bigint[], privateKey: Json.PrivateKey): Signed<bigint[]> {
     let privateKey_ = PrivateKey.fromBase58(privateKey);
-    let signature = sign({ fields }, privateKey_, network ?? 'testnet');
+    let signature = sign({ fields }, privateKey_, 'testnet');
     return {
       signature: Signature.toBase58(signature),
       publicKey: PublicKey.toBase58(PrivateKey.toPublicKey(privateKey_)),
@@ -141,15 +132,12 @@ class Client {
    * @returns True if the `signedFields` contains a valid signature matching
    * the fields and publicKey.
    */
-  verifyFields(
-    { data, signature, publicKey }: Signed<bigint[]>,
-    network?: NetworkId
-  ) {
+  verifyFields({ data, signature, publicKey }: Signed<bigint[]>) {
     return verify(
       Signature.fromBase58(signature),
       { fields: data },
       PublicKey.fromBase58(publicKey),
-      network ?? 'testnet'
+      'testnet'
     );
   }
 

--- a/src/mina-signer/mina-signer.ts
+++ b/src/mina-signer/mina-signer.ts
@@ -39,16 +39,14 @@ export { Client as default };
 const defaultValidUntil = '4294967295';
 
 class Client {
-  private network: NetworkId; // TODO: Rename to "networkId" for consistency with remaining codebase.
+  private network: NetworkId;
 
   constructor(options: { network: NetworkId }) {
     if (!options?.network) {
       throw Error('Invalid Specified Network');
     }
     const specifiedNetwork = options.network.toLowerCase();
-    if (specifiedNetwork !== 'mainnet' && specifiedNetwork !== 'testnet') {
-      throw Error('Invalid Specified Network');
-    }
+
     this.network = specifiedNetwork;
   }
 
@@ -122,9 +120,13 @@ class Client {
    * @param privateKey The private key used for signing
    * @returns The signed field elements
    */
-  signFields(fields: bigint[], privateKey: Json.PrivateKey): Signed<bigint[]> {
+  signFields(
+    fields: bigint[],
+    privateKey: Json.PrivateKey,
+    network?: NetworkId
+  ): Signed<bigint[]> {
     let privateKey_ = PrivateKey.fromBase58(privateKey);
-    let signature = sign({ fields }, privateKey_, 'testnet');
+    let signature = sign({ fields }, privateKey_, network ?? 'testnet');
     return {
       signature: Signature.toBase58(signature),
       publicKey: PublicKey.toBase58(PrivateKey.toPublicKey(privateKey_)),
@@ -139,12 +141,15 @@ class Client {
    * @returns True if the `signedFields` contains a valid signature matching
    * the fields and publicKey.
    */
-  verifyFields({ data, signature, publicKey }: Signed<bigint[]>) {
+  verifyFields(
+    { data, signature, publicKey }: Signed<bigint[]>,
+    network?: NetworkId
+  ) {
     return verify(
       Signature.fromBase58(signature),
       { fields: data },
       PublicKey.fromBase58(publicKey),
-      'testnet'
+      network ?? 'testnet'
     );
   }
 

--- a/src/mina-signer/src/random-transaction.ts
+++ b/src/mina-signer/src/random-transaction.ts
@@ -141,6 +141,8 @@ const RandomTransaction = {
   zkappCommand,
   zkappCommandAndFeePayerKey,
   zkappCommandJson,
-  networkId: Random.oneOf<NetworkId[]>('testnet', 'mainnet', 'other'),
+  networkId: Random.oneOf<NetworkId[]>('testnet', 'mainnet', {
+    custom: 'other',
+  }),
   accountUpdateWithCallDepth: accountUpdate,
 };

--- a/src/mina-signer/src/random-transaction.ts
+++ b/src/mina-signer/src/random-transaction.ts
@@ -141,6 +141,6 @@ const RandomTransaction = {
   zkappCommand,
   zkappCommandAndFeePayerKey,
   zkappCommandJson,
-  networkId: Random.oneOf<NetworkId[]>('testnet', 'mainnet'),
+  networkId: Random.oneOf<NetworkId[]>('testnet', 'mainnet', 'other'),
   accountUpdateWithCallDepth: accountUpdate,
 };

--- a/src/mina-signer/src/sign-legacy.unit-test.ts
+++ b/src/mina-signer/src/sign-legacy.unit-test.ts
@@ -29,7 +29,8 @@ let networks: NetworkId[] = ['testnet', 'mainnet'];
 
 for (let network of networks) {
   let i = 0;
-  let reference = signatures[network];
+  let reference =
+    signatures[typeof network === 'string' ? network : network.custom];
 
   for (let payment of payments) {
     let signature = signPayment(payment, privateKey, network);

--- a/src/mina-signer/src/sign-legacy.unit-test.ts
+++ b/src/mina-signer/src/sign-legacy.unit-test.ts
@@ -21,6 +21,7 @@ import { Field } from '../../provable/field-bigint.js';
 import { Random, test } from '../../lib/testing/property.js';
 import { RandomTransaction } from './random-transaction.js';
 import { NetworkId } from './types.js';
+import { Network } from 'src/lib/precondition.js';
 
 let { privateKey, publicKey } = keypair;
 let networks: NetworkId[] = ['testnet', 'mainnet'];
@@ -29,8 +30,7 @@ let networks: NetworkId[] = ['testnet', 'mainnet'];
 
 for (let network of networks) {
   let i = 0;
-  let reference =
-    signatures[typeof network === 'string' ? network : network.custom];
+  let reference = signatures[NetworkId.toString(network)];
 
   for (let payment of payments) {
     let signature = signPayment(payment, privateKey, network);

--- a/src/mina-signer/src/sign-legacy.unit-test.ts
+++ b/src/mina-signer/src/sign-legacy.unit-test.ts
@@ -21,7 +21,6 @@ import { Field } from '../../provable/field-bigint.js';
 import { Random, test } from '../../lib/testing/property.js';
 import { RandomTransaction } from './random-transaction.js';
 import { NetworkId } from './types.js';
-import { Network } from 'src/lib/precondition.js';
 
 let { privateKey, publicKey } = keypair;
 let networks: NetworkId[] = ['testnet', 'mainnet'];

--- a/src/mina-signer/src/sign-zkapp-command.ts
+++ b/src/mina-signer/src/sign-zkapp-command.ts
@@ -165,7 +165,6 @@ const zkAppBodyPrefix = (network: string) => {
       return prefixes.zkappBodyMainnet;
     case 'testnet':
       return prefixes.zkappBodyTestnet;
-
     default:
       return 'ZkappBody' + network;
   }

--- a/src/mina-signer/src/sign-zkapp-command.ts
+++ b/src/mina-signer/src/sign-zkapp-command.ts
@@ -15,6 +15,7 @@ import {
   Signature,
   signFieldElement,
   verifyFieldElement,
+  zkAppBodyPrefix,
 } from './signature.js';
 import { mocks } from '../../bindings/crypto/constants.js';
 import { NetworkId } from './types.js';
@@ -35,7 +36,6 @@ export {
   accountUpdateFromFeePayer,
   isCallDepthValid,
   CallForest,
-  createCustomPrefix,
 };
 
 function signZkappCommand(
@@ -159,30 +159,6 @@ function accountUpdatesToCallForest<A extends { body: { callDepth: number } }>(
   }
   return forest;
 }
-
-const createCustomPrefix = (prefix: string) => {
-  const maxLength = 20;
-  const paddingChar = '*';
-  let length = prefix.length;
-
-  if (length <= maxLength) {
-    let diff = maxLength - length;
-    return prefix + paddingChar.repeat(diff);
-  } else {
-    return prefix.substring(0, maxLength);
-  }
-};
-
-const zkAppBodyPrefix = (network: string) => {
-  switch (network) {
-    case 'mainnet':
-      return prefixes.zkappBodyMainnet;
-    case 'testnet':
-      return prefixes.zkappBodyTestnet;
-    default:
-      return createCustomPrefix(network + 'ZkappBody');
-  }
-};
 
 function accountUpdateHash(update: AccountUpdate, networkId: NetworkId) {
   assertAuthorizationKindValid(update);

--- a/src/mina-signer/src/sign-zkapp-command.ts
+++ b/src/mina-signer/src/sign-zkapp-command.ts
@@ -35,6 +35,7 @@ export {
   accountUpdateFromFeePayer,
   isCallDepthValid,
   CallForest,
+  createCustomPrefix,
 };
 
 function signZkappCommand(
@@ -159,7 +160,7 @@ function accountUpdatesToCallForest<A extends { body: { callDepth: number } }>(
   return forest;
 }
 
-const createCustomBodyPrefix = (prefix: string) => {
+const createCustomPrefix = (prefix: string) => {
   const maxLength = 20;
   const paddingChar = '*';
   let length = prefix.length;
@@ -179,7 +180,7 @@ const zkAppBodyPrefix = (network: string) => {
     case 'testnet':
       return prefixes.zkappBodyTestnet;
     default:
-      return createCustomBodyPrefix(network + 'ZkappBody');
+      return createCustomPrefix(network + 'ZkappBody');
   }
 };
 

--- a/src/mina-signer/src/sign-zkapp-command.ts
+++ b/src/mina-signer/src/sign-zkapp-command.ts
@@ -159,6 +159,19 @@ function accountUpdatesToCallForest<A extends { body: { callDepth: number } }>(
   return forest;
 }
 
+const createCustomBodyPrefix = (prefix: string) => {
+  const maxLength = 20;
+  const paddingChar = '*';
+  let length = prefix.length;
+
+  if (length <= maxLength) {
+    let diff = maxLength - length;
+    return prefix + paddingChar.repeat(diff);
+  } else {
+    return prefix.substring(0, maxLength);
+  }
+};
+
 const zkAppBodyPrefix = (network: string) => {
   switch (network) {
     case 'mainnet':
@@ -166,7 +179,7 @@ const zkAppBodyPrefix = (network: string) => {
     case 'testnet':
       return prefixes.zkappBodyTestnet;
     default:
-      return 'ZkappBody' + network;
+      return createCustomBodyPrefix(network + 'ZkappBody');
   }
 };
 

--- a/src/mina-signer/src/sign-zkapp-command.unit-test.ts
+++ b/src/mina-signer/src/sign-zkapp-command.unit-test.ts
@@ -146,7 +146,7 @@ test(
     let zkappCommandJson = ZkappCommand.toJSON(zkappCommand);
     let ocamlCommitments = Test.hashFromJson.transactionCommitments(
       JSON.stringify(zkappCommandJson),
-      typeof networkId === 'string' ? networkId : networkId.custom
+      NetworkId.toString(networkId)
     );
     let callForest = accountUpdatesToCallForest(zkappCommand.accountUpdates);
     let commitment = callForestHash(callForest, networkId);
@@ -194,7 +194,7 @@ test(
     // tx commitment
     let ocamlCommitments = Test.hashFromJson.transactionCommitments(
       JSON.stringify(zkappCommandJson),
-      typeof networkId === 'string' ? networkId : networkId.custom
+      NetworkId.toString(networkId)
     );
     let callForest = accountUpdatesToCallForest(zkappCommand.accountUpdates);
     let commitment = callForestHash(callForest, networkId);
@@ -244,7 +244,7 @@ test(
     let sigOCaml = Test.signature.signFieldElement(
       ocamlCommitments.fullCommitment,
       Ml.fromPrivateKey(feePayerKeySnarky),
-      typeof networkId === 'string' ? networkId : networkId.custom
+      NetworkId.toString(networkId)
     );
 
     expect(Signature.toBase58(sigFieldElements)).toEqual(sigOCaml);

--- a/src/mina-signer/src/sign-zkapp-command.unit-test.ts
+++ b/src/mina-signer/src/sign-zkapp-command.unit-test.ts
@@ -112,6 +112,14 @@ test(
     let hashSnarky = accountUpdateSnarky.hash();
     let hash = accountUpdateHash(accountUpdate, networkId);
     expect(hash).toEqual(hashSnarky.toBigInt());
+    /* 
+    // check against different network hash
+    expect(hash).not.toEqual(
+      accountUpdateHash(
+        accountUpdate,
+        NetworkId.toString(networkId) === 'mainnet' ? 'testnet' : 'mainnet'
+      )
+    ); */
   }
 );
 

--- a/src/mina-signer/src/sign-zkapp-command.unit-test.ts
+++ b/src/mina-signer/src/sign-zkapp-command.unit-test.ts
@@ -112,14 +112,14 @@ test(
     let hashSnarky = accountUpdateSnarky.hash();
     let hash = accountUpdateHash(accountUpdate, networkId);
     expect(hash).toEqual(hashSnarky.toBigInt());
-    /* 
+
     // check against different network hash
     expect(hash).not.toEqual(
       accountUpdateHash(
         accountUpdate,
         NetworkId.toString(networkId) === 'mainnet' ? 'testnet' : 'mainnet'
       )
-    ); */
+    );
   }
 );
 

--- a/src/mina-signer/src/sign-zkapp-command.unit-test.ts
+++ b/src/mina-signer/src/sign-zkapp-command.unit-test.ts
@@ -146,7 +146,7 @@ test(
     let zkappCommandJson = ZkappCommand.toJSON(zkappCommand);
     let ocamlCommitments = Test.hashFromJson.transactionCommitments(
       JSON.stringify(zkappCommandJson),
-      networkId
+      typeof networkId === 'string' ? networkId : networkId.custom
     );
     let callForest = accountUpdatesToCallForest(zkappCommand.accountUpdates);
     let commitment = callForestHash(callForest, networkId);
@@ -194,7 +194,7 @@ test(
     // tx commitment
     let ocamlCommitments = Test.hashFromJson.transactionCommitments(
       JSON.stringify(zkappCommandJson),
-      networkId
+      typeof networkId === 'string' ? networkId : networkId.custom
     );
     let callForest = accountUpdatesToCallForest(zkappCommand.accountUpdates);
     let commitment = callForestHash(callForest, networkId);
@@ -244,7 +244,7 @@ test(
     let sigOCaml = Test.signature.signFieldElement(
       ocamlCommitments.fullCommitment,
       Ml.fromPrivateKey(feePayerKeySnarky),
-      networkId
+      typeof networkId === 'string' ? networkId : networkId.custom
     );
 
     expect(Signature.toBase58(sigFieldElements)).toEqual(sigOCaml);

--- a/src/mina-signer/src/signature.ts
+++ b/src/mina-signer/src/signature.ts
@@ -313,14 +313,14 @@ function hashMessageLegacy(
   return HashLegacy.hashWithPrefix(prefix, packToFieldsLegacy(input));
 }
 
-const toBytePadded = (b: number) => ('000000000' + b.toString(2)).substr(-8);
+const numberToBytePadded = (b: number) => b.toString(2).padStart(8, '0');
 
 function networkIdOfString(n: string): [bigint, number] {
   let l = n.length;
   let acc = '';
   for (let i = l - 1; i >= 0; i--) {
     let b = n.charCodeAt(i);
-    let padded = toBytePadded(b);
+    let padded = numberToBytePadded(b);
     acc = acc.concat(padded);
   }
   return [BigInt('0b' + acc), acc.length];

--- a/src/mina-signer/src/signature.ts
+++ b/src/mina-signer/src/signature.ts
@@ -153,7 +153,7 @@ function deriveNonce(
   let id = getNetworkId(networkId);
   let input = HashInput.append(message, {
     fields: [x, y, d],
-    packed: [[id, 40]],
+    packed: [id],
   });
   let packedInput = packToFields(input);
   let inputBits = packedInput.map(Field.toBits).flat();
@@ -321,7 +321,7 @@ function hashMessageLegacy(
 
 const toBytePadded = (b: number) => ('000000000' + b.toString(2)).substr(-8);
 
-function networkIdOfString(n: string) {
+function networkIdOfString(n: string): [bigint, number] {
   let l = n.length;
   let acc = '';
   for (let i = l - 1; i >= 0; i--) {
@@ -329,15 +329,15 @@ function networkIdOfString(n: string) {
     let padded = toBytePadded(b);
     acc = acc.concat(padded);
   }
-  return BigInt('0b' + [...acc].reverse().join(''));
+  return [BigInt('0b' + acc), acc.length];
 }
 
-function getNetworkId(networkId: string) {
+function getNetworkId(networkId: string): [bigint, number] {
   switch (networkId) {
     case 'mainnet':
-      return networkIdMainnet;
+      return [networkIdMainnet, 8];
     case 'testnet':
-      return networkIdTestnet;
+      return [networkIdTestnet, 8];
     default:
       return networkIdOfString(networkId);
   }

--- a/src/mina-signer/src/signature.ts
+++ b/src/mina-signer/src/signature.ts
@@ -359,7 +359,7 @@ const signaturePrefix = (network: NetworkId) => {
     case 'testnet':
       return prefixes.signatureTestnet;
     default:
-      return createCustomPrefix(network + 'Signature');
+      return createCustomPrefix(s + 'Signature');
   }
 };
 
@@ -371,6 +371,6 @@ const zkAppBodyPrefix = (network: NetworkId) => {
     case 'testnet':
       return prefixes.zkappBodyTestnet;
     default:
-      return createCustomPrefix(network + 'ZkappBody');
+      return createCustomPrefix(s + 'ZkappBody');
   }
 };

--- a/src/mina-signer/src/signature.ts
+++ b/src/mina-signer/src/signature.ts
@@ -327,13 +327,14 @@ function networkIdOfString(n: string): [bigint, number] {
 }
 
 function getNetworkIdHashInput(network: NetworkId): [bigint, number] {
-  switch (NetworkId.toString(network)) {
+  let s = NetworkId.toString(network);
+  switch (s) {
     case 'mainnet':
       return [networkIdMainnet, 8];
     case 'testnet':
       return [networkIdTestnet, 8];
     default:
-      return networkIdOfString(network as string);
+      return networkIdOfString(s);
   }
 }
 
@@ -351,7 +352,8 @@ const createCustomPrefix = (prefix: string) => {
 };
 
 const signaturePrefix = (network: NetworkId) => {
-  switch (NetworkId.toString(network)) {
+  let s = NetworkId.toString(network);
+  switch (s) {
     case 'mainnet':
       return prefixes.signatureMainnet;
     case 'testnet':
@@ -362,7 +364,8 @@ const signaturePrefix = (network: NetworkId) => {
 };
 
 const zkAppBodyPrefix = (network: NetworkId) => {
-  switch (NetworkId.toString(network)) {
+  let s = NetworkId.toString(network);
+  switch (s) {
     case 'mainnet':
       return prefixes.zkappBodyMainnet;
     case 'testnet':

--- a/src/mina-signer/src/signature.ts
+++ b/src/mina-signer/src/signature.ts
@@ -277,7 +277,7 @@ function deriveNonceLegacy(
 ): Scalar {
   let { x, y } = publicKey;
   let scalarBits = Scalar.toBits(privateKey);
-  let id = getNetworkId(networkId);
+  let id = getNetworkId(networkId)[0];
   let idBits = bytesToBits([Number(id)]);
   let input = HashInputLegacy.append(message, {
     fields: [x, y],

--- a/src/mina-signer/src/signature.ts
+++ b/src/mina-signer/src/signature.ts
@@ -326,14 +326,14 @@ function networkIdOfString(n: string): [bigint, number] {
   return [BigInt('0b' + acc), acc.length];
 }
 
-function getNetworkIdHashInput(networkId: string): [bigint, number] {
-  switch (networkId) {
+function getNetworkIdHashInput(network: NetworkId): [bigint, number] {
+  switch (typeof network === 'string' ? network : network.custom) {
     case 'mainnet':
       return [networkIdMainnet, 8];
     case 'testnet':
       return [networkIdTestnet, 8];
     default:
-      return networkIdOfString(networkId);
+      return networkIdOfString(network as string);
   }
 }
 
@@ -350,8 +350,8 @@ const createCustomPrefix = (prefix: string) => {
   }
 };
 
-const signaturePrefix = (network: string) => {
-  switch (network) {
+const signaturePrefix = (network: NetworkId) => {
+  switch (typeof network === 'string' ? network : network.custom) {
     case 'mainnet':
       return prefixes.signatureMainnet;
     case 'testnet':
@@ -361,8 +361,8 @@ const signaturePrefix = (network: string) => {
   }
 };
 
-const zkAppBodyPrefix = (network: string) => {
-  switch (network) {
+const zkAppBodyPrefix = (network: NetworkId) => {
+  switch (typeof network === 'string' ? network : network.custom) {
     case 'mainnet':
       return prefixes.zkappBodyMainnet;
     case 'testnet':

--- a/src/mina-signer/src/signature.ts
+++ b/src/mina-signer/src/signature.ts
@@ -327,7 +327,7 @@ function networkIdOfString(n: string): [bigint, number] {
 }
 
 function getNetworkIdHashInput(network: NetworkId): [bigint, number] {
-  switch (typeof network === 'string' ? network : network.custom) {
+  switch (NetworkId.toString(network)) {
     case 'mainnet':
       return [networkIdMainnet, 8];
     case 'testnet':
@@ -351,7 +351,7 @@ const createCustomPrefix = (prefix: string) => {
 };
 
 const signaturePrefix = (network: NetworkId) => {
-  switch (typeof network === 'string' ? network : network.custom) {
+  switch (NetworkId.toString(network)) {
     case 'mainnet':
       return prefixes.signatureMainnet;
     case 'testnet':
@@ -362,7 +362,7 @@ const signaturePrefix = (network: NetworkId) => {
 };
 
 const zkAppBodyPrefix = (network: NetworkId) => {
-  switch (typeof network === 'string' ? network : network.custom) {
+  switch (NetworkId.toString(network)) {
     case 'mainnet':
       return prefixes.zkappBodyMainnet;
     case 'testnet':

--- a/src/mina-signer/src/signature.unit-test.ts
+++ b/src/mina-signer/src/signature.unit-test.ts
@@ -48,7 +48,7 @@ function checkConsistentSingle(
   let actualTest = Test.signature.signFieldElement(
     msgMl,
     keyMl,
-    typeof networkId === 'string' ? networkId : networkId.custom
+    NetworkId.toString(networkId)
   );
   expect(Signature.toBase58(sig)).toEqual(actualTest);
 }

--- a/src/mina-signer/src/signature.unit-test.ts
+++ b/src/mina-signer/src/signature.unit-test.ts
@@ -39,8 +39,8 @@ function checkConsistentSingle(
   // consistent with OCaml
   let msgMl = FieldConst.fromBigint(msg);
   let keyMl = Ml.fromPrivateKey(keySnarky);
-  let actualTest = Test.signature.signFieldElement(msgMl, keyMl, false);
-  let actualMain = Test.signature.signFieldElement(msgMl, keyMl, true);
+  let actualTest = Test.signature.signFieldElement(msgMl, keyMl, 'testnet');
+  let actualMain = Test.signature.signFieldElement(msgMl, keyMl, 'mainnet');
   expect(Signature.toBase58(sigTest)).toEqual(actualTest);
   expect(Signature.toBase58(sigMain)).toEqual(actualMain);
 }

--- a/src/mina-signer/src/test-vectors/legacySignatures.ts
+++ b/src/mina-signer/src/test-vectors/legacySignatures.ts
@@ -90,7 +90,7 @@ let strings = [
  * - the 3 stake delegations,
  * - the 3 strings.
  */
-let signatures = {
+let signatures: { [k: string]: { field: string; scalar: string }[] } = {
   testnet: [
     {
       field:

--- a/src/mina-signer/src/types.ts
+++ b/src/mina-signer/src/types.ts
@@ -11,6 +11,12 @@ export type PrivateKey = string;
 export type Signature = SignatureJson;
 export type NetworkId = 'mainnet' | 'testnet' | { custom: string };
 
+export const NetworkId = {
+  toString(network: NetworkId) {
+    return typeof network === 'string' ? network : network.custom;
+  },
+};
+
 export type Keypair = {
   readonly privateKey: PrivateKey;
   readonly publicKey: PublicKey;

--- a/src/mina-signer/src/types.ts
+++ b/src/mina-signer/src/types.ts
@@ -9,7 +9,7 @@ export type Field = number | bigint | string;
 export type PublicKey = string;
 export type PrivateKey = string;
 export type Signature = SignatureJson;
-export type NetworkId = 'mainnet' | 'testnet' | string;
+export type NetworkId = string;
 
 export const NetworkID = {
   Mainnet: 'mainnet',

--- a/src/mina-signer/src/types.ts
+++ b/src/mina-signer/src/types.ts
@@ -11,12 +11,6 @@ export type PrivateKey = string;
 export type Signature = SignatureJson;
 export type NetworkId = string;
 
-export const NetworkID = {
-  Mainnet: 'mainnet',
-  Testnet: 'testnet',
-  Other: (other: string) => other,
-};
-
 export type Keypair = {
   readonly privateKey: PrivateKey;
   readonly publicKey: PublicKey;

--- a/src/mina-signer/src/types.ts
+++ b/src/mina-signer/src/types.ts
@@ -9,7 +9,13 @@ export type Field = number | bigint | string;
 export type PublicKey = string;
 export type PrivateKey = string;
 export type Signature = SignatureJson;
-export type NetworkId = 'mainnet' | 'testnet';
+export type NetworkId = 'mainnet' | 'testnet' | string;
+
+export const NetworkID = {
+  Mainnet: 'mainnet',
+  Testnet: 'testnet',
+  Other: (other: string) => other,
+};
 
 export type Keypair = {
   readonly privateKey: PrivateKey;

--- a/src/mina-signer/src/types.ts
+++ b/src/mina-signer/src/types.ts
@@ -9,7 +9,7 @@ export type Field = number | bigint | string;
 export type PublicKey = string;
 export type PrivateKey = string;
 export type Signature = SignatureJson;
-export type NetworkId = string;
+export type NetworkId = 'mainnet' | 'testnet' | { custom: string };
 
 export type Keypair = {
   readonly privateKey: PrivateKey;

--- a/src/snarky.d.ts
+++ b/src/snarky.d.ts
@@ -663,7 +663,6 @@ declare const Test: {
     /**
      * Returns the commitment of a JSON transaction.
      */
-    test(networkid: string): void;
     transactionCommitments(
       txJson: string,
       networkId: string

--- a/src/snarky.d.ts
+++ b/src/snarky.d.ts
@@ -647,7 +647,7 @@ declare const Test: {
     signFieldElement(
       messageHash: FieldConst,
       privateKey: ScalarConst,
-      isMainnet: boolean
+      networkId: string
     ): string;
     /**
      * Returns a dummy signature.
@@ -663,6 +663,7 @@ declare const Test: {
     /**
      * Returns the commitment of a JSON transaction.
      */
+    test(networkid: string): void;
     transactionCommitments(
       txJson: string,
       networkId: string


### PR DESCRIPTION
This PR enables custom network signing and verification, all across our stack (o1js and mina-signer). This feature unlocks the use of o1js and mina-signer with layer 2s/3s or chains isomorphic to Mina. All while maintaining backwards compatibility


bindings https://github.com/o1-labs/o1js-bindings/pull/247

closes https://github.com/o1-labs/o1js/issues/1149

