### PR TITLE
Fix Merkle map keys

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,10 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
   - Fixes soundness of ECDSA; slightly increases its constraints from ~28k to 29k
   - Breaks circuits that used EC addition, like ECDSA
 
+### Fixed
+
+- Fix error when computing Merkle map witnesses, introduced in the last version due to the `toBits()` change https://github.com/o1-labs/o1js/pull/1559
+
 ## [0.18.0](https://github.com/o1-labs/o1js/compare/74948acac...1b6fd8b8e) - 2024-04-09
 
 ### Breaking changes

--- a/src/lib/provable/merkle-map.ts
+++ b/src/lib/provable/merkle-map.ts
@@ -5,7 +5,9 @@ import { MerkleTree, MerkleWitness } from './merkle-tree.js';
 import { Provable } from './provable.js';
 import { BinableFp } from '../../mina-signer/src/field-bigint.js';
 
-export class MerkleMap {
+export { MerkleMap, MerkleMapWitness };
+
+class MerkleMap {
   tree: MerkleTree;
 
   /**
@@ -69,7 +71,7 @@ export class MerkleMap {
   }
 }
 
-export class MerkleMapWitness extends CircuitValue {
+class MerkleMapWitness extends CircuitValue {
   @arrayProp(Bool, 255) isLefts: Bool[];
   @arrayProp(Field, 255) siblings: Field[];
 

--- a/src/lib/provable/test/merkle-tree.unit-test.ts
+++ b/src/lib/provable/test/merkle-tree.unit-test.ts
@@ -2,6 +2,7 @@ import { Bool, Field } from '../wrapped.js';
 import { maybeSwap } from '../merkle-tree.js';
 import { Random, test } from '../../testing/property.js';
 import { expect } from 'expect';
+import { MerkleMap } from '../merkle-map.js';
 
 test(Random.bool, Random.field, Random.field, (b, x, y) => {
   let [x0, y0] = maybeSwap(Bool(!!b), Field(x), Field(y));
@@ -14,4 +15,11 @@ test(Random.bool, Random.field, Random.field, (b, x, y) => {
     expect(x0.toBigInt()).toEqual(y);
     expect(y0.toBigInt()).toEqual(x);
   }
+});
+
+test(Random.field, (key) => {
+  let map = new MerkleMap();
+  let witness = map.getWitness(Field(key));
+  let [, calculatedKey] = witness.computeRootAndKey(Field(0));
+  expect(calculatedKey.toBigInt()).toEqual(key);
 });


### PR DESCRIPTION
fixes https://github.com/o1-labs/o1js/issues/1552

the issue was a bit subtle - the previous code assumed that `field.toBits()` returned 255 bits, which it no longer does
