### PR TITLE
Always test against berkeley in CI

### DIFF
--- a/.github/workflows/live-tests.yml
+++ b/.github/workflows/live-tests.yml
@@ -16,7 +16,6 @@ jobs:
   berkeley:
     timeout-minutes: 45
     runs-on: ubuntu-latest
-    if: github.ref == 'refs/heads/main' || (github.event_name == 'pull_request')
     services:
       mina-local-network:
         image: o1labs/mina-local-network:berkeley-latest-lightnet

--- a/.github/workflows/live-tests.yml
+++ b/.github/workflows/live-tests.yml
@@ -13,7 +13,7 @@ on:
   workflow_dispatch: {}
 
 jobs:
-  main-branch:
+  berkeley:
     timeout-minutes: 45
     runs-on: ubuntu-latest
     if: github.ref == 'refs/heads/main' || (github.event_name == 'pull_request')

--- a/.github/workflows/live-tests.yml
+++ b/.github/workflows/live-tests.yml
@@ -1,4 +1,4 @@
-name: Test o1js against the real network
+name: Test o1js against lightnet
 on:
   push:
     branches:
@@ -16,33 +16,7 @@ jobs:
   main-branch:
     timeout-minutes: 45
     runs-on: ubuntu-latest
-    if: github.ref == 'refs/heads/main' || (github.event_name == 'pull_request' && github.base_ref == 'main')
-    services:
-      mina-local-network:
-        image: o1labs/mina-local-network:o1js-main-latest-lightnet
-        env:
-          NETWORK_TYPE: 'single-node'
-          PROOF_LEVEL: 'none'
-        ports:
-          - 3085:3085
-          - 5432:5432
-          - 8080:8080
-          - 8181:8181
-          - 8282:8282
-        volumes:
-          - /tmp:/root/logs
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
-      - name: Use shared steps for live testing jobs
-        uses: ./.github/actions/live-tests-shared
-        with:
-          mina-branch-name: o1js-main
-
-  berkeley-branch:
-    timeout-minutes: 45
-    runs-on: ubuntu-latest
-    if: github.ref == 'refs/heads/berkeley' || (github.event_name == 'pull_request' && github.base_ref == 'berkeley')
+    if: github.ref == 'refs/heads/main' || (github.event_name == 'pull_request')
     services:
       mina-local-network:
         image: o1labs/mina-local-network:berkeley-latest-lightnet
@@ -64,29 +38,3 @@ jobs:
         uses: ./.github/actions/live-tests-shared
         with:
           mina-branch-name: berkeley
-
-  develop-branch:
-    timeout-minutes: 45
-    runs-on: ubuntu-latest
-    if: github.ref == 'refs/heads/develop' || (github.event_name == 'pull_request' && github.base_ref == 'develop')
-    services:
-      mina-local-network:
-        image: o1labs/mina-local-network:develop-latest-lightnet
-        env:
-          NETWORK_TYPE: 'single-node'
-          PROOF_LEVEL: 'none'
-        ports:
-          - 3085:3085
-          - 5432:5432
-          - 8080:8080
-          - 8181:8181
-          - 8282:8282
-        volumes:
-          - /tmp:/root/logs
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
-      - name: Use shared steps for live testing jobs
-        uses: ./.github/actions/live-tests-shared
-        with:
-          mina-branch-name: develop


### PR DESCRIPTION
This makes CI always test against lightnet built from berkeley, to make sure we stay compatible with devnet