### PR TITLE
ARM64 GitHub self-hosted runner for benchmarks.

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -15,7 +15,7 @@ jobs:
       fail-fast: true
       matrix:
         node: [20]
-        runners: [sdk-self-hosted-linux-amd64]
+        runners: [sdk-self-hosted-linux-amd64, sdk-self-hosted-linux-arm64]
     runs-on: ${{ matrix.runners }}
     steps:
       - name: Checkout repository


### PR DESCRIPTION
Closes https://github.com/o1-labs/benchmark-infra/issues/3