### PR TITLE
Improve performance by reverting Apple silicon workaround (root problem is fixed upstream)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,11 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 - Support for custom network identifiers other than `mainnet` or `testnet` https://github.com/o1-labs/o1js/pull/1444
 - `PrivateKey.randomKeypair()` to generate private and public key in one command https://github.com/o1-labs/o1js/pull/1446
+- `setNumberOfWorkers()` to allow developer to override the number of workers used during compilation and proof generation/verification https://github.com/o1-labs/o1js/pull/1456
+
+### Changed
+
+- Improve all-around performance by reverting the Apple silicon workaround (https://github.com/o1-labs/o1js/pull/683) as the root problem is now fixed upstream https://github.com/o1-labs/o1js/pull/1456
 
 ### Deprecated
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,6 @@
       "dependencies": {
         "blakejs": "1.2.1",
         "cachedir": "^2.4.0",
-        "detect-gpu": "^5.0.5",
         "isomorphic-fetch": "^3.0.0",
         "js-sha256": "^0.9.0",
         "reflect-metadata": "^0.1.13",
@@ -2639,14 +2638,6 @@
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
-      }
-    },
-    "node_modules/detect-gpu": {
-      "version": "5.0.37",
-      "resolved": "https://registry.npmjs.org/detect-gpu/-/detect-gpu-5.0.37.tgz",
-      "integrity": "sha512-EraWs84faI4iskB4qvE39bevMIazEvd1RpoyGLOBesRLbiz6eMeJqqRPHjEFClfRByYZzi9IzU35rBXIO76oDw==",
-      "dependencies": {
-        "webgl-constants": "^1.1.1"
       }
     },
     "node_modules/detect-newline": {
@@ -6651,11 +6642,6 @@
       "dependencies": {
         "makeerror": "1.0.12"
       }
-    },
-    "node_modules/webgl-constants": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/webgl-constants/-/webgl-constants-1.1.1.tgz",
-      "integrity": "sha512-LkBXKjU5r9vAW7Gcu3T5u+5cvSvh5WwINdr0C+9jpzVB41cjQAP5ePArDtk/WHYdVj0GefCgM73BA7FlIiNtdg=="
     },
     "node_modules/webidl-conversions": {
       "version": "3.0.1",

--- a/package.json
+++ b/package.json
@@ -95,7 +95,6 @@
   "dependencies": {
     "blakejs": "1.2.1",
     "cachedir": "^2.4.0",
-    "detect-gpu": "^5.0.5",
     "isomorphic-fetch": "^3.0.0",
     "js-sha256": "^0.9.0",
     "reflect-metadata": "^0.1.13",

--- a/src/index.ts
+++ b/src/index.ts
@@ -117,6 +117,8 @@ export { Crypto } from './lib/crypto.js';
 
 export type { NetworkId } from './mina-signer/mina-signer.js';
 
+export { setNumberOfWorkers } from './lib/proof-system/workers.js';
+
 // experimental APIs
 import { memoizeWitness } from './lib/provable.js';
 export { Experimental };

--- a/src/lib/proof-system/workers.ts
+++ b/src/lib/proof-system/workers.ts
@@ -1,4 +1,6 @@
-export const workers = {
+export { workers, setNumberOfWorkers };
+
+const workers = {
   numWorkers: undefined as number | undefined,
 };
 
@@ -10,6 +12,6 @@ export const workers = {
  * setNumberOfWorkers(2); // set the number of workers to 2
  * ```
  */
-export const setNumberOfWorkers = (numWorkers: number) => {
+const setNumberOfWorkers = (numWorkers: number) => {
   workers.numWorkers = numWorkers;
 };

--- a/src/lib/proof-system/workers.ts
+++ b/src/lib/proof-system/workers.ts
@@ -1,0 +1,15 @@
+export const workers = {
+  numWorkers: undefined as number | undefined,
+};
+
+/**
+ * Set the number of workers to use for parallelizing the proof generation. By default the number of workers is set to the number of physical CPU cores on your machine, but there may be some instances where you want to set the number of workers manually. Some machines may have a large number of cores, but not enough memory to support that many workers. In that case, you can set the number of workers to a lower number to avoid running out of memory. On the other hand, some machines with heterogeneous cores may benefit from setting the number of workers to a lower number to avoid contention between core types if load-link/store-conditional multithreading is used. Feel free to experiment and see what works best for your use case. Maybe you can squeeze slightly more performance out by tweaking this value :)
+
+ * @example
+ * ```typescript
+ * setNumberOfWorkers(2); // set the number of workers to 2
+ * ```
+ */
+export const setNumberOfWorkers = (numWorkers: number) => {
+  workers.numWorkers = numWorkers;
+};


### PR DESCRIPTION
Closes: #1337 ;)
Bindings PR: o1-labs/o1js-bindings#251

* Spawns one worker for each physical core by default (for some reason, `numCpus - 1` was faster a month ago, but when I tested today, `numCores` was slightly faster).
* Exposes `setNumberOfWorkers()` to allow developers to manually set the number of workers.
* Removes detect-gpu dependency

I tested and everything worked well, prover time decrease of ~35% in browser, and ~46% in node. Compile time improvement is even more significant ~60%! (Tested on Apple M1 Pro 10-Core).

I wasn't exactly sure of the best way to implement the `setNumberOfWorkers()` function, and where everything should live/what it should be named. So I would appreciate any feedback on that kinda thing :)