### PR TITLE
Fix type naming with nodenext resolution

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,6 @@
 export type { ProvablePure } from './snarky.js';
 export { Ledger } from './snarky.js';
-export type { FieldVar, FieldConst } from './lib/field.js';
+export type { FieldVar, FieldConst, FieldType } from './lib/field.js';
 export { Field, Bool, Group, Scalar } from './lib/core.js';
 export {
   createForeignField,

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,12 @@
-export type { ProvablePure } from './snarky.js';
+export type { ProvablePure, Gate, GateType } from './snarky.js';
 export { Ledger } from './snarky.js';
-export type { FieldVar, FieldConst, FieldType } from './lib/field.js';
+export type {
+  FieldVar,
+  FieldConst,
+  FieldType,
+  Field as InternalField,
+} from './lib/field.js';
+export type { Bool as InternalBool } from './lib/bool.js';
 export { Field, Bool, Group, Scalar } from './lib/core.js';
 export {
   createForeignField,

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,6 @@
 export type { ProvablePure } from './snarky.js';
 export { Ledger } from './snarky.js';
+export type { FieldVar, FieldConst } from './lib/field.js';
 export { Field, Bool, Group, Scalar } from './lib/core.js';
 export {
   createForeignField,

--- a/src/lib/circuit-value.ts
+++ b/src/lib/circuit-value.ts
@@ -1,6 +1,8 @@
 import 'reflect-metadata';
 import { ProvablePure, Snarky } from '../snarky.js';
-import { Field, Bool, Scalar, Group } from './core.js';
+import { Field } from './field.js';
+import { Bool } from './bool.js';
+import { Scalar, Group } from './core.js';
 import {
   provable,
   provablePure,

--- a/src/lib/core.ts
+++ b/src/lib/core.ts
@@ -1,4 +1,4 @@
-import { Field as InternalField } from './field.js';
+import { Field as InternalField, FieldVar, FieldConst } from './field.js';
 import { Bool as InternalBool } from './bool.js';
 import { Group as InternalGroup } from './group.js';
 import { Scalar } from './scalar.js';

--- a/src/lib/proof-system.ts
+++ b/src/lib/proof-system.ts
@@ -373,7 +373,7 @@ function ZkProgram<
   ): [K, Prover<PublicInput, PublicOutput, Types[K]>] {
     async function prove_(
       publicInput: PublicInput,
-      ...args: TupleToInstances<Types[typeof key]>
+      ...args: TupleToInstances<Types[typeof key]> & any[]
     ): Promise<Proof<PublicInput, PublicOutput>> {
       let picklesProver = compileOutput?.provers?.[i];
       if (picklesProver === undefined) {
@@ -413,7 +413,7 @@ function ZkProgram<
       (publicInputType as any) === Undefined ||
       (publicInputType as any) === Void
     ) {
-      prove = ((...args: TupleToInstances<Types[typeof key]>) =>
+      prove = ((...args: TupleToInstances<Types[typeof key]> & any[]) =>
         (prove_ as any)(undefined, ...args)) as any;
     } else {
       prove = prove_ as any;
@@ -1026,7 +1026,7 @@ type Infer<T> = T extends Subclass<typeof Proof>
 type Tuple<T> = [T, ...T[]] | [];
 type TupleToInstances<T> = {
   [I in keyof T]: Infer<T[I]>;
-} & any[];
+};
 
 type Subclass<Class extends new (...args: any) => any> = (new (
   ...args: any
@@ -1043,13 +1043,13 @@ type Method<
 > = PublicInput extends undefined
   ? {
       privateInputs: Args;
-      method(...args: TupleToInstances<Args>): PublicOutput;
+      method(...args: TupleToInstances<Args> & any[]): PublicOutput;
     }
   : {
       privateInputs: Args;
       method(
         publicInput: PublicInput,
-        ...args: TupleToInstances<Args>
+        ...args: TupleToInstances<Args> & any[]
       ): PublicOutput;
     };
 
@@ -1059,11 +1059,11 @@ type Prover<
   Args extends Tuple<PrivateInput>
 > = PublicInput extends undefined
   ? (
-      ...args: TupleToInstances<Args>
+      ...args: TupleToInstances<Args> & any[]
     ) => Promise<Proof<PublicInput, PublicOutput>>
   : (
       publicInput: PublicInput,
-      ...args: TupleToInstances<Args>
+      ...args: TupleToInstances<Args> & any[]
     ) => Promise<Proof<PublicInput, PublicOutput>>;
 
 type ProvableOrUndefined<A> = A extends undefined ? typeof Undefined : A;


### PR DESCRIPTION
- export fieldvar, fieldconst
- get rid of some import() types
- remove reliance on internal type by making it something TS resolves when compiling
- export internal field/bool types (todo: find a different solution)
