### PR TITLE
Improve error handling for setting out of bounds on-chain state

### DIFF
--- a/src/lib/mina/state.ts
+++ b/src/lib/mina/state.ts
@@ -196,10 +196,13 @@ function createState<T>(): InternalStateType<T> {
       let stateAsFields = this._contract.stateType.toFields(state);
       let accountUpdate = this._contract.instance.self;
       stateAsFields.forEach((x, i) => {
-        AccountUpdate.setValue(
-          accountUpdate.body.update.appState[layout.offset + i],
-          x
-        );
+        let appStateSlot =
+          accountUpdate.body.update.appState[layout.offset + i];
+        if (!appStateSlot)
+          throw Error(
+            `Attempted to set on-chain state variable \`${this._contract?.key}\`. Currently, only a total of 8 fields elements of on-chain state are supported.`
+          );
+        AccountUpdate.setValue(appStateSlot, x);
       });
     },
 


### PR DESCRIPTION
i still cant believe that arrays are typed so badly 

low hanging error message improvement 
closes #1571