### PR TITLE
Fix Int64 sign checks and mod

### DIFF
--- a/src/lib/provable/int.ts
+++ b/src/lib/provable/int.ts
@@ -1227,9 +1227,24 @@ class Int64 extends CircuitValue implements BalanceChange {
     this.toField().assertEquals(y_.toField(), message);
   }
   /**
-   * Checks if the value is positive.
+   * @deprecated Use {@link isPositiveV2()} or {@link isNonNegativeV2()} instead.
    */
   isPositive() {
+    return this.sgn.isPositive();
+  }
+
+  /**
+   * Checks if the value is positive (x > 0).
+   */
+  isPositiveV2() {
+    return this.magnitude.equals(UInt64.zero).not().and(this.sgn.isPositive());
+  }
+
+  /**
+   * Checks if the value is non-negative (x >= 0).
+   */
+  isNonNegativeV2() {
+    // this will be the correct logic when `checkV2` is enabled
     return this.sgn.isPositive();
   }
 

--- a/src/lib/provable/int.ts
+++ b/src/lib/provable/int.ts
@@ -1142,14 +1142,26 @@ class Int64 extends CircuitValue implements BalanceChange {
   }
 
   /**
-   * Negates the value.
-   *
-   * `Int64.from(5).neg()` will turn into `Int64.from(-5)`
+   * @deprecated Use {@link negV2()} instead.
    */
   neg() {
     // doesn't need further check if `this` is valid
     return new Int64(this.magnitude, this.sgn.neg());
   }
+
+  /**
+   * Negates the value.
+   *
+   * `Int64.from(5).neg()` will turn into `Int64.from(-5)`
+   */
+  negV2() {
+    return Provable.if(
+      this.magnitude.value.equals(0),
+      Int64.zero,
+      new Int64(this.magnitude, this.sgn.neg())
+    );
+  }
+
   /**
    * Addition with overflow checking.
    */


### PR DESCRIPTION
- add Int64 check method which doesn't allow ambiguous 0, to be enabled in v2
- fix `neg()` in the unique representation
- deprecate misleading `isPositive()` and replace with to v2 methods
- fixed version of Int64.mod()
