### PR TITLE
make dummy proof lazy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 - Fixed issue in `UInt64.rightShift()` where it incorrectly performed a left shift instead of a right shift. https://github.com/o1-labs/o1js/pull/1617
 - Fixed issue in `ForeignField.toBits()` where high limbs were under-constrained for input length less than 176. https://github.com/o1-labs/o1js/pull/1617
+- Make `dummyBase64Proof()` lazy. Significant speed up when generating many account updates with authorization `Proof` while proofs turned off. https://github.com/o1-labs/o1js/pull/1624
 
 ### Added
 

--- a/src/lib/proof-system/zkprogram.ts
+++ b/src/lib/proof-system/zkprogram.ts
@@ -1193,9 +1193,14 @@ async function dummyProof(maxProofsVerified: 0 | 1 | 2, domainLog2: number) {
   );
 }
 
+let dummyProofCache: string | undefined;
+
 async function dummyBase64Proof() {
+  if (dummyProofCache) return dummyProofCache;
   let proof = await dummyProof(2, 15);
-  return Pickles.proofToBase64([2, proof]);
+  let base64Proof = Pickles.proofToBase64([2, proof]);
+  dummyProofCache = base64Proof;
+  return base64Proof;
 }
 
 // what feature flags to set to enable certain gate types


### PR DESCRIPTION
down from 160ms to 0.001ms for subsequent account updates with proof