### PR TITLE
Benchmark runner

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,10 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased](https://github.com/o1-labs/o1js/compare/74948acac...HEAD)
 
+### Added
+
+- Internal benchmarking tooling to keep track of performance https://github.com/o1-labs/o1js/pull/1481
+
 ## [0.17.0](https://github.com/o1-labs/o1js/compare/1ad7333e9e...74948acac) - 2024-03-06
 
 ### Breaking changes

--- a/benchmarks/benchmark.ts
+++ b/benchmarks/benchmark.ts
@@ -1,0 +1,104 @@
+/**
+ * Benchmark runner
+ */
+export { BenchmarkResult, benchmark, printResults };
+
+type BenchmarkResult = {
+  label: string;
+  mean: number;
+  stdDev: number;
+  full: number[];
+};
+
+async function benchmark(
+  label: string,
+  run:
+    | ((
+        tic: (label?: string) => void,
+        toc: (label?: string) => void
+      ) => Promise<void>)
+    | ((tic: (label?: string) => void, toc: (label?: string) => void) => void),
+  options?: {
+    numberOfRuns?: number;
+    numberOfWarmups?: number;
+  }
+): Promise<BenchmarkResult[]> {
+  const { numberOfRuns = 5, numberOfWarmups = 0 } = options ?? {};
+
+  let lastStartKey: string;
+  let startTime: Record<string, number | undefined> = {}; // key: startTime
+  let runTimes: Record<string, number[]> = {}; // key: [(endTime - startTime)]
+
+  function reset() {
+    startTime = {};
+  }
+
+  function start(key?: string) {
+    lastStartKey = key ?? '';
+    key = getKey(label, key);
+    if (startTime[key] !== undefined)
+      throw Error('running `start(label)` with an already started label');
+    startTime[key] = performance.now();
+  }
+
+  function stop(key?: string) {
+    let end = performance.now();
+    key ??= lastStartKey;
+    if (key === undefined) {
+      throw Error('running `stop()` with no start defined');
+    }
+    key = getKey(label, key);
+    let start_ = startTime[key];
+    startTime[key] = undefined;
+    if (start_ === undefined)
+      throw Error('running `stop()` with no start defined');
+    let times = (runTimes[key] ??= []);
+    times.push(end - start_);
+  }
+
+  let noop = () => {};
+  for (let i = 0; i < numberOfWarmups; i++) {
+    reset();
+    await run(noop, noop);
+  }
+  for (let i = 0; i < numberOfRuns; i++) {
+    reset();
+    await run(start, stop);
+  }
+
+  const results: BenchmarkResult[] = [];
+
+  for (let key in runTimes) {
+    let times = runTimes[key];
+    results.push({ label: key, ...getStatistics(times) });
+  }
+  return results;
+}
+
+function getKey(label: string, key?: string) {
+  return key ? `${label} - ${key}` : label;
+}
+
+function getStatistics(numbers: number[]) {
+  let sum = 0;
+  let sumSquares = 0;
+  for (let i of numbers) {
+    sum += i;
+    sumSquares += i ** 2;
+  }
+  let n = numbers.length;
+  let mean = sum / n;
+  let stdDev = Math.sqrt((sumSquares - sum ** 2 / n) / (n - 1)) / mean;
+
+  return { mean, stdDev, full: numbers };
+}
+
+function printResults(results: BenchmarkResult[]) {
+  for (let result of results) {
+    console.log(`${result.label}: ${resultToString(result)}`);
+  }
+}
+
+function resultToString({ mean, stdDev }: BenchmarkResult) {
+  return `${mean.toFixed(2)}ms ± ${(stdDev * 100).toFixed(1)}%`;
+}

--- a/benchmarks/benchmark.ts
+++ b/benchmarks/benchmark.ts
@@ -98,7 +98,7 @@ function printResult(
   result: BenchmarkResult,
   previousResult?: BenchmarkResult
 ) {
-  console.log(result.label);
+  console.log(result.label + `\n`);
   console.log(`time: ${resultToString(result)}`);
 
   if (previousResult === undefined) return;
@@ -123,6 +123,7 @@ function printResult(
   } else {
     console.log('Change within noise threshold.');
   }
+  console.log('\n');
 }
 
 function resultToString({ mean, variance }: BenchmarkResult) {

--- a/benchmarks/ecdsa.ts
+++ b/benchmarks/ecdsa.ts
@@ -7,9 +7,9 @@
  * ```
  */
 import { keccakAndEcdsa } from '../src/examples/crypto/ecdsa/ecdsa.js';
-import { benchmark, pValue, printResults } from './benchmark.js';
+import { BenchmarkResult, benchmark, printResult } from './benchmark.js';
 
-let result = await benchmark(
+let results = await benchmark(
   'ecdsa',
   async (tic, toc) => {
     tic('build constraint system');
@@ -20,32 +20,21 @@ let result = await benchmark(
   { numberOfWarmups: 2, numberOfRuns: 5 }
 );
 
+// mock: load previous results
+let previousResults: BenchmarkResult[] = [
+  {
+    label: 'ecdsa - build constraint system',
+    size: 5,
+    mean: 3103.639612600001,
+    variance: 72678.9751211293,
+  },
+];
+
 // example for how to log results
+// criterion-style comparison of result to previous one, check significant improvement
 
-let previousResult = {
-  label: 'ecdsa - build constraint system',
-  mean: 3103.639612600001,
-  variance: 72678.9751211293,
-  full: [
-    3560.7922879999987, 2891.445788000001, 2946.1976350000023,
-    2996.3062800000007, 3123.456072000001,
-  ],
-};
-printResults([previousResult]);
-printResults(result);
-
-// comparing results for significant improvement
-
-let p = pValue(result[0], previousResult);
-
-if (p < 0.05) {
-  if (result[0].mean > previousResult.mean) {
-    console.log(`Performance has improved. p = ${p.toFixed(3)} < 0.05`);
-  } else {
-    console.log(`Performance has degraded. p = ${p.toFixed(3)} < 0.05`);
-  }
-} else {
-  console.log(
-    `Performance has not changed significantly. p = ${p.toFixed(3)} > 0.05`
-  );
+for (let i = 0; i < results.length; i++) {
+  let result = results[i];
+  let previous = previousResults[i];
+  printResult(result, previous);
 }

--- a/benchmarks/ecdsa.ts
+++ b/benchmarks/ecdsa.ts
@@ -1,0 +1,25 @@
+/**
+ * Benchmark runner example
+ *
+ * Run with
+ * ```
+ * ./run benchmarks/ecdsa.ts --bundle
+ * ```
+ */
+import { keccakAndEcdsa } from '../src/examples/crypto/ecdsa/ecdsa.js';
+import { benchmark, printResults } from './benchmark.js';
+
+let result = await benchmark(
+  'ecdsa',
+  async (tic, toc) => {
+    tic('compile (cached)');
+    await keccakAndEcdsa.compile();
+    toc();
+  },
+  // two warmups to ensure full caching
+  { numberOfWarmups: 2, numberOfRuns: 5 }
+);
+
+// just an example for how to log results
+console.log(result[0].full);
+printResults(result);

--- a/benchmarks/ecdsa.ts
+++ b/benchmarks/ecdsa.ts
@@ -20,7 +20,7 @@ let publicKey = Secp256k1.generator.scale(privateKey);
 let message = Bytes32.fromString("what's up");
 let signature = Ecdsa.sign(message.toBytes(), privateKey.toBigInt());
 
-let results = await benchmark(
+const EcdsaBenchmark = benchmark(
   'ecdsa',
   async (tic, toc) => {
     tic('build constraint system');
@@ -41,6 +41,7 @@ let results = await benchmark(
 );
 
 // mock: load previous results
+
 let previousResults: BenchmarkResult[] = [
   {
     label: 'ecdsa - build constraint system',
@@ -55,6 +56,10 @@ let previousResults: BenchmarkResult[] = [
     size: 5,
   },
 ];
+
+// run benchmark
+
+let results = await EcdsaBenchmark.run();
 
 // example for how to log results
 // criterion-style comparison of result to previous one, check significant improvement

--- a/benchmarks/ecdsa.ts
+++ b/benchmarks/ecdsa.ts
@@ -7,19 +7,45 @@
  * ```
  */
 import { keccakAndEcdsa } from '../src/examples/crypto/ecdsa/ecdsa.js';
-import { benchmark, printResults } from './benchmark.js';
+import { benchmark, pValue, printResults } from './benchmark.js';
 
 let result = await benchmark(
   'ecdsa',
   async (tic, toc) => {
-    tic('compile (cached)');
-    await keccakAndEcdsa.compile();
+    tic('build constraint system');
+    await keccakAndEcdsa.analyzeMethods();
     toc();
   },
   // two warmups to ensure full caching
   { numberOfWarmups: 2, numberOfRuns: 5 }
 );
 
-// just an example for how to log results
-console.log(result[0].full);
+// example for how to log results
+
+let previousResult = {
+  label: 'ecdsa - build constraint system',
+  mean: 3103.639612600001,
+  variance: 72678.9751211293,
+  full: [
+    3560.7922879999987, 2891.445788000001, 2946.1976350000023,
+    2996.3062800000007, 3123.456072000001,
+  ],
+};
+printResults([previousResult]);
 printResults(result);
+
+// comparing results for significant improvement
+
+let p = pValue(result[0], previousResult);
+
+if (p < 0.05) {
+  if (result[0].mean > previousResult.mean) {
+    console.log(`Performance has improved. p = ${p.toFixed(3)} < 0.05`);
+  } else {
+    console.log(`Performance has degraded. p = ${p.toFixed(3)} < 0.05`);
+  }
+} else {
+  console.log(
+    `Performance has not changed significantly. p = ${p.toFixed(3)} > 0.05`
+  );
+}

--- a/benchmarks/ecdsa.ts
+++ b/benchmarks/ecdsa.ts
@@ -27,7 +27,7 @@ const EcdsaBenchmark = benchmark(
     keccakAndEcdsa.analyzeMethods();
     toc();
 
-    tic('ecdsa verify (witness gen / check)');
+    tic('witness generation');
     Provable.runAndCheck(() => {
       let message_ = Provable.witness(Bytes32.provable, () => message);
       let signature_ = Provable.witness(Ecdsa.provable, () => signature);
@@ -50,7 +50,7 @@ let previousResults: BenchmarkResult[] = [
     size: 5,
   },
   {
-    label: 'ecdsa - ecdsa verify (witness gen / check)',
+    label: 'ecdsa - witness generation',
     mean: 2062.8708897999995,
     variance: 13973.913943626918,
     size: 5,

--- a/benchmarks/tsconfig.json
+++ b/benchmarks/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "extends": "../tsconfig.json",
+  "include": ["."],
+  "exclude": [],
+  "compilerOptions": {
+    "rootDir": "..",
+    "baseUrl": "..",
+    "paths": {
+      "o1js": ["."]
+    }
+  }
+}

--- a/benchmarks/types.d.ts
+++ b/benchmarks/types.d.ts
@@ -1,0 +1,1 @@
+declare module 'jstat';

--- a/package-lock.json
+++ b/package-lock.json
@@ -33,6 +33,7 @@
         "glob": "^8.0.3",
         "howslow": "^0.1.0",
         "jest": "^28.1.3",
+        "jstat": "^1.9.6",
         "minimist": "^1.2.7",
         "prettier": "^2.8.4",
         "replace-in-file": "^6.3.5",
@@ -5199,6 +5200,12 @@
       "optionalDependencies": {
         "graceful-fs": "^4.1.6"
       }
+    },
+    "node_modules/jstat": {
+      "version": "1.9.6",
+      "resolved": "https://registry.npmjs.org/jstat/-/jstat-1.9.6.tgz",
+      "integrity": "sha512-rPBkJbK2TnA8pzs93QcDDPlKcrtZWuuCo2dVR0TFLOJSxhqfWOVCSp8aV3/oSbn+4uY4yw1URtLpHQedtmXfug==",
+      "dev": true
     },
     "node_modules/keyv": {
       "version": "4.5.4",

--- a/package.json
+++ b/package.json
@@ -82,6 +82,7 @@
     "glob": "^8.0.3",
     "howslow": "^0.1.0",
     "jest": "^28.1.3",
+    "jstat": "^1.9.6",
     "minimist": "^1.2.7",
     "prettier": "^2.8.4",
     "replace-in-file": "^6.3.5",


### PR DESCRIPTION
closes #923

adds a benchmark runner and tooling to extract the relevant statistics, similar to Criterion.rs.

Also adds an example for writing benchmarks and comparing results:

```sh
> ./run benchmarks/ecdsa.ts --bundle
ecdsa - build constraint system

time: 3048.970ms ± 3.8%
change: -1.761% (p = 0.69 > 0.05)
Change within noise threshold.


ecdsa - ecdsa verify (witness gen / check)

time: 1994.532ms ± 2.9%
change: -3.313% (p = 0.29 > 0.05)
Change within noise threshold.

```