### PR TITLE
Handle missing extended provable methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 ### Fixes
 
 - Fix type inference for `method.returns(Type)`, to require a matching return signature https://github.com/o1-labs/o1js/pull/1653
+- Fix `Struct.empty()` returning a garbage object when one of the base types doesn't support `empty()` https://github.com/o1-labs/o1js/pull/1657
 
 ## [1.2.0](https://github.com/o1-labs/o1js/compare/4a17de857...6a1012162) - 2024-05-14
 

--- a/src/lib/provable/group.ts
+++ b/src/lib/provable/group.ts
@@ -352,16 +352,16 @@ class Group {
       fields: [x.x, x.y],
     };
   }
+
+  static empty() {
+    return Group.zero;
+  }
 }
 
 // internal helpers
 
 function isConstant(g: Group) {
   return g.x.isConstant() && g.y.isConstant();
-}
-
-function toTuple(g: Group): [0, FieldVar, FieldVar] {
-  return [0, g.x.value, g.y.value];
 }
 
 function toProjective(g: Group) {

--- a/src/lib/provable/scalar.ts
+++ b/src/lib/provable/scalar.ts
@@ -317,6 +317,10 @@ class Scalar implements ShiftedScalar {
   static fromJSON(x: string) {
     return Scalar.from(SignableFq.fromJSON(x));
   }
+
+  static empty() {
+    return Scalar.from(0n);
+  }
 }
 
 // internal helpers

--- a/src/lib/provable/test/struct.unit-test.ts
+++ b/src/lib/provable/test/struct.unit-test.ts
@@ -18,6 +18,8 @@ import { Bool } from '../bool.js';
 import assert from 'assert/strict';
 import { FieldType } from '../core/fieldvar.js';
 import { From } from '../../../bindings/lib/provable-generic.js';
+import { Group } from '../group.js';
+import { modifiedField } from '../types/fields.js';
 
 let type = provable({
   nested: { a: Number, b: Boolean },
@@ -85,6 +87,26 @@ expect(jsValue).toEqual({
 
 expect(type.fromValue(jsValue)).toEqual(value);
 
+// empty
+let empty = type.empty();
+expect(empty).toEqual({
+  nested: { a: 0, b: false },
+  other: '',
+  pk: PublicKey.empty(),
+  bool: new Bool(false),
+  uint: [UInt32.zero, UInt32.zero],
+});
+
+// empty with Group
+expect(provable({ value: Group }).empty()).toEqual({ value: Group.zero });
+
+// fails with a clear error on input without an empty method
+const FieldWithoutEmpty = modifiedField({});
+delete (FieldWithoutEmpty as any).empty;
+expect(() => provable({ value: FieldWithoutEmpty }).empty()).toThrow(
+  'Expected `empty()` method on anonymous type object'
+);
+
 // check
 await Provable.runAndCheck(() => {
   type.check(value);
@@ -120,7 +142,7 @@ class MyStructPure extends Struct({
   uint: [UInt32, UInt32],
 }) {}
 
-// Struct.from() works on both js and provable inputs
+// Struct.fromValue() works on both js and provable inputs
 
 let myStructInput = {
   nested: { a: Field(1), b: 2n },

--- a/src/lib/provable/types/struct.ts
+++ b/src/lib/provable/types/struct.ts
@@ -1,7 +1,6 @@
 import { Field, Bool, Scalar, Group } from '../wrapped.js';
 import {
   provable,
-  provablePure,
   provableTuple,
   HashInput,
   NonMethods,


### PR DESCRIPTION
fixes #1656

* add missing `empty()` methods on `Group` and `Scalar`
* in bindings: properly handle the case of a missing `empty()` method
* cover `empty()` behaviour in unit test
