### PR TITLE
Experimental offchain state, pt 2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,10 +15,15 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
     _Security_ in case of vulnerabilities.
  -->
 
-## [Unreleased](https://github.com/o1-labs/o1js/compare/4a17de857...HEAD)
+## [Unreleased](https://github.com/o1-labs/o1js/compare/6a1012162...HEAD)
+
+## [1.2.0](https://github.com/o1-labs/o1js/compare/4a17de857...6a1012162) - 2024-05-14
 
 ### Added
 
+- **Offchain storage MVP** exported under `Experimental.OffchainStorage` https://github.com/o1-labs/o1js/pull/1630 https://github.com/o1-labs/o1js/pull/1652
+  - allows you to store any number of fields and key-value maps on your zkApp
+  - implemented using actions which define an offchain Merkle tree
 - `Option` for defining an optional version of any provable type https://github.com/o1-labs/o1js/pull/1630
 - `MerkleTree.clone()` and `MerkleTree.getLeaf()`, new convenience methods for merkle trees https://github.com/o1-labs/o1js/pull/1630
 - `MerkleList.forEach()`, a simple and safe way for iterating over a `MerkleList`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ### Added
 
-- **Offchain storage MVP** exported under `Experimental.OffchainStorage` https://github.com/o1-labs/o1js/pull/1630 https://github.com/o1-labs/o1js/pull/1652
+- **Offchain state MVP** exported under `Experimental.OffchainState` https://github.com/o1-labs/o1js/pull/1630 https://github.com/o1-labs/o1js/pull/1652
   - allows you to store any number of fields and key-value maps on your zkApp
   - implemented using actions which define an offchain Merkle tree
 - `Option` for defining an optional version of any provable type https://github.com/o1-labs/o1js/pull/1630

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "o1js",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "o1js",
-      "version": "1.1.0",
+      "version": "1.2.0",
       "license": "Apache-2.0",
       "dependencies": {
         "blakejs": "1.2.1",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "o1js",
   "description": "TypeScript framework for zk-SNARKs and zkApps",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "license": "Apache-2.0",
   "homepage": "https://github.com/o1-labs/o1js/",
   "keywords": [

--- a/src/index.ts
+++ b/src/index.ts
@@ -128,6 +128,7 @@ export { setNumberOfWorkers } from './lib/proof-system/workers.js';
 
 // experimental APIs
 import { memoizeWitness } from './lib/provable/provable.js';
+import * as OffchainState_ from './lib/mina/actions/offchain-state.js';
 export { Experimental };
 
 const Experimental_ = {
@@ -140,6 +141,19 @@ const Experimental_ = {
  */
 namespace Experimental {
   export let memoizeWitness = Experimental_.memoizeWitness;
+
+  // offchain state
+  export let OffchainState = OffchainState_.OffchainState;
+
+  /**
+   * Commitments that keep track of the current state of an offchain Merkle tree constructed from actions.
+   * Intended to be stored on-chain.
+   *
+   * Fields:
+   * - `root`: The root of the current Merkle tree
+   * - `actionState`: The hash pointing to the list of actions that have been applied to form the current Merkle tree
+   */
+  export class OffchainStateCommitments extends OffchainState_.OffchainStateCommitments {}
 }
 
 Error.stackTraceLimit = 100000;

--- a/src/lib/mina/actions/offchain-contract.unit-test.ts
+++ b/src/lib/mina/actions/offchain-contract.unit-test.ts
@@ -111,7 +111,11 @@ console.timeEnd('deploy');
 
 console.time('create account');
 await Mina.transaction(sender, async () => {
+  // first call (should succeed)
   await contract.createAccount(sender, UInt64.from(1000));
+
+  // second call (should fail)
+  await contract.createAccount(sender, UInt64.from(2000));
 })
   .sign([sender.key])
   .prove()
@@ -137,9 +141,13 @@ await checkAgainstSupply(1000n);
 // transfer
 
 console.time('transfer');
-await Mina.transaction(sender, () =>
-  contract.transfer(sender, receiver, UInt64.from(100))
-)
+await Mina.transaction(sender, async () => {
+  // first call (should succeed)
+  await contract.transfer(sender, receiver, UInt64.from(100));
+
+  // second call (should fail)
+  await contract.transfer(sender, receiver, UInt64.from(200));
+})
   .sign([sender.key])
   .prove()
   .send();

--- a/src/lib/mina/actions/offchain-contract.unit-test.ts
+++ b/src/lib/mina/actions/offchain-contract.unit-test.ts
@@ -50,11 +50,11 @@ class ExampleContract extends SmartContract {
      * This is safe, because both updates will only be accepted if both previous balances are still correct.
      */
     offchainState.fields.accounts.update(from, {
-      from: fromBalance,
+      from: fromOption,
       to: fromBalance.sub(amount),
     });
     offchainState.fields.accounts.update(to, {
-      from: toBalance,
+      from: toOption,
       to: toBalance.add(amount),
     });
   }

--- a/src/lib/mina/actions/offchain-contract.unit-test.ts
+++ b/src/lib/mina/actions/offchain-contract.unit-test.ts
@@ -27,13 +27,13 @@ class ExampleContract extends SmartContract {
 
     // TODO using `update()` on the total supply means that this method
     // can only be called once every settling cycle
-    let totalSupply = await offchainState.fields.totalSupply.get();
-    offchainState.fields.totalSupply.set(totalSupply.add(amountToMint));
-    // TODO this fails, because `from` does not yield the correct value hash if the field was not set before
-    // offchainState.fields.totalSupply.update({
-    //   from: totalSupply,
-    //   to: totalSupply.add(amountToMint),
-    // });
+    let totalSupplyOption = await offchainState.fields.totalSupply.get();
+    let totalSupply = totalSupplyOption.orElse(0n);
+
+    offchainState.fields.totalSupply.update({
+      from: totalSupplyOption,
+      to: totalSupply.add(amountToMint),
+    });
   }
 
   @method
@@ -61,7 +61,7 @@ class ExampleContract extends SmartContract {
 
   @method.returns(UInt64)
   async getSupply() {
-    return await offchainState.fields.totalSupply.get();
+    return (await offchainState.fields.totalSupply.get()).orElse(0n);
   }
 
   @method.returns(UInt64)

--- a/src/lib/mina/actions/offchain-contract.unit-test.ts
+++ b/src/lib/mina/actions/offchain-contract.unit-test.ts
@@ -23,7 +23,7 @@ class ExampleContract extends SmartContract {
 
   @method
   async createAccount(address: PublicKey, amountToMint: UInt64) {
-    offchainState.fields.accounts.set(address, amountToMint);
+    offchainState.fields.accounts.overwrite(address, amountToMint);
 
     // TODO using `update()` on the total supply means that this method
     // can only be called once every settling cycle

--- a/src/lib/mina/actions/offchain-contract.unit-test.ts
+++ b/src/lib/mina/actions/offchain-contract.unit-test.ts
@@ -32,7 +32,11 @@ class ExampleContract extends SmartContract {
 
   @method
   async createAccount(address: PublicKey, amountToMint: UInt64) {
-    offchainState.fields.accounts.overwrite(address, amountToMint);
+    // setting `from` to `undefined` means that the account must not exist yet
+    offchainState.fields.accounts.update(address, {
+      from: undefined,
+      to: amountToMint,
+    });
 
     // TODO using `update()` on the total supply means that this method
     // can only be called once every settling cycle
@@ -166,10 +170,12 @@ await Mina.transaction(sender, async () => {
   await contract.transfer(sender, receiver, UInt64.from(200));
   await contract.transfer(sender, receiver, UInt64.from(300));
   await contract.transfer(sender, receiver, UInt64.from(400));
-  await contract.transfer(sender, receiver, UInt64.from(500));
 
   // create another account (should succeed)
   await contract.createAccount(other, UInt64.from(555));
+
+  // create existing account again (should fail)
+  await contract.createAccount(receiver, UInt64.from(333));
 })
   .sign([sender.key])
   .prove()

--- a/src/lib/mina/actions/offchain-state-rollup.ts
+++ b/src/lib/mina/actions/offchain-state-rollup.ts
@@ -28,6 +28,14 @@ class ActionIterator extends MerkleListIterator.create(
   Actions.emptyActionState()
 ) {}
 
+/**
+ * Commitments that keep track of the current state of an offchain Merkle tree constructed from actions.
+ * Intended to be stored on-chain.
+ *
+ * Fields:
+ * - `root`: The root of the current Merkle tree
+ * - `actionState`: The hash pointing to the list of actions that have been applied to form the current Merkle tree
+ */
 class OffchainStateCommitments extends Struct({
   // this should just be a MerkleTree type that carries the full tree as aux data
   root: Field,

--- a/src/lib/mina/actions/offchain-state-rollup.ts
+++ b/src/lib/mina/actions/offchain-state-rollup.ts
@@ -302,20 +302,17 @@ function OffchainStateRollup({
       }
 
       // base proof
-      console.time('batch 0');
       let slice = sliceActions(iterator, maxActionsPerBatch);
       let proof = await offchainStateRollup.firstBatch(
         inputState,
         slice,
         Unconstrained.from(tree)
       );
-      console.timeEnd('batch 0');
 
       // recursive proofs
       for (let i = 1; ; i++) {
         if (iterator.isAtEnd().toBoolean()) break;
 
-        console.time(`batch ${i}`);
         let slice = sliceActions(iterator, maxActionsPerBatch);
         proof = await offchainStateRollup.nextBatch(
           inputState,
@@ -323,7 +320,6 @@ function OffchainStateRollup({
           Unconstrained.from(tree),
           proof
         );
-        console.timeEnd(`batch ${i}`);
       }
 
       return { proof, tree };

--- a/src/lib/mina/actions/offchain-state-rollup.ts
+++ b/src/lib/mina/actions/offchain-state-rollup.ts
@@ -105,7 +105,9 @@ function merkleUpdateBatch(
  * This program represents a proof that we can go from OffchainStateCommitments A -> B
  */
 function OffchainStateRollup({
-  maxUpdatesPerBatch = 2,
+  // 1 actions uses about 7.5k constraints
+  // we can fit 7 * 7.5k = 52.5k constraints in one method next to the proof verification
+  maxUpdatesPerBatch = 3,
   maxActionsPerUpdate = 2,
 } = {}) {
   let offchainStateRollup = ZkProgram({

--- a/src/lib/mina/actions/offchain-state-rollup.ts
+++ b/src/lib/mina/actions/offchain-state-rollup.ts
@@ -115,15 +115,6 @@ function merkleUpdateBatch(
     let actualPreviousValue = Provable.witness(Field, () =>
       intermediateTree.get().getLeaf(key.toBigInt())
     );
-    Provable.log({
-      key,
-      value,
-      isCheckPoint,
-      isDummy,
-      usesPreviousValue,
-      previousValue,
-      actualPreviousValue,
-    });
 
     // prove that the witness and `actualPreviousValue` is correct, by comparing the implied root and key
     // note: this just works if the (key, value) is a (0,0) dummy, because the value at the 0 key will always be 0

--- a/src/lib/mina/actions/offchain-state.ts
+++ b/src/lib/mina/actions/offchain-state.ts
@@ -198,7 +198,23 @@ function OffchainState<
         let update = contract().self;
         update.body.actions = Actions.pushEvent(update.body.actions, action);
       },
-      update: notImplemented,
+
+      update({ from, to }) {
+        // serialize into action
+        let action = toAction({
+          prefix,
+          keyType: undefined,
+          valueType: type,
+          key: undefined,
+          value: type.fromValue(to),
+          previousValue: type.fromValue(from),
+        });
+
+        // push action on account update
+        let update = contract().self;
+        update.body.actions = Actions.pushEvent(update.body.actions, action);
+      },
+
       async get() {
         let key = toKeyHash(prefix, undefined, undefined);
         let optionValue = await get(key, type);
@@ -230,7 +246,23 @@ function OffchainState<
         let update = contract().self;
         update.body.actions = Actions.pushEvent(update.body.actions, action);
       },
-      update: notImplemented,
+
+      update(key, { from, to }) {
+        // serialize into action
+        let action = toAction({
+          prefix,
+          keyType,
+          valueType,
+          key,
+          value: valueType.fromValue(to),
+          previousValue: valueType.fromValue(from),
+        });
+
+        // push action on account update
+        let update = contract().self;
+        update.body.actions = Actions.pushEvent(update.body.actions, action);
+      },
+
       async get(key) {
         let keyHash = toKeyHash(prefix, keyType, key);
         return await get(keyHash, valueType);

--- a/src/lib/mina/actions/offchain-state.ts
+++ b/src/lib/mina/actions/offchain-state.ts
@@ -215,9 +215,7 @@ function OffchainState<
 
       async get() {
         let key = toKeyHash(prefix, undefined, undefined);
-        let optionValue = await get(key, type);
-        // for fields that are not in the map, we return the default value -- similar to onchain state
-        return optionValue.orElse(type.empty());
+        return await get(key, type);
       },
     };
   }
@@ -342,13 +340,15 @@ function OffchainField<T extends Any>(type: T) {
 }
 type OffchainField<T, TValue> = {
   /**
-   * Get the value of the field.
+   * Get the value of the field, or none if it doesn't exist yet.
    */
-  get(): Promise<T>;
+  get(): Promise<Option<T>>;
+
   /**
    * Set the value of the field.
    */
   set(value: T | TValue): void;
+
   /**
    * Update the value of the field, while requiring a specific previous value.
    *
@@ -367,10 +367,12 @@ type OffchainMap<K, V, VValue> = {
    * Get the value for this key, or none if it doesn't exist.
    */
   get(key: K): Promise<Option<V, VValue>>;
+
   /**
    * Set the value for this key.
    */
   set(key: K, value: V | VValue): void;
+
   /**
    * Update the value of the field, while requiring a specific previous value.
    *

--- a/src/lib/mina/actions/offchain-state.ts
+++ b/src/lib/mina/actions/offchain-state.ts
@@ -70,6 +70,24 @@ type OffchainState<Config extends { [key: string]: OffchainStateKind }> = {
 
   /**
    * Settle the offchain state.
+   *
+   * Use this in a contract method as follows:
+   *
+   * @example
+   * ```ts
+   * class StateProof extends offchainState.Proof {}
+   *
+   * // ...
+   *
+   * class MyContract extends SmartContract {
+   *   \@method
+   *   async settle(proof: StateProof) {
+   *     await offchainState.settle(proof);
+   *   }
+   * }
+   * ```
+   *
+   * The `StateProof` can be created by calling `offchainState.createSettlementProof()`.
    */
   settle(
     proof: Proof<OffchainStateCommitments, OffchainStateCommitments>
@@ -82,6 +100,35 @@ type OffchainStateContract = SmartContract & {
 
 const MerkleWitness256 = MerkleWitness(256);
 
+/**
+ * Offchain state for a `SmartContract`.
+ *
+ * ```ts
+ * // declare your offchain state
+ *
+ * const offchainState = OffchainState({
+ *   accounts: OffchainState.Map(PublicKey, UInt64),
+ *   totalSupply: OffchainState.Field(UInt64),
+ * });
+ *
+ * // use it in a contract, by adding an onchain state field of type `OffchainStateCommitments`
+ *
+ * class MyContract extends SmartContract {
+ *  \@state(OffchainStateCommitments) offchainState = State(
+ *    OffchainStateCommitments.empty()
+ *   );
+ *
+ *   // ...
+ * }
+ *
+ * // set the contract instance
+ *
+ * let contract = new MyContract(address);
+ * offchainState.setContractInstance(contract);
+ * ```
+ *
+ * See the individual methods on `offchainState` for more information on usage.
+ */
 function OffchainState<
   const Config extends { [key: string]: OffchainStateKind }
 >(config: Config): OffchainState<Config> {

--- a/src/lib/mina/actions/offchain-state.ts
+++ b/src/lib/mina/actions/offchain-state.ts
@@ -120,8 +120,6 @@ function OffchainState<
     return { merkleMap, valueMap };
   };
 
-  const notImplemented = (): any => assert(false, 'Not implemented');
-
   let rollup = OffchainStateRollup();
 
   function contract() {
@@ -207,7 +205,7 @@ function OffchainState<
           valueType: type,
           key: undefined,
           value: type.fromValue(to),
-          previousValue: type.fromValue(from),
+          previousValue: from,
         });
 
         // push action on account update
@@ -255,7 +253,7 @@ function OffchainState<
           valueType,
           key,
           value: valueType.fromValue(to),
-          previousValue: valueType.fromValue(from),
+          previousValue: from,
         });
 
         // push action on account update
@@ -355,9 +353,10 @@ type OffchainField<T, TValue> = {
    * Update the value of the field, while requiring a specific previous value.
    *
    * If the previous value does not match, the update will not be applied.
-   * If no previous value is present, the `from` value is ignored and the update applied unconditionally.
+   *
+   * Note that the previous value is an option: to require that the field was not set before, use `Option.none()`.
    */
-  update(update: { from: T | TValue; to: T | TValue }): void;
+  update(update: { from: Option<T>; to: T | TValue }): void;
 };
 
 function OffchainMap<K extends Any, V extends Any>(key: K, value: V) {
@@ -376,9 +375,10 @@ type OffchainMap<K, V, VValue> = {
    * Update the value of the field, while requiring a specific previous value.
    *
    * If the previous value does not match, the update will not be applied.
-   * If no previous value is present, the `from` value is ignored and the update applied unconditionally.
+   *
+   * Note that the previous value is an option: to require that the field was not set before, use `Option.none()`.
    */
-  update(key: K, update: { from: V | VValue; to: V | VValue }): void;
+  update(key: K, update: { from: Option<V>; to: V | VValue }): void;
 };
 
 type OffchainStateKind =

--- a/src/lib/mina/actions/offchain-state.ts
+++ b/src/lib/mina/actions/offchain-state.ts
@@ -186,13 +186,13 @@ function OffchainState<
     return {
       set(value) {
         // serialize into action
-        let action = toAction(
+        let action = toAction({
           prefix,
-          undefined,
-          type,
-          undefined,
-          type.fromValue(value)
-        );
+          keyType: undefined,
+          valueType: type,
+          key: undefined,
+          value: type.fromValue(value),
+        });
 
         // push action on account update
         let update = contract().self;
@@ -218,13 +218,13 @@ function OffchainState<
     return {
       set(key, value) {
         // serialize into action
-        let action = toAction(
+        let action = toAction({
           prefix,
           keyType,
           valueType,
           key,
-          valueType.fromValue(value)
-        );
+          value: valueType.fromValue(value),
+        });
 
         // push action on account update
         let update = contract().self;

--- a/src/lib/provable/bool.ts
+++ b/src/lib/provable/bool.ts
@@ -92,6 +92,22 @@ class Bool {
   }
 
   /**
+   * Whether this Bool implies another Bool `y`.
+   *
+   * This is the same as `x.not().or(y)`: if `x` is true, then `y` must be true for the implication to be true.
+   *
+   * @example
+   * ```ts
+   * let isZero = x.equals(0);
+   * let lessThan10 = x.lessThan(10);
+   * assert(isZero.implies(lessThan10), 'x = 0 implies x < 10');
+   * ```
+   */
+  implies(y: Bool | boolean): Bool {
+    return this.not().or(y);
+  }
+
+  /**
    * Proves that this {@link Bool} is equal to `y`.
    * @param y a {@link Bool}.
    */

--- a/src/lib/provable/merkle-list.ts
+++ b/src/lib/provable/merkle-list.ts
@@ -209,7 +209,9 @@ class MerkleList<T> implements MerkleListBase<T> {
       let { element, isDummy } = iter.Unsafe.next();
       callback(element, isDummy, i);
     }
-    iter.assertAtEnd();
+    iter.assertAtEnd(
+      `Expected MerkleList to have at most ${length} elements, but it has more.`
+    );
   }
 
   startIterating(): MerkleListIterator<T> {
@@ -394,8 +396,11 @@ class MerkleListIterator<T> implements MerkleListIteratorBase<T> {
     this.currentHash = Provable.if(condition, this.hash, this.currentHash);
   }
 
-  assertAtEnd() {
-    return this.currentHash.assertEquals(this.hash);
+  assertAtEnd(message?: string) {
+    return this.currentHash.assertEquals(
+      this.hash,
+      message ?? 'Merkle list iterator is not at the end'
+    );
   }
 
   isAtStart() {

--- a/src/lib/provable/option.ts
+++ b/src/lib/provable/option.ts
@@ -1,4 +1,4 @@
-import { InferValue } from '../../bindings/lib/provable-generic.js';
+import { From, InferValue } from '../../bindings/lib/provable-generic.js';
 import { emptyValue } from '../proof-system/zkprogram.js';
 import { Provable } from './provable.js';
 import { InferProvable, Struct } from './types/struct.js';
@@ -11,7 +11,7 @@ type Option<T, V = any> = { isSome: Bool; value: T } & {
   orElse(defaultValue: T | V): T;
 };
 
-type OptionOrValue<T, V> = Option<T, V> | { isSome: boolean; value: V };
+type OptionOrValue<T, V> = { isSome: boolean | Bool; value: V | T };
 
 /**
  * Define an optional version of a provable type.
@@ -36,6 +36,9 @@ function Option<A extends Provable<any, any>>(
   // TODO make V | undefined the value type
   { isSome: boolean; value: InferValue<A> }
 > & {
+  fromValue: (
+    value: From<{ isSome: typeof Bool; value: A }>
+  ) => Option<InferProvable<A>, InferValue<A>>;
   from(value?: InferProvable<A>): Option<InferProvable<A>, InferValue<A>>;
   none(): Option<InferProvable<A>, InferValue<A>>;
 } {

--- a/src/lib/provable/option.ts
+++ b/src/lib/provable/option.ts
@@ -74,7 +74,7 @@ function Option<A extends Provable<any, any>>(
         return { isSome: Bool(false), value: emptyValue(strictType) };
       // TODO: this isn't 100% robust. We would need recursive type validation on any nested objects to make it work
       if (typeof value === 'object' && 'isSome' in value)
-        return PlainOption.fromValue(value as any);
+        return PlainOption.fromValue(value as any); // type-cast here is ok, matches implementation
       return { isSome: Bool(true), value: strictType.fromValue(value) };
     },
   };

--- a/src/lib/provable/types/unconstrained.ts
+++ b/src/lib/provable/types/unconstrained.ts
@@ -110,7 +110,7 @@ and Provable.asProver() blocks, which execute outside the proof.
     });
   }
 
-  static provable: Provable<Unconstrained<any>> & {
+  static provable: Provable<Unconstrained<any>, Unconstrained<any>> & {
     toInput: (x: Unconstrained<any>) => {
       fields?: Field[];
       packed?: [Field, number][];
@@ -130,7 +130,10 @@ and Provable.asProver() blocks, which execute outside the proof.
     },
   };
 
-  static provableWithEmpty<T>(empty: T): Provable<Unconstrained<T>> & {
+  static provableWithEmpty<T>(empty: T): Provable<
+    Unconstrained<T>,
+    Unconstrained<T>
+  > & {
     toInput: (x: Unconstrained<any>) => {
       fields?: Field[];
       packed?: [Field, number][];

--- a/src/lib/provable/types/unconstrained.ts
+++ b/src/lib/provable/types/unconstrained.ts
@@ -93,7 +93,7 @@ and Provable.asProver() blocks, which execute outside the proof.
   /**
    * Create an `Unconstrained` from a witness computation.
    */
-  static witness<T>(compute: () => T) {
+  static witness<T>(compute: () => T): Unconstrained<T> {
     return witness(
       Unconstrained.provable,
       () => new Unconstrained(true, compute())


### PR DESCRIPTION
* follow up for #1630
* releases the MVP as `Experimental.OffchainState`
* adds an `update()` method for which allows a state precondition
  * a single failed precondition causes all state changes in an entire update (method call) to be skipped
  * precondition is in the form of an `Option<T>` so that we can require the previous state to either exist or not exist
  * `field.get()` was changed to return an option, otherwise we wouldn't have access to that info
* improve Merkle update efficiency, by first transforming actions into a flat list without dummies due to fewer actions per update
  * previously, 3 updates per batch + 2 actions per update caused 6 in-circuit merkle updates
  * now, 6 actions per batch + n actions per update (n <= 6) cause 6 in-circuit merkle updates
  * the amount of updates per batch we process is no longer uniform. instead, we process a fixed number of _actions_ per batch

TODO:
* [x] make failed updates work (change Merkle update logic everywhere, not just in the offchain prover)