### PR TITLE
Fix absolute imports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,10 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased](https://github.com/o1-labs/o1js/compare/4a17de857...HEAD)
 
+### Fixes
+
+- Fix absolute imports which prevented compilation in some TS projects that used o1js https://github.com/o1-labs/o1js/pull/1628
+
 ## [1.1.0](https://github.com/o1-labs/o1js/compare/1ad7333e9e...4a17de857) - 2024-04-30
 
 ### Added

--- a/src/lib/mina/transaction.ts
+++ b/src/lib/mina/transaction.ts
@@ -21,7 +21,7 @@ import * as Fetch from './fetch.js';
 import { type SendZkAppResponse, sendZkappQuery } from './graphql.js';
 import { type FetchMode } from './transaction-context.js';
 import { assertPromise } from '../util/assert.js';
-import { Types } from 'src/bindings/mina-transaction/types.js';
+import { Types } from '../../bindings/mina-transaction/types.js';
 
 export {
   Transaction,


### PR DESCRIPTION
Fixes two places where the code accidentally used absolute instead of relative imports.

This prevents successful compilation in some TS projects that use o1js.
A workaround until this fix is released is to set `skipLibCheck: true` in the TS config.

bindings: https://github.com/o1-labs/o1js-bindings/pull/270