### PR TITLE
Add dynamic SHA256 update method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,11 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ### Added
 
+- Added `SHA256Hasher` class that allows streaming preimage bytes into a provable SHA256 hash function.
+  - exposed via `Gadgets.SHA256.update(data)`
+
+### Added
+
 - Added `base64Encode()` and `base64Decode(byteLength)` methods to the `Bytes` class.
 
 ### Fixes

--- a/src/examples/crypto/sha256/run.ts
+++ b/src/examples/crypto/sha256/run.ts
@@ -1,5 +1,11 @@
-import { Bytes12, SHA256Program } from './sha256.js';
+import {
+  Bytes12,
+  SHA256Program,
+  SHA256UpdateProgram,
+  Bytes6,
+} from './sha256.js';
 
+console.log('SHA256Program Benchmarks');
 console.time('compile');
 await SHA256Program.compile();
 console.timeEnd('compile');
@@ -21,3 +27,30 @@ if (
 )
   throw new Error('Invalid sha256 digest!');
 if (!isValid) throw new Error('Invalid proof');
+
+console.log('\nSHA256UpdateProgram Benchmarks');
+console.time('compile');
+await SHA256UpdateProgram.compile();
+console.timeEnd('compile');
+
+console.log(
+  'dynamic sha256 rows:',
+  (await SHA256UpdateProgram.analyzeMethods()).update.rows
+);
+
+let preimage1 = Bytes6.fromString('hello ');
+let preimage2 = Bytes6.fromString('world!');
+
+console.time('prove');
+let proofHasher = await SHA256UpdateProgram.update(preimage1, preimage2);
+console.timeEnd('prove');
+let isValidProof = await SHA256UpdateProgram.verify(proofHasher);
+
+console.log('digest:', proofHasher.publicOutput.toHex());
+
+if (
+  proof.publicOutput.toHex() !==
+  '7509e5bda0c762d2bac7f90d758b5b2263fa01ccbc542ab5e3df163be08e6ca9'
+)
+  throw new Error('Invalid sha256 digest!');
+if (!isValidProof) throw new Error('Invalid proof');

--- a/src/examples/crypto/sha256/sha256.ts
+++ b/src/examples/crypto/sha256/sha256.ts
@@ -1,8 +1,9 @@
 import { Bytes, Gadgets, ZkProgram } from 'o1js';
 
-export { SHA256Program, Bytes12 };
+export { SHA256Program, Bytes12, SHA256UpdateProgram, Bytes6 };
 
 class Bytes12 extends Bytes(12) {}
+class Bytes6 extends Bytes(6) {}
 
 let SHA256Program = ZkProgram({
   name: 'sha256',
@@ -12,6 +13,19 @@ let SHA256Program = ZkProgram({
       privateInputs: [Bytes12.provable],
       async method(xs: Bytes12) {
         return Gadgets.SHA256.hash(xs);
+      },
+    },
+  },
+});
+
+let SHA256UpdateProgram = ZkProgram({
+  name: 'sha256-update',
+  publicOutput: Bytes(32).provable,
+  methods: {
+    update: {
+      privateInputs: [Bytes6.provable, Bytes6.provable],
+      async method(xs1: Bytes6, xs2: Bytes6) {
+        return Gadgets.SHA256.update(xs1).update(xs2).digest();
       },
     },
   },

--- a/src/lib/provable/gadgets/sha256.ts
+++ b/src/lib/provable/gadgets/sha256.ts
@@ -366,13 +366,13 @@ class SHA256Hasher {
 
       for (let i = 0; i < 16; i++) {
         let j = pos + i * 4;
-        W[i] = new UInt32(
+        W[i] = UInt32.Unsafe.fromField(
           Field.fromBits(
             M.slice(j, (j += 4))
               .map((x) => x.value.toBits(8))
               .reverse()
               .flat()
-          ).value
+          )
         );
       }
 


### PR DESCRIPTION
## Description

- This implementation enables streaming preimage bytes into a provable SHA256 hash function.
- It is primarily an adaptation of [StableLib's](https://github.com/StableLib/stablelib/blob/a7bac13/packages/sha256/sha256.ts) SHA256 class, modified to be provable.

## Changes

- Added a `SHA256Hasher` class.
- Introduced an optional boolean `reverseEndianness` parameter to the `bytesToWords`, `wordsToBytes`, `wordToBytes`, and `bytesToWord` functions in the `bit-slices.ts` file.
- Created a `zkProgram` that demonstrates similar functionality to [SHA256Program](https://github.com/o1-labs/o1js/blob/main/src/examples/crypto/sha256/sha256.ts#L7-L18) but dynamically.
- Added sliding window tests inspired by [noble-hashes test](https://github.com/paulmillr/noble-hashes/blob/main/test/hashes.test.js#L472-L497) in accordance with the [noble approach to testing](https://github.com/paulmillr/noble-hashes/blob/main/test/README.md).

## Notes

- There is some redundant code in the `hashBlocks` method of the hasher class since the core logic is copied from the original `SHA256.hash()` function.
- The dynamic SHA256 is slightly less efficient than the original SHA256 hash function, likely due to byte processing:
  - For `Bytes12` input:
    - `SHA256.hash` --> 5036 rows
    - `SHA256.update` --> 5241 rows
- It's noteworthy that a fluent interface or method chaining works as provable in o1js, which opens up possibilities for various future implementations.
- Attempting to witness a hasher instance with `Provable.witness` is currently not possible, but it would be a valuable feature.
- Observing how noble-hashes use abstract classes with method chaining suggests that it might be possible to migrate many binary hash functions to be provable in o1js, similar to [noble-hashes](https://github.com/paulmillr/noble-hashes).

 