### PR TITLE
Run benchmarks on self-hosted GitHub Actions runner (x86).

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -15,8 +15,8 @@ jobs:
       fail-fast: true
       matrix:
         node: [20]
-        os: [ubuntu-latest, macos-latest, windows-latest]
-    runs-on: ${{ matrix.os }}
+        runners: [sdk-self-hosted-linux-amd64]
+    runs-on: ${{ matrix.runners }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4


### PR DESCRIPTION
Closes https://github.com/o1-labs/benchmark-infra/issues/2