### PR TITLE
Fix method.returns() inference

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 ### Fixes
 
 - Fix absolute imports which prevented compilation in some TS projects that used o1js https://github.com/o1-labs/o1js/pull/1628
+- Fix type inference for `method.returns(Type)`, to require a matching return signature https://github.com/o1-labs/o1js/pull/1653
 
 ## [1.1.0](https://github.com/o1-labs/o1js/compare/1ad7333e9e...4a17de857) - 2024-04-30
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,10 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased](https://github.com/o1-labs/o1js/compare/6a1012162...HEAD)
 
+### Fixes
+
+- Fix type inference for `method.returns(Type)`, to require a matching return signature https://github.com/o1-labs/o1js/pull/1653
+
 ## [1.2.0](https://github.com/o1-labs/o1js/compare/4a17de857...6a1012162) - 2024-05-14
 
 ### Added
@@ -41,7 +45,6 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 ### Fixes
 
 - Fix absolute imports which prevented compilation in some TS projects that used o1js https://github.com/o1-labs/o1js/pull/1628
-- Fix type inference for `method.returns(Type)`, to require a matching return signature https://github.com/o1-labs/o1js/pull/1653
 
 ## [1.1.0](https://github.com/o1-labs/o1js/compare/1ad7333e9e...4a17de857) - 2024-04-30
 

--- a/src/lib/mina/zkapp.ts
+++ b/src/lib/mina/zkapp.ts
@@ -19,6 +19,7 @@ import {
 import {
   cloneCircuitValue,
   FlexibleProvablePure,
+  InferProvable,
 } from '../provable/types/struct.js';
 import {
   Provable,
@@ -170,12 +171,14 @@ function method<K extends string, T extends SmartContract>(
  * }
  * ```
  */
-method.returns = function <K extends string, T extends SmartContract, R>(
-  returnType: Provable<R>
-) {
+method.returns = function <
+  K extends string,
+  T extends SmartContract,
+  R extends Provable<any>
+>(returnType: R) {
   return function decorateMethod(
     target: T & {
-      [k in K]: (...args: any) => Promise<R>;
+      [k in K]: (...args: any) => Promise<InferProvable<R>>;
     },
     methodName: K & string & keyof T,
     descriptor: PropertyDescriptor


### PR DESCRIPTION
Without this PR, method return types were inferred as `any`, so the `method.returns(Type)` decorator allowed the method to return any type. Now, the return type has to match the `Type` value

### Is this a breaking change? (no)

In my opinion, generic type parameter changes are a grey area, and we should decide case-by-case whether we consider them breaking the API:
* In most cases, the _intention_ is for the type parameter to be inferred, not to be passed in explicitly. This is especially the case when the generic type signature is very complex and you wouldn't expect anyone to try to make it explicit. In that case, I would consider the type params not public API
* In some cases where type parameters are designed to be / in practice are passed in explicitly, we should consider them public API and apply semver to them

I'm confident that we can consider this change as an example of the first case, and consider this not a breaking change.

![image](https://github.com/o1-labs/o1js/assets/20989968/de69811c-ecdb-4ab6-899a-66a2169a7eee)
