### PR TITLE
Change `Transaction/PendingTransaction` behaviors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,9 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ### Breaking changes
 
+- Improved on parity fix of `Mina.Localblockchain` and`Mina.Network` to make `.send()` and `.wait()` throw an error by default if the transaction was not successful. https://github.com/o1-labs/o1js/pull/1480
+  - Changed `Transaction.isSuccess` to `Transaction.status` to better represent the state of a transaction.
+  - `Transaction.safeSend()` and `PendingTransaction.safeWait()` are introduced to return a `IncludedTransaction` or `RejectedTransaction` object without throwing errors.
 - Fixed parity between `Mina.LocalBlockchain` and `Mina.Network` to have the same behaviors https://github.com/o1-labs/o1js/pull/1422
   - Changed the `TransactionId` type to `Transaction`. Additionally added `PendingTransaction` and `RejectedTransaction` types to better represent the state of a transaction.
   - `transaction.send()` no longer throws an error if the transaction was not successful for `Mina.LocalBlockchain` and `Mina.Network`. Instead, it returns a `PendingTransaction` object that contains the error. Use `transaction.sendOrThrowIfError` to throw the error if the transaction was not successful.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,14 +19,13 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ### Breaking changes
 
-- Improved on parity fix of `Mina.Localblockchain` and`Mina.Network` to make `.send()` and `.wait()` throw an error by default if the transaction was not successful. https://github.com/o1-labs/o1js/pull/1480
-  - Changed `Transaction.isSuccess` to `Transaction.status` to better represent the state of a transaction.
-  - `Transaction.safeSend()` and `PendingTransaction.safeWait()` are introduced to return a `IncludedTransaction` or `RejectedTransaction` object without throwing errors.
-- Fixed parity between `Mina.LocalBlockchain` and `Mina.Network` to have the same behaviors https://github.com/o1-labs/o1js/pull/1422
+- Fixed parity between `Mina.LocalBlockchain` and `Mina.Network` to have the same behaviors https://github.com/o1-labs/o1js/pull/1422 https://github.com/o1-labs/o1js/pull/1480
   - Changed the `TransactionId` type to `Transaction`. Additionally added `PendingTransaction` and `RejectedTransaction` types to better represent the state of a transaction.
-  - `transaction.send()` no longer throws an error if the transaction was not successful for `Mina.LocalBlockchain` and `Mina.Network`. Instead, it returns a `PendingTransaction` object that contains the error. Use `transaction.sendOrThrowIfError` to throw the error if the transaction was not successful.
-  - `transaction.wait()` no longer throws an error if the transaction was not successful for `Mina.LocalBlockchain` and `Mina.Network`. Instead, it returns either a `IncludedTransaction` or `RejectedTransaction`. Use `transaction.waitOrThrowIfError` to throw the error if the transaction was not successful.
+  - `Transaction.safeSend()` and `PendingTransaction.safeWait()` are introduced to return a `IncludedTransaction` or `RejectedTransaction` object without throwing errors.
+  - `transaction.send()` throws an error if the transaction was not successful for both `Mina.LocalBlockchain` and `Mina.Network` and returns a `PendingTransaction` object if it was successful. Use `transaction.safeSend` to send a transaction that will not throw an error and either return a `PendingTransaction` or `RejectedTransaction`.
+  - `transaction.wait()` throws an error if the transaction was not successful for both `Mina.LocalBlockchain` and `Mina.Network` and returns a `IncludedTransaction` object if it was successful. Use `transaction.safeWait` to send a transaction that will not throw an error and either return a `IncludedTransaction` or `RejectedTransaction`.
   - `transaction.hash()` is no longer a function, it is now a property that returns the hash of the transaction.
+  - Changed `Transaction.isSuccess` to `Transaction.status` to better represent the state of a transaction.
 - Improved efficiency of computing `AccountUpdate.callData` by packing field elements into as few field elements as possible https://github.com/o1-labs/o1js/pull/1458
   - This leads to a large reduction in the number of constraints used when inputs to a zkApp method are many field elements (e.g. a long list of `Bool`s)
 - Return events in the `LocalBlockchain` in reverse chronological order (latest events at the beginning) to match the behavior of the `Network` https://github.com/o1-labs/o1js/pull/1460

--- a/src/examples/zkapps/dex/run-live.ts
+++ b/src/examples/zkapps/dex/run-live.ts
@@ -286,7 +286,7 @@ async function ensureFundedAccount(privateKeyBase58: string) {
 }
 
 function logPendingTransaction(pendingTx: Mina.PendingTransaction) {
-  if (!pendingTx.isSuccess) throw Error('transaction failed');
+  if (pendingTx.status === 'rejected') throw Error('transaction failed');
   console.log(
     'tx sent: ' +
       (useCustomLocalNetwork

--- a/src/examples/zkapps/dex/run.ts
+++ b/src/examples/zkapps/dex/run.ts
@@ -237,9 +237,7 @@ async function main({ withVesting }: { withVesting: boolean }) {
         (USER_DX * oldBalances.total.lqXY) / oldBalances.dex.X
     );
   } else {
-    await expect(tx.sendOrThrowIfError()).rejects.toThrow(
-      /Update_not_permitted_timing/
-    );
+    await expect(tx.send()).rejects.toThrow(/Update_not_permitted_timing/);
   }
 
   /**
@@ -254,14 +252,14 @@ async function main({ withVesting }: { withVesting: boolean }) {
   });
   await tx.prove();
   tx.sign([keys.user2]);
-  await expect(tx.sendOrThrowIfError()).rejects.toThrow(/Overflow/);
+  await expect(tx.send()).rejects.toThrow(/Overflow/);
   console.log('supplying with insufficient tokens (should fail)');
   tx = await Mina.transaction(addresses.user, () => {
     dex.supplyLiquidityBase(UInt64.from(1e9), UInt64.from(1e9));
   });
   await tx.prove();
   tx.sign([keys.user]);
-  await expect(tx.sendOrThrowIfError()).rejects.toThrow(/Overflow/);
+  await expect(tx.send()).rejects.toThrow(/Overflow/);
 
   /**
    * - Resulting operation will overflow the SC’s receiving token by type or by any other applicable limits;
@@ -280,7 +278,7 @@ async function main({ withVesting }: { withVesting: boolean }) {
     );
   });
   await tx.prove();
-  await tx.sign([feePayerKey, keys.tokenY]).sendOrThrowIfError();
+  await tx.sign([feePayerKey, keys.tokenY]).send();
   console.log('supply overflowing liquidity');
   await expect(async () => {
     tx = await Mina.transaction(addresses.tokenX, () => {
@@ -291,7 +289,7 @@ async function main({ withVesting }: { withVesting: boolean }) {
     });
     await tx.prove();
     tx.sign([keys.tokenX]);
-    await tx.sendOrThrowIfError();
+    await tx.send();
   }).rejects.toThrow();
 
   /**
@@ -318,7 +316,7 @@ async function main({ withVesting }: { withVesting: boolean }) {
     dex.supplyLiquidity(UInt64.from(10));
   });
   await tx.prove();
-  await expect(tx.sign([keys.tokenX]).sendOrThrowIfError()).rejects.toThrow(
+  await expect(tx.sign([keys.tokenX]).send()).rejects.toThrow(
     /Update_not_permitted_balance/
   );
 
@@ -345,9 +343,7 @@ async function main({ withVesting }: { withVesting: boolean }) {
     });
     await tx.prove();
     tx.sign([keys.user]);
-    await expect(tx.sendOrThrowIfError()).rejects.toThrow(
-      /Source_minimum_balance_violation/
-    );
+    await expect(tx.send()).rejects.toThrow(/Source_minimum_balance_violation/);
 
     // another slot => now it should work
     Local.incrementGlobalSlot(1);
@@ -456,7 +452,7 @@ async function main({ withVesting }: { withVesting: boolean }) {
   });
   await tx.prove();
   tx.sign([keys.user, keys.user2]);
-  await expect(tx.sendOrThrowIfError()).rejects.toThrow(
+  await expect(tx.send()).rejects.toThrow(
     /Account_balance_precondition_unsatisfied/
   );
 
@@ -491,9 +487,7 @@ async function main({ withVesting }: { withVesting: boolean }) {
     dex.redeemLiquidity(UInt64.from(1n));
   });
   await tx.prove();
-  await expect(tx.sign([keys.user2]).sendOrThrowIfError()).rejects.toThrow(
-    /Overflow/
-  );
+  await expect(tx.sign([keys.user2]).send()).rejects.toThrow(/Overflow/);
   [oldBalances, balances] = [balances, getTokenBalances()];
 
   /**

--- a/src/examples/zkapps/dex/upgradability.ts
+++ b/src/examples/zkapps/dex/upgradability.ts
@@ -123,9 +123,9 @@ async function atomicActionsTest({ withVesting }: { withVesting: boolean }) {
   });
   await tx.prove();
 
-  await expect(
-    tx.sign([feePayerKey, keys.dex]).sendOrThrowIfError()
-  ).rejects.toThrow(/Cannot update field 'delegate'/);
+  await expect(tx.sign([feePayerKey, keys.dex]).send()).rejects.toThrow(
+    /Cannot update field 'delegate'/
+  );
 
   console.log('changing delegate permission back to normal');
 
@@ -185,9 +185,9 @@ async function atomicActionsTest({ withVesting }: { withVesting: boolean }) {
     fieldUpdate.requireSignature();
   });
   await tx.prove();
-  await expect(
-    tx.sign([feePayerKey, keys.dex]).sendOrThrowIfError()
-  ).rejects.toThrow(/Cannot update field 'delegate'/);
+  await expect(tx.sign([feePayerKey, keys.dex]).send()).rejects.toThrow(
+    /Cannot update field 'delegate'/
+  );
 
   /**
    * # Atomic Actions 3
@@ -461,9 +461,9 @@ async function upgradeabilityTests({ withVesting }: { withVesting: boolean }) {
     modifiedDex.deploy(); // cannot deploy new VK because its forbidden
   });
   await tx.prove();
-  await expect(
-    tx.sign([feePayerKey, keys.dex]).sendOrThrowIfError()
-  ).rejects.toThrow(/Cannot update field 'verificationKey'/);
+  await expect(tx.sign([feePayerKey, keys.dex]).send()).rejects.toThrow(
+    /Cannot update field 'verificationKey'/
+  );
 
   console.log('trying to invoke modified swap method');
   // method should still be valid since the upgrade was forbidden

--- a/src/examples/zkapps/hello-world/run-live.ts
+++ b/src/examples/zkapps/hello-world/run-live.ts
@@ -59,7 +59,7 @@ let transaction = await Mina.transaction(
 transaction.sign([senderKey, zkAppKey]);
 console.log('Sending the transaction.');
 let pendingTx = await transaction.send();
-if (pendingTx.hash !== undefined) {
+if (pendingTx.status === 'pending') {
   console.log(`Success! Deploy transaction sent.
 Your smart contract will be deployed
 as soon as the transaction is included in a block.
@@ -77,7 +77,7 @@ transaction = await Mina.transaction({ sender, fee: transactionFee }, () => {
 await transaction.sign([senderKey]).prove();
 console.log('Sending the transaction.');
 pendingTx = await transaction.send();
-if (pendingTx.hash !== undefined) {
+if (pendingTx.status === 'pending') {
   console.log(`Success! Update transaction sent.
 Your smart contract state will be updated
 as soon as the transaction is included in a block.

--- a/src/examples/zkapps/hello-world/run.ts
+++ b/src/examples/zkapps/hello-world/run.ts
@@ -27,7 +27,7 @@ txn = await Mina.transaction(feePayer1.publicKey, () => {
   AccountUpdate.fundNewAccount(feePayer1.publicKey);
   zkAppInstance.deploy();
 });
-await txn.sign([feePayer1.privateKey, zkAppPrivateKey]).sendOrThrowIfError();
+await txn.sign([feePayer1.privateKey, zkAppPrivateKey]).send();
 
 const initialState =
   Mina.getAccount(zkAppAddress).zkapp?.appState?.[0].toString();
@@ -45,7 +45,7 @@ txn = await Mina.transaction(feePayer1.publicKey, () => {
   zkAppInstance.update(Field(4), adminPrivateKey);
 });
 await txn.prove();
-await txn.sign([feePayer1.privateKey]).sendOrThrowIfError();
+await txn.sign([feePayer1.privateKey]).send();
 
 currentState = Mina.getAccount(zkAppAddress).zkapp?.appState?.[0].toString();
 
@@ -70,7 +70,7 @@ try {
     zkAppInstance.update(Field(16), wrongAdminPrivateKey);
   });
   await txn.prove();
-  await txn.sign([feePayer1.privateKey]).sendOrThrowIfError();
+  await txn.sign([feePayer1.privateKey]).send();
 } catch (err: any) {
   handleError(err, 'Account_delegate_precondition_unsatisfied');
 }
@@ -91,7 +91,7 @@ try {
     zkAppInstance.update(Field(30), adminPrivateKey);
   });
   await txn.prove();
-  await txn.sign([feePayer1.privateKey]).sendOrThrowIfError();
+  await txn.sign([feePayer1.privateKey]).send();
 } catch (err: any) {
   handleError(err, 'assertEquals');
 }
@@ -118,7 +118,7 @@ try {
     }
   );
   await txn.prove();
-  await txn.sign([feePayer1.privateKey]).sendOrThrowIfError();
+  await txn.sign([feePayer1.privateKey]).send();
 } catch (err: any) {
   handleError(err, 'assertEquals');
 }
@@ -134,7 +134,7 @@ txn2 = await Mina.transaction({ sender: feePayer2.publicKey, fee: '2' }, () => {
   zkAppInstance.update(Field(16), adminPrivateKey);
 });
 await txn2.prove();
-await txn2.sign([feePayer2.privateKey]).sendOrThrowIfError();
+await txn2.sign([feePayer2.privateKey]).send();
 
 currentState = Mina.getAccount(zkAppAddress).zkapp?.appState?.[0].toString();
 
@@ -151,7 +151,7 @@ txn3 = await Mina.transaction({ sender: feePayer3.publicKey, fee: '1' }, () => {
   zkAppInstance.update(Field(256), adminPrivateKey);
 });
 await txn3.prove();
-await txn3.sign([feePayer3.privateKey]).sendOrThrowIfError();
+await txn3.sign([feePayer3.privateKey]).send();
 
 currentState = Mina.getAccount(zkAppAddress).zkapp?.appState?.[0].toString();
 
@@ -174,7 +174,7 @@ try {
     }
   );
   await txn4.prove();
-  await txn4.sign([feePayer4.privateKey]).sendOrThrowIfError();
+  await txn4.sign([feePayer4.privateKey]).send();
 } catch (err: any) {
   handleError(err, 'assertEquals');
 }

--- a/src/lib/account-update.unit-test.ts
+++ b/src/lib/account-update.unit-test.ts
@@ -120,7 +120,7 @@ function createAccountUpdate() {
     AccountUpdate.fundNewAccount(feePayer);
   });
   tx.sign();
-  await expect(tx.sendOrThrowIfError()).rejects.toThrow(
+  await expect(tx.send()).rejects.toThrow(
     'Check signature: Invalid signature on fee payer for key'
   );
 }

--- a/src/lib/caller.unit-test.ts
+++ b/src/lib/caller.unit-test.ts
@@ -27,6 +27,6 @@ let tx = await Mina.transaction(privateKey, () => {
 });
 
 // according to this test, the child doesn't get token permissions
-await expect(tx.sendOrThrowIfError()).rejects.toThrow(
+await expect(tx.send()).rejects.toThrow(
   'can not use or pass on token permissions'
 );

--- a/src/lib/mina.ts
+++ b/src/lib/mina.ts
@@ -37,6 +37,7 @@ import {
   type PendingTransaction,
   type IncludedTransaction,
   type RejectedTransaction,
+  type PendingTransactionStatus,
   createTransaction,
   newTransaction,
   transaction,
@@ -57,9 +58,10 @@ export {
   Network,
   currentTransaction,
   Transaction,
-  PendingTransaction,
-  IncludedTransaction,
-  RejectedTransaction,
+  type PendingTransaction,
+  type IncludedTransaction,
+  type RejectedTransaction,
+  type PendingTransactionStatus,
   activeInstance,
   setActiveInstance,
   transaction,
@@ -271,11 +273,12 @@ function Network(
         response?.errors.forEach((e: any) => errors.push(JSON.stringify(e)));
       }
 
-      const isSuccess = errors.length === 0;
+      const status: PendingTransactionStatus =
+        errors.length === 0 ? 'pending' : 'rejected';
       const hash = Test.transactionHash.hashZkAppCommand(txn.toJSON());
       const pendingTransaction: Omit<PendingTransaction, 'wait' | 'safeWait'> =
         {
-          isSuccess,
+          status,
           data: response?.data,
           errors,
           transaction: txn.transaction,
@@ -356,7 +359,7 @@ function Network(
         maxAttempts?: number;
         interval?: number;
       }): Promise<IncludedTransaction | RejectedTransaction> => {
-        if (!isSuccess) {
+        if (status === 'rejected') {
           return createRejectedTransaction(
             pendingTransaction,
             pendingTransaction.errors

--- a/src/lib/mina/local-blockchain.ts
+++ b/src/lib/mina/local-blockchain.ts
@@ -18,8 +18,11 @@ import { invalidTransactionError } from './errors.js';
 import {
   Transaction,
   PendingTransaction,
-  createIncludedOrRejectedTransaction,
   createTransaction,
+  createIncludedTransaction,
+  createRejectedTransaction,
+  IncludedTransaction,
+  RejectedTransaction,
 } from './transaction.js';
 import {
   type DeprecatedFeePayerSpec,
@@ -257,33 +260,21 @@ function LocalBlockchain({
       });
 
       const hash = Test.transactionHash.hashZkAppCommand(txn.toJSON());
-      const pendingTransaction: Omit<
-        PendingTransaction,
-        'wait' | 'waitOrThrowIfError'
-      > = {
-        isSuccess,
-        errors,
-        transaction: txn.transaction,
-        hash,
-        toJSON: txn.toJSON,
-        toPretty: txn.toPretty,
-      };
+      const pendingTransaction: Omit<PendingTransaction, 'wait' | 'safeWait'> =
+        {
+          isSuccess,
+          errors,
+          transaction: txn.transaction,
+          hash,
+          toJSON: txn.toJSON,
+          toPretty: txn.toPretty,
+        };
 
       const wait = async (_options?: {
         maxAttempts?: number;
         interval?: number;
-      }) => {
-        return createIncludedOrRejectedTransaction(
-          pendingTransaction,
-          pendingTransaction.errors
-        );
-      };
-
-      const waitOrThrowIfError = async (_options?: {
-        maxAttempts?: number;
-        interval?: number;
-      }) => {
-        const pendingTransaction = await wait(_options);
+      }): Promise<IncludedTransaction> => {
+        const pendingTransaction = await safeWait(_options);
         if (pendingTransaction.status === 'rejected') {
           throw Error(
             `Transaction failed with errors:\n${pendingTransaction.errors.join(
@@ -294,10 +285,23 @@ function LocalBlockchain({
         return pendingTransaction;
       };
 
+      const safeWait = async (_options?: {
+        maxAttempts?: number;
+        interval?: number;
+      }): Promise<IncludedTransaction | RejectedTransaction> => {
+        if (!isSuccess) {
+          return createRejectedTransaction(
+            pendingTransaction,
+            pendingTransaction.errors
+          );
+        }
+        return createIncludedTransaction(pendingTransaction);
+      };
+
       return {
         ...pendingTransaction,
         wait,
-        waitOrThrowIfError,
+        safeWait,
       };
     },
     async transaction(sender: DeprecatedFeePayerSpec, f: () => void) {

--- a/src/lib/mina/local-blockchain.ts
+++ b/src/lib/mina/local-blockchain.ts
@@ -23,6 +23,7 @@ import {
   createRejectedTransaction,
   IncludedTransaction,
   RejectedTransaction,
+  PendingTransactionStatus,
 } from './transaction.js';
 import {
   type DeprecatedFeePayerSpec,
@@ -174,7 +175,7 @@ function LocalBlockchain({
         }
       }
 
-      let isSuccess = true;
+      let status: PendingTransactionStatus = 'pending';
       const errors: string[] = [];
       try {
         ledger.applyJsonTransaction(
@@ -183,7 +184,7 @@ function LocalBlockchain({
           JSON.stringify(networkState)
         );
       } catch (err: any) {
-        isSuccess = false;
+        status = 'rejected';
         try {
           const errorMessages = JSON.parse(err.message);
           const formattedError = invalidTransactionError(
@@ -262,7 +263,7 @@ function LocalBlockchain({
       const hash = Test.transactionHash.hashZkAppCommand(txn.toJSON());
       const pendingTransaction: Omit<PendingTransaction, 'wait' | 'safeWait'> =
         {
-          isSuccess,
+          status,
           errors,
           transaction: txn.transaction,
           hash,
@@ -289,7 +290,7 @@ function LocalBlockchain({
         maxAttempts?: number;
         interval?: number;
       }): Promise<IncludedTransaction | RejectedTransaction> => {
-        if (!isSuccess) {
+        if (status === 'rejected') {
           return createRejectedTransaction(
             pendingTransaction,
             pendingTransaction.errors

--- a/src/lib/mina/mina-instance.ts
+++ b/src/lib/mina/mina-instance.ts
@@ -6,7 +6,11 @@ import { UInt64, UInt32 } from '../int.js';
 import { PublicKey, PrivateKey } from '../signature.js';
 import type { EventActionFilterOptions } from '././../mina/graphql.js';
 import type { NetworkId } from '../../mina-signer/src/types.js';
-import type { Transaction, PendingTransaction } from '../mina.js';
+import type {
+  Transaction,
+  PendingTransaction,
+  RejectedTransaction,
+} from '../mina.js';
 import type { Account } from './account.js';
 import type { NetworkValue } from '../precondition.js';
 import type * as Fetch from '../fetch.js';

--- a/src/lib/mina/transaction.ts
+++ b/src/lib/mina/transaction.ts
@@ -31,6 +31,7 @@ export {
   type PendingTransaction,
   type IncludedTransaction,
   type RejectedTransaction,
+  type PendingTransactionStatus,
   createTransaction,
   sendTransaction,
   newTransaction,
@@ -115,6 +116,7 @@ type Transaction = {
   safeSend(): Promise<PendingTransaction | RejectedTransaction>;
 };
 
+type PendingTransactionStatus = 'pending' | 'rejected';
 /**
  * Represents a transaction that has been submitted to the blockchain but has not yet reached a final state.
  * The {@link PendingTransaction} type extends certain functionalities from the base {@link Transaction} type,
@@ -144,7 +146,7 @@ type PendingTransaction = Pick<
    * }
    * ```
    */
-  isSuccess: boolean;
+  status: PendingTransactionStatus;
 
   /**
    * Waits for the transaction to be finalized and returns the result.

--- a/src/lib/mina/transaction.ts
+++ b/src/lib/mina/transaction.ts
@@ -36,7 +36,8 @@ export {
   newTransaction,
   getAccount,
   transaction,
-  createIncludedOrRejectedTransaction,
+  createRejectedTransaction,
+  createIncludedTransaction,
 };
 
 /**
@@ -160,7 +161,7 @@ type PendingTransaction = Pick<
   wait(options?: {
     maxAttempts?: number;
     interval?: number;
-  }): Promise<IncludedTransaction | RejectedTransaction>;
+  }): Promise<IncludedTransaction>;
 
   /**
    * Similar to `wait`, but throws an error if the transaction is rejected or if it fails to finalize within the given attempts.
@@ -178,7 +179,7 @@ type PendingTransaction = Pick<
    * }
    * ```
    */
-  waitOrThrowIfError(options?: {
+  safeWait(options?: {
     maxAttempts?: number;
     interval?: number;
   }): Promise<IncludedTransaction | RejectedTransaction>;
@@ -504,7 +505,7 @@ function createRejectedTransaction(
     toJSON,
     toPretty,
     hash,
-  }: Omit<PendingTransaction, 'wait' | 'waitOrThrowIfError'>,
+  }: Omit<PendingTransaction, 'wait' | 'safeWait'>,
   errors: string[]
 ): RejectedTransaction {
   return {
@@ -524,10 +525,7 @@ function createIncludedTransaction({
   toJSON,
   toPretty,
   hash,
-}: Omit<
-  PendingTransaction,
-  'wait' | 'waitOrThrowIfError'
->): IncludedTransaction {
+}: Omit<PendingTransaction, 'wait' | 'safeWait'>): IncludedTransaction {
   return {
     status: 'included',
     transaction,
@@ -536,14 +534,4 @@ function createIncludedTransaction({
     hash,
     data,
   };
-}
-
-function createIncludedOrRejectedTransaction(
-  transaction: Omit<PendingTransaction, 'wait' | 'waitOrThrowIfError'>,
-  errors: string[]
-): IncludedTransaction | RejectedTransaction {
-  if (errors.length > 0) {
-    return createRejectedTransaction(transaction, errors);
-  }
-  return createIncludedTransaction(transaction);
 }

--- a/src/lib/mina/transaction.ts
+++ b/src/lib/mina/transaction.ts
@@ -112,7 +112,7 @@ type Transaction = {
    * }
    * ```
    */
-  sendSafe(): Promise<PendingTransaction | RejectedTransaction>;
+  safeSend(): Promise<PendingTransaction | RejectedTransaction>;
 };
 
 /**
@@ -422,7 +422,7 @@ function newTransaction(transaction: ZkappCommand, proofsEnabled?: boolean) {
       }
       return pendingTransaction;
     },
-    async sendSafe() {
+    async safeSend() {
       const pendingTransaction = await sendTransaction(self);
       if (pendingTransaction.errors.length > 0) {
         return createRejectedTransaction(

--- a/src/lib/precondition.test.ts
+++ b/src/lib/precondition.test.ts
@@ -238,7 +238,7 @@ describe('preconditions', () => {
           precondition().assertEquals(p.add(1) as any);
           AccountUpdate.attachToTransaction(zkapp.self);
         });
-        await tx.sign([feePayerKey]).sendOrThrowIfError();
+        await tx.sign([feePayerKey]).send();
       }).rejects.toThrow(/unsatisfied/);
     }
   });
@@ -251,7 +251,7 @@ describe('preconditions', () => {
           precondition().requireEquals(p.add(1) as any);
           AccountUpdate.attachToTransaction(zkapp.self);
         });
-        await tx.sign([feePayerKey]).sendOrThrowIfError();
+        await tx.sign([feePayerKey]).send();
       }).rejects.toThrow(/unsatisfied/);
     }
   });
@@ -263,7 +263,7 @@ describe('preconditions', () => {
         precondition().assertEquals(p.not());
         AccountUpdate.attachToTransaction(zkapp.self);
       });
-      await expect(tx.sign([feePayerKey]).sendOrThrowIfError()).rejects.toThrow(
+      await expect(tx.sign([feePayerKey]).send()).rejects.toThrow(
         /unsatisfied/
       );
     }
@@ -276,7 +276,7 @@ describe('preconditions', () => {
         precondition().requireEquals(p.not());
         AccountUpdate.attachToTransaction(zkapp.self);
       });
-      await expect(tx.sign([feePayerKey]).sendOrThrowIfError()).rejects.toThrow(
+      await expect(tx.sign([feePayerKey]).send()).rejects.toThrow(
         /unsatisfied/
       );
     }
@@ -288,9 +288,7 @@ describe('preconditions', () => {
       zkapp.account.delegate.assertEquals(publicKey);
       AccountUpdate.attachToTransaction(zkapp.self);
     });
-    await expect(tx.sign([feePayerKey]).sendOrThrowIfError()).rejects.toThrow(
-      /unsatisfied/
-    );
+    await expect(tx.sign([feePayerKey]).send()).rejects.toThrow(/unsatisfied/);
   });
 
   it('unsatisfied requireEquals should be rejected (public key)', async () => {
@@ -299,9 +297,7 @@ describe('preconditions', () => {
       zkapp.account.delegate.requireEquals(publicKey);
       AccountUpdate.attachToTransaction(zkapp.self);
     });
-    await expect(tx.sign([feePayerKey]).sendOrThrowIfError()).rejects.toThrow(
-      /unsatisfied/
-    );
+    await expect(tx.sign([feePayerKey]).send()).rejects.toThrow(/unsatisfied/);
   });
 
   it('unsatisfied assertBetween should be rejected', async () => {
@@ -311,7 +307,7 @@ describe('preconditions', () => {
         precondition().assertBetween(p.add(20), p.add(30));
         AccountUpdate.attachToTransaction(zkapp.self);
       });
-      await expect(tx.sign([feePayerKey]).sendOrThrowIfError()).rejects.toThrow(
+      await expect(tx.sign([feePayerKey]).send()).rejects.toThrow(
         /unsatisfied/
       );
     }
@@ -324,7 +320,7 @@ describe('preconditions', () => {
         precondition().requireBetween(p.add(20), p.add(30));
         AccountUpdate.attachToTransaction(zkapp.self);
       });
-      await expect(tx.sign([feePayerKey]).sendOrThrowIfError()).rejects.toThrow(
+      await expect(tx.sign([feePayerKey]).send()).rejects.toThrow(
         /unsatisfied/
       );
     }
@@ -335,9 +331,7 @@ describe('preconditions', () => {
       zkapp.currentSlot.assertBetween(UInt32.from(20), UInt32.from(30));
       AccountUpdate.attachToTransaction(zkapp.self);
     });
-    await expect(tx.sign([feePayerKey]).sendOrThrowIfError()).rejects.toThrow(
-      /unsatisfied/
-    );
+    await expect(tx.sign([feePayerKey]).send()).rejects.toThrow(/unsatisfied/);
   });
 
   it('unsatisfied currentSlot.requireBetween should be rejected', async () => {
@@ -345,9 +339,7 @@ describe('preconditions', () => {
       zkapp.currentSlot.requireBetween(UInt32.from(20), UInt32.from(30));
       AccountUpdate.attachToTransaction(zkapp.self);
     });
-    await expect(tx.sign([feePayerKey]).sendOrThrowIfError()).rejects.toThrow(
-      /unsatisfied/
-    );
+    await expect(tx.sign([feePayerKey]).send()).rejects.toThrow(/unsatisfied/);
   });
 
   // TODO: is this a gotcha that should be addressed?
@@ -359,9 +351,7 @@ describe('preconditions', () => {
       zkapp.requireSignature();
       AccountUpdate.attachToTransaction(zkapp.self);
     });
-    expect(() =>
-      tx.sign([zkappKey, feePayerKey]).sendOrThrowIfError()
-    ).toThrow();
+    expect(() => tx.sign([zkappKey, feePayerKey]).send()).toThrow();
   });
 });
 

--- a/src/lib/token.test.ts
+++ b/src/lib/token.test.ts
@@ -328,7 +328,7 @@ describe('Token', () => {
             tokenZkapp.requireSignature();
           })
         ).sign([zkAppBKey, feePayerKey, tokenZkappKey]);
-        await expect(tx.sendOrThrowIfError()).rejects.toThrow();
+        await expect(tx.send()).rejects.toThrow();
       });
     });
 
@@ -396,7 +396,7 @@ describe('Token', () => {
           })
         ).sign([zkAppBKey, feePayerKey, tokenZkappKey]);
 
-        await expect(tx.sendOrThrowIfError()).rejects.toThrow();
+        await expect(tx.send()).rejects.toThrow();
       });
 
       test('should error if sender sends more tokens than they have', async () => {
@@ -420,7 +420,7 @@ describe('Token', () => {
             tokenZkapp.requireSignature();
           })
         ).sign([zkAppBKey, feePayerKey, tokenZkappKey]);
-        await expect(tx.sendOrThrowIfError()).rejects.toThrow();
+        await expect(tx.send()).rejects.toThrow();
       });
     });
   });
@@ -581,9 +581,9 @@ describe('Token', () => {
           });
           AccountUpdate.attachToTransaction(tokenZkapp.self);
         });
-        await expect(
-          tx.sign([feePayerKey]).sendOrThrowIfError()
-        ).rejects.toThrow(/Update_not_permitted_access/);
+        await expect(tx.sign([feePayerKey]).send()).rejects.toThrow(
+          /Update_not_permitted_access/
+        );
       });
     });
   });

--- a/src/tests/transaction-flow.ts
+++ b/src/tests/transaction-flow.ts
@@ -111,8 +111,10 @@ async function sendAndVerifyTransaction(
     const pendingTransaction = await transaction.send();
     return await pendingTransaction.wait();
   } else {
-    const pendingTransaction = await transaction.send();
-    return await pendingTransaction.safeWait();
+    const pendingTransaction = await transaction.safeSend();
+    if (pendingTransaction.status === 'pending') {
+      return await pendingTransaction.safeWait();
+    }
   }
 }
 

--- a/src/tests/transaction-flow.ts
+++ b/src/tests/transaction-flow.ts
@@ -114,6 +114,8 @@ async function sendAndVerifyTransaction(
     const pendingTransaction = await transaction.safeSend();
     if (pendingTransaction.status === 'pending') {
       return await pendingTransaction.safeWait();
+    } else {
+      throw Error('Transaction failed');
     }
   }
 }

--- a/src/tests/transaction-flow.ts
+++ b/src/tests/transaction-flow.ts
@@ -115,7 +115,7 @@ async function sendAndVerifyTransaction(
     if (pendingTransaction.status === 'pending') {
       return await pendingTransaction.safeWait();
     } else {
-      throw Error('Transaction failed');
+      return pendingTransaction;
     }
   }
 }

--- a/src/tests/transaction-flow.ts
+++ b/src/tests/transaction-flow.ts
@@ -109,10 +109,10 @@ async function sendAndVerifyTransaction(
   await transaction.prove();
   if (throwOnFail) {
     const pendingTransaction = await transaction.send();
-    return await pendingTransaction.waitOrThrowIfError();
+    return await pendingTransaction.wait();
   } else {
     const pendingTransaction = await transaction.send();
-    return await pendingTransaction.wait();
+    return await pendingTransaction.safeWait();
   }
 }
 

--- a/src/tests/transaction-flow.ts
+++ b/src/tests/transaction-flow.ts
@@ -108,7 +108,7 @@ async function sendAndVerifyTransaction(
 ) {
   await transaction.prove();
   if (throwOnFail) {
-    const pendingTransaction = await transaction.sendOrThrowIfError();
+    const pendingTransaction = await transaction.send();
     return await pendingTransaction.waitOrThrowIfError();
   } else {
     const pendingTransaction = await transaction.send();


### PR DESCRIPTION
# Description

Change the default behavior of `Transaction.send()` to throw an error if any errors are detected during processing. Additionally, we change `isSuccess` from `Transaction` and use `status` instead to indicate the transaction's current status. `status` can either be `pending` or `rejected`.

Also changes the tests and documentation. 