### PR TITLE
Update node version requirement to 18.14.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "snarky-run": "src/build/run.js"
   },
   "engines": {
-    "node": ">=16.4.0"
+    "node": ">=18.14.0"
   },
   "scripts": {
     "dev": "npx tsc -p tsconfig.test.json && node src/build/copy-to-dist.js",


### PR DESCRIPTION
[os.availableParallelism()](https://nodejs.org/api/os.html#osavailableparallelism) used [here](https://github.com/o1-labs/o1js-bindings/blob/main/js/node/node-backend.js#L87) is available since node version `18.14.0`