### PR TITLE
Indexed Merkle tree

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ### Added
 
-- `IndexedMerkleMap`, a better primitive for Merkleized storage which uses 4-8x fewer constraints than `MerkleMap` https://github.com/o1-labs/o1js/pull/1666
+- `Experimental.IndexedMerkleMap`, a better primitive for Merkleized storage which uses 4-8x fewer constraints than `MerkleMap` https://github.com/o1-labs/o1js/pull/1666
   - In contrast to `MerkleTree` and `MerkleMap`, `IndexedMerkleMap` has a high-level API that can be used in provable code.
 
 ### Deprecated

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,11 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased](https://github.com/o1-labs/o1js/compare/54d6545bf...HEAD)
 
+### Added
+
+- `IndexedMerkleMap`, a better primitive for Merkleized storage which uses 4-8x fewer constraints than `MerkleMap` https://github.com/o1-labs/o1js/pull/1666
+  - In contrast to `MerkleTree` and `MerkleMap`, `IndexedMerkleMap` has a high-level API that can be used in provable code.
+
 ### Deprecated
 
 - `Int64.isPositive()` and `Int64.mod()` deprecated because they behave incorrectly on `-0` https://github.com/o1-labs/o1js/pull/1660

--- a/src/index.ts
+++ b/src/index.ts
@@ -52,7 +52,7 @@ export { Gadgets } from './lib/provable/gadgets/gadgets.js';
 export { Types } from './bindings/mina-transaction/types.js';
 
 export { MerkleList, MerkleListIterator } from './lib/provable/merkle-list.js';
-export { IndexedMerkleMap } from './lib/provable/merkle-tree-indexed.js';
+import { IndexedMerkleMap } from './lib/provable/merkle-tree-indexed.js';
 export { Option } from './lib/provable/option.js';
 
 export * as Mina from './lib/mina/mina.js';
@@ -134,6 +134,7 @@ export { Experimental };
 
 const Experimental_ = {
   memoizeWitness,
+  IndexedMerkleMap,
 };
 
 /**
@@ -142,6 +143,9 @@ const Experimental_ = {
  */
 namespace Experimental {
   export let memoizeWitness = Experimental_.memoizeWitness;
+
+  // indexed merkle map
+  export let IndexedMerkleMap = Experimental_.IndexedMerkleMap;
 
   // offchain state
   export let OffchainState = OffchainState_.OffchainState;

--- a/src/index.ts
+++ b/src/index.ts
@@ -52,6 +52,7 @@ export { Gadgets } from './lib/provable/gadgets/gadgets.js';
 export { Types } from './bindings/mina-transaction/types.js';
 
 export { MerkleList, MerkleListIterator } from './lib/provable/merkle-list.js';
+export { IndexedMerkleMap } from './lib/provable/merkle-tree-indexed.js';
 export { Option } from './lib/provable/option.js';
 
 export * as Mina from './lib/mina/mina.js';

--- a/src/lib/provable/bytes.ts
+++ b/src/lib/provable/bytes.ts
@@ -198,6 +198,7 @@ class Bytes {
   static _size?: number;
   static _provable?: ProvablePureExtended<
     Bytes,
+    { bytes: { value: bigint }[] },
     { bytes: { value: string }[] }
   >;
 

--- a/src/lib/provable/core/provable-context.ts
+++ b/src/lib/provable/core/provable-context.ts
@@ -26,6 +26,7 @@ export {
   inCompileMode,
   gatesFromJson,
   printGates,
+  summarizeGates,
   MlConstraintSystem,
 };
 
@@ -167,13 +168,7 @@ function constraintSystemToJS(cs: MlConstraintSystem) {
       printGates(gates);
     },
     summary() {
-      let gateTypes: Partial<Record<GateType | 'Total rows', number>> = {};
-      gateTypes['Total rows'] = rows;
-      for (let gate of gates) {
-        gateTypes[gate.type] ??= 0;
-        gateTypes[gate.type]!++;
-      }
-      return gateTypes;
+      return summarizeGates(gates);
     },
   };
 }
@@ -186,6 +181,18 @@ function gatesFromJson(cs: { gates: JsonGate[]; public_input_size: number }) {
     return { type: typ, wires, coeffs };
   });
   return { publicInputSize: cs.public_input_size, gates };
+}
+
+// collect a summary of the constraint system
+
+function summarizeGates(gates: Gate[]) {
+  let gateTypes: Partial<Record<GateType | 'Total rows', number>> = {};
+  gateTypes['Total rows'] = gates.length;
+  for (let gate of gates) {
+    gateTypes[gate.type] ??= 0;
+    gateTypes[gate.type]!++;
+  }
+  return gateTypes;
 }
 
 // print a constraint system

--- a/src/lib/provable/crypto/foreign-curve.ts
+++ b/src/lib/provable/crypto/foreign-curve.ts
@@ -242,6 +242,7 @@ class ForeignCurve {
   static _Scalar?: typeof AlmostForeignField;
   static _provable?: ProvablePureExtended<
     ForeignCurve,
+    { x: bigint; y: bigint },
     { x: string; y: string }
   >;
 

--- a/src/lib/provable/crypto/foreign-ecdsa.ts
+++ b/src/lib/provable/crypto/foreign-ecdsa.ts
@@ -164,6 +164,7 @@ class EcdsaSignature {
   static _Curve?: typeof ForeignCurve;
   static _provable?: ProvablePureExtended<
     EcdsaSignature,
+    { r: bigint; s: bigint },
     { r: string; s: string }
   >;
 

--- a/src/lib/provable/merkle-tree-indexed.ts
+++ b/src/lib/provable/merkle-tree-indexed.ts
@@ -52,6 +52,16 @@ class IndexedMerkleMap implements IndexedMerkleMapBase {
     readonly sortedLeaves: LeafValue[];
   }>;
 
+  static provable = provableFromClass(IndexedMerkleMap, {
+    root: Field,
+    length: Field,
+    height: Number,
+    data: Unconstrained.provableWithEmpty({
+      nodes: [] as (bigint | undefined)[][],
+      sortedLeaves: [] as LeafValue[],
+    }),
+  });
+
   /**
    * Creates a new, empty Indexed Merkle Map, given its height.
    */

--- a/src/lib/provable/merkle-tree-indexed.ts
+++ b/src/lib/provable/merkle-tree-indexed.ts
@@ -1,0 +1,29 @@
+import { Field } from './field.js';
+import { Option } from './option.js';
+import { Struct } from './types/struct.js';
+
+type IndexedMerkleMapBase = {
+  // (lower-level) method to insert a new leaf `(key, value)`. proves that `key` doesn't exist yet
+  insert(key: Field, value: Field): void;
+
+  // (lower-level) method to update an existing leaf `(key, value)`. proves that the `key` exists.
+  update(key: Field, value: Field): void;
+
+  // method that performs _either_ an insertion or update, depending on whether the key exists
+  set(key: Field, value: Field): void;
+
+  // method to get a value from a key. returns an option to account for the key not existing
+  // note: this has to prove that the option's `isSome` is correct
+  get(key: Field): Option<Field>; // the optional `Field` here is the value
+
+  // optional / nice-to-have: remove a key and its value from the tree; proves that the key is included.
+  // (implementation: leave a wasted leaf in place but skip it in the linked list encoding)
+  remove(key: Field): void;
+};
+
+class Leaf extends Struct({
+  key: Field,
+  value: Field,
+  nextKey: Field,
+  nextIndex: Field,
+}) {}

--- a/src/lib/provable/merkle-tree-indexed.ts
+++ b/src/lib/provable/merkle-tree-indexed.ts
@@ -296,15 +296,15 @@ class IndexedMerkleMap implements IndexedMerkleMapBase {
    */
   private setLeafUnconstrained(leafExists: Bool | boolean, leaf: Leaf) {
     Provable.asProver(() => {
+      let { nodes, sortedLeaves } = this.data.get();
+
       // update internal hash nodes
       let i = Number(leaf.index.toBigInt());
-      let nodes = this.data.get().nodes;
       Nodes.setLeafNode(nodes, i, Leaf.hashNode(leaf).toBigInt());
 
       // update sorted list
       let leafValue = Leaf.toValue(leaf);
       let iSorted = leaf.sortedIndex.get();
-      let { sortedLeaves } = this.data.get();
 
       if (Bool(leafExists).toBoolean()) {
         sortedLeaves[iSorted] = leafValue;

--- a/src/lib/provable/merkle-tree-indexed.ts
+++ b/src/lib/provable/merkle-tree-indexed.ts
@@ -20,7 +20,7 @@ export { Leaf };
  * Class factory for an Indexed Merkle Map with a given height.
  *
  * ```ts
- * class MerkleMap extends IndexedMerkleMap(3) {}
+ * class MerkleMap extends IndexedMerkleMap(33) {}
  *
  * let map = new MerkleMap();
  *
@@ -37,6 +37,7 @@ export { Leaf };
  *   methods: {
  *     test: {
  *       privateInputs: [MerkleMap.provable, Field],
+ *
  *       method(map: MerkleMap, key: Field) {
  *         // get the value associated with `key`
  *         let value = map.get(key).orElse(0n);

--- a/src/lib/provable/merkle-tree-indexed.ts
+++ b/src/lib/provable/merkle-tree-indexed.ts
@@ -122,7 +122,10 @@ class IndexedMerkleMap implements IndexedMerkleMapBase {
     this.data = Unconstrained.from({ nodes, sortedLeaves });
   }
 
-  insert(key: Field, value: Field) {
+  insert(key: Field | bigint, value: Field | bigint) {
+    key = Field(key);
+    value = Field(value);
+
     // prove that the key doesn't exist yet by presenting a valid low node
     let low = Provable.witness(Leaf, () => this.findLeaf(key).low);
     this.proveInclusion(low, 'Invalid low node');
@@ -149,7 +152,10 @@ class IndexedMerkleMap implements IndexedMerkleMapBase {
     this.setLeafUnconstrained(false, leaf);
   }
 
-  update(key: Field, value: Field) {
+  update(key: Field | bigint, value: Field | bigint) {
+    key = Field(key);
+    value = Field(value);
+
     // prove that the key exists by presenting a leaf that contains it
     let self = Provable.witness(Leaf, () => this.findLeaf(key).self);
     this.proveInclusion(self, 'Key does not exist in the tree');
@@ -161,7 +167,10 @@ class IndexedMerkleMap implements IndexedMerkleMapBase {
     this.setLeafUnconstrained(true, newSelf);
   }
 
-  set(key: Field, value: Field) {
+  set(key: Field | bigint, value: Field | bigint) {
+    key = Field(key);
+    value = Field(value);
+
     // prove whether the key exists or not, by showing a valid low node
     let { low, self } = Provable.witness(LeafPair, () => this.findLeaf(key));
     this.proveInclusion(low, 'Invalid low node');
@@ -195,7 +204,9 @@ class IndexedMerkleMap implements IndexedMerkleMapBase {
     this.setLeafUnconstrained(keyExists, newLeaf);
   }
 
-  get(key: Field): Option<Field> {
+  get(key: Field | bigint): Option<Field> {
+    key = Field(key);
+
     // prove whether the key exists or not, by showing a valid low node
     let { low, self } = Provable.witness(LeafPair, () => this.findLeaf(key));
     this.proveInclusion(low, 'Invalid low node');

--- a/src/lib/provable/merkle-tree-indexed.ts
+++ b/src/lib/provable/merkle-tree-indexed.ts
@@ -242,9 +242,28 @@ abstract class IndexedMerkleMapAbstract {
   /**
    * Get a value from a key.
    *
-   * Returns an option which is `None` if the key doesn't exist. (In that case, the option's value is unconstrained.)
+   * Proves that the key already exists in the map yet and fails otherwise.
    */
-  get(key: Field | bigint): Option<Field, bigint> {
+  get(key: Field | bigint): Field {
+    key = Field(key);
+
+    // prove that the key exists by presenting a leaf that contains it
+    let self = Provable.witness(Leaf, () => this._findLeaf(key).self);
+    this.proveInclusion(self, 'Key does not exist in the tree');
+    self.key.assertEquals(key, 'Invalid leaf (key)');
+
+    return self.value;
+  }
+
+  /**
+   * Get a value from a key.
+   *
+   * Returns an option which is `None` if the key doesn't exist. (In that case, the option's value is unconstrained.)
+   *
+   * Note that this is more flexible than `get()` and allows you to handle the case where the key doesn't exist.
+   * However, it uses about twice as many constraints for that reason.
+   */
+  getOption(key: Field | bigint): Option<Field, bigint> {
     key = Field(key);
 
     // prove whether the key exists or not, by showing a valid low node

--- a/src/lib/provable/merkle-tree-indexed.ts
+++ b/src/lib/provable/merkle-tree-indexed.ts
@@ -155,27 +155,27 @@ function bisectUnique(
   lowIndex: number;
   foundValue: boolean;
 } {
-  // invariants: iLow <= (target index) <= iHigh and 0 <= iLow < length
-  let [iLow, iHigh] = [0, length];
+  let [iLow, iHigh] = [0, length - 1];
+  if (getValue(iLow) > target) return { lowIndex: -1, foundValue: false };
+  if (getValue(iHigh) < target) return { lowIndex: iHigh, foundValue: false };
+
+  // invariant: 0 <= iLow <= lowIndex <= iHigh < length
+  // since we are either returning or reducing (iHigh - iLow), we'll eventually terminate correctly
   while (true) {
     if (iHigh === iLow) {
-      let foundValue = getValue(iLow) === target;
-      return { lowIndex: iLow, foundValue };
-    } else if (iHigh - iLow === 1) {
-      // this gets us to the iHigh = iLow case in the next iteration
-      if (getValue(iHigh) <= target) iLow = iHigh;
-      else iHigh = iLow;
+      return { lowIndex: iLow, foundValue: getValue(iLow) === target };
+    }
+    // either iLow + 1 = iHigh = iMid, or iLow < iMid < iHigh
+    // in both cases, the range gets strictly smaller
+    let iMid = Math.ceil((iLow + iHigh) / 2);
+    if (getValue(iMid) <= target) {
+      // iMid is in the candidate set, and strictly larger than iLow
+      // preserves iLow <= lowIndex
+      iLow = iMid;
     } else {
-      // because of the other cases, we know that iLow < iMid < iHigh
-      let iMid = Math.floor((iLow + iHigh) / 2);
-      if (getValue(iMid) <= target) {
-        iLow = iMid;
-      } else {
-        // we can use iMid - 1 because
-        // - iMid > iLow >= 0, and
-        // - iMid is no longer a candidate index that we can return
-        iHigh = iMid - 1;
-      }
+      // iMid is no longer in the candidate set, so we can exclude it right away
+      // preserves lowIndex <= iHigh
+      iHigh = iMid - 1;
     }
   }
 }

--- a/src/lib/provable/merkle-tree-indexed.ts
+++ b/src/lib/provable/merkle-tree-indexed.ts
@@ -65,16 +65,15 @@ class IndexedMerkleMap implements IndexedMerkleMapBase {
 
   // the raw data stored in the tree, plus helper structures
   readonly data: Unconstrained<{
-    // leaves sorted by index
-    readonly leaves: LeafValue[];
-
-    // leaves sorted by key, with a circular linked list encoded by nextKey
-    // we always have sortedLeaves[n-1].nextKey = 0 = sortedLeaves[0].key
-    // for i=0,...n-2, sortedLeaves[i].nextKey = sortedLeaves[i+1].key
-    readonly sortedLeaves: LeafValue[];
-
     // for every level, an array of hashes
     readonly nodes: (bigint | undefined)[][];
+
+    // leaves sorted by key, with a circular linked list encoded by nextKey
+    // we always have
+    // sortedLeaves[0].key = 0
+    // sortedLeaves[n-1].nextKey = Field.ORDER - 1
+    // for i=0,...n-2, sortedLeaves[i].nextKey = sortedLeaves[i+1].key
+    readonly sortedLeaves: LeafValue[];
   }>;
 
   /**
@@ -224,9 +223,8 @@ class IndexedMerkleMap implements IndexedMerkleMapBase {
       this.setLeafNode(i, node.toBigInt());
 
       // update leaf lists
-      let { leaves, sortedLeaves } = this.data.get();
+      let { sortedLeaves } = this.data.get();
       let leafValue = Leaf.toValue(newLeaf);
-      leaves[i] = leafValue;
       sortedLeaves[leaf.sortedIndex.get()] = leafValue;
     });
   }
@@ -255,8 +253,7 @@ class IndexedMerkleMap implements IndexedMerkleMapBase {
         sortedIndex: Unconstrained.from(iSorted),
       });
 
-      let { leaves, sortedLeaves } = this.data.get();
-      leaves.push(leafValue);
+      let { sortedLeaves } = this.data.get();
       sortedLeaves.splice(iSorted, 0, leafValue);
     });
   }
@@ -273,13 +270,11 @@ class IndexedMerkleMap implements IndexedMerkleMapBase {
       // update leaf lists
       let leafValue = Leaf.toValue(leaf);
       let iSorted = leaf.sortedIndex.get();
-      let { leaves, sortedLeaves } = this.data.get();
+      let { sortedLeaves } = this.data.get();
 
       if (Bool(leafExists).toBoolean()) {
-        leaves[i] = leafValue;
         sortedLeaves[iSorted] = leafValue;
       } else {
-        leaves.push(leafValue);
         sortedLeaves.splice(iSorted, 0, leafValue);
       }
     });

--- a/src/lib/provable/merkle-tree-indexed.ts
+++ b/src/lib/provable/merkle-tree-indexed.ts
@@ -7,7 +7,9 @@ import { assert } from './gadgets/common.js';
 import { Unconstrained } from './types/unconstrained.js';
 import { Provable } from './provable.js';
 import { Poseidon } from './crypto/poseidon.js';
-import { maybeSwap } from './merkle-tree.js';
+import { conditionalSwap } from './merkle-tree.js';
+
+export { IndexedMerkleMap };
 
 type IndexedMerkleMapBase = {
   root: Field;
@@ -296,7 +298,7 @@ class IndexedMerkleMap implements IndexedMerkleMapBase {
         let isLeft = !isRight.toBoolean();
         return this.getNode(level, isLeft ? i + 1 : i - 1, false);
       });
-      let [right, left] = maybeSwap(isRight, node, sibling);
+      let [right, left] = conditionalSwap(isRight, node, sibling);
       node = Poseidon.hash([left, right]);
       indexU.updateAsProver((i) => i >> 1);
     }

--- a/src/lib/provable/merkle-tree-indexed.ts
+++ b/src/lib/provable/merkle-tree-indexed.ts
@@ -191,8 +191,10 @@ class IndexedMerkleMapBase {
    * Update an existing leaf `(key, value)`.
    *
    * Proves that the `key` exists.
+   *
+   * Returns the previous value.
    */
-  update(key: Field | bigint, value: Field | bigint) {
+  update(key: Field | bigint, value: Field | bigint): Field {
     key = Field(key);
     value = Field(value);
 
@@ -207,6 +209,8 @@ class IndexedMerkleMapBase {
     let newSelf = { ...self, value };
     this.root = this._proveUpdate(newSelf, path);
     this._setLeafUnconstrained(true, newSelf);
+
+    return self.value;
   }
 
   /**
@@ -216,8 +220,10 @@ class IndexedMerkleMapBase {
    * can use it if you don't know whether the key exists or not.
    *
    * However, this comes at an efficiency cost, so prefer to use `insert()` or `update()` if you know whether the key exists.
+   *
+   * Returns the previous value, as an option (which is `None` if the key didn't exist before).
    */
-  set(key: Field | bigint, value: Field | bigint) {
+  set(key: Field | bigint, value: Field | bigint): Option<Field, bigint> {
     key = Field(key);
     value = Field(value);
 
@@ -260,6 +266,9 @@ class IndexedMerkleMapBase {
     this.root = this._proveUpdate(newLeaf, path);
     this.length = Provable.if(keyExists, this.length, this.length.add(1));
     this._setLeafUnconstrained(keyExists, newLeaf);
+
+    // return the previous value
+    return new OptionField({ isSome: keyExists, value: self.value });
   }
 
   /**

--- a/src/lib/provable/merkle-tree-indexed.ts
+++ b/src/lib/provable/merkle-tree-indexed.ts
@@ -33,6 +33,7 @@ class Leaf extends Struct({
   nextKey: Field,
   nextIndex: Field,
 }) {}
+type LeafValue = InferValue<typeof Leaf>;
 
 class IndexedMerkleMap implements IndexedMerkleMapBase {
   // data defining the provable interface of a tree
@@ -42,10 +43,13 @@ class IndexedMerkleMap implements IndexedMerkleMapBase {
 
   // the raw data stored in the tree, plus helper structures
   readonly data: Unconstrained<{
-    readonly leaves: InferValue<typeof Leaf>[];
+    readonly leaves: LeafValue[];
 
     // for every level, an array of hashes
     readonly nodes: (bigint | undefined)[][];
+
+    // sorted list of low nodes
+    readonly lowNodes: LeafValue[];
   }>;
 
   /**
@@ -60,9 +64,9 @@ class IndexedMerkleMap implements IndexedMerkleMapBase {
     }
 
     this.length = Field(0);
-    let leaves: InferValue<typeof Leaf>[] = [];
-
-    this.data = Unconstrained.from({ leaves, nodes });
+    let leaves: LeafValue[] = [];
+    let lowNodes: LeafValue[] = [];
+    this.data = Unconstrained.from({ leaves, lowNodes, nodes });
   }
 
   insert(key: Field, value: Field) {
@@ -86,6 +90,8 @@ class IndexedMerkleMap implements IndexedMerkleMapBase {
   }
 
   // helper methods
+
+  private getLowNode(key: bigint) {}
 
   // invariant: for every node that is not undefined, its descendants are either empty or not undefined
   private setLeafNode(index: number, leaf: bigint) {

--- a/src/lib/provable/merkle-tree-indexed.ts
+++ b/src/lib/provable/merkle-tree-indexed.ts
@@ -20,12 +20,33 @@ export { Leaf };
  * Class factory for an Indexed Merkle Map with a given height.
  *
  * ```ts
- * let map = new (IndexedMerkleMap(3))();
+ * class MerkleMap extends IndexedMerkleMap(3) {}
+ *
+ * let map = new MerkleMap();
  *
  * map.set(2n, 14n);
  * map.set(1n, 13n);
  *
  * let x = map.get(2n).assertSome(); // 14
+ * ```
+ *
+ * Indexed Merkle maps can be used directly in provable code:
+ *
+ * ```ts
+ * ZkProgram({
+ *   methods: {
+ *     test: {
+ *       privateInputs: [MerkleMap.provable, Field],
+ *       method(map: MerkleMap, key: Field) {
+ *         // get the value associated with `key`
+ *         let value = map.get(key).orElse(0n);
+ *
+ *         // increment the value by 1
+ *         map.set(key, value.add(1));
+ *       }
+ *     }
+ *   }
+ * })
  * ```
  */
 function IndexedMerkleMap(height: number) {
@@ -222,7 +243,7 @@ abstract class IndexedMerkleMapAbstract {
    *
    * Returns an option which is `None` if the key doesn't exist. (In that case, the option's value is unconstrained.)
    */
-  get(key: Field | bigint): Option<Field> {
+  get(key: Field | bigint): Option<Field, bigint> {
     key = Field(key);
 
     // prove whether the key exists or not, by showing a valid low node

--- a/src/lib/provable/merkle-tree-indexed.ts
+++ b/src/lib/provable/merkle-tree-indexed.ts
@@ -41,15 +41,20 @@ class IndexedMerkleMap implements IndexedMerkleMapBase {
   // the raw data stored in the tree
   readonly leaves: InferValue<typeof Leaf>[] = [];
 
-  // helpers structures
-  length: number; // length of the leaves array
-  readonly nodes: Field[][] = []; // for every level, an array of hashes
+  // helper structures
+  length: number = 0; // length of the leaves array
+  readonly nodes: (bigint | undefined)[][]; // for every level, an array of hashes
 
   /**
    * Creates a new, empty Indexed Merkle Map, given its height.
    */
   constructor(height: number) {
-    this.root = Field(zero(height - 1));
+    this.root = Field(empty(height - 1));
+
+    this.nodes = Array(height);
+    for (let level = 0; level < height; level++) {
+      this.nodes[level] = [];
+    }
   }
 
   insert(key: Field, value: Field) {
@@ -71,14 +76,46 @@ class IndexedMerkleMap implements IndexedMerkleMapBase {
   remove(key: Field) {
     assert(false, 'not implemented');
   }
+
+  // helper methods
+
+  // invariant: for every node that is not undefined, its descendants are either empty or not undefined
+  private setLeafNode(index: number, leaf: bigint) {
+    this.nodes[0][index] = leaf;
+
+    let isLeft = index % 2 === 0;
+
+    for (let level = 1; level < this.height; level++) {
+      index = Math.floor(index / 2);
+
+      let left = this.getNode(level - 1, index * 2, isLeft);
+      let right = this.getNode(level - 1, index * 2 + 1, !isLeft);
+      this.nodes[level][index] = PoseidonBigint.hash([left, right]);
+
+      isLeft = index % 2 === 0;
+    }
+  }
+
+  private getNode(level: number, index: number, nonEmpty: boolean) {
+    let node = this.nodes[level]?.[index];
+    if (node === undefined) {
+      if (nonEmpty)
+        throw Error(
+          `node at level=${level}, index=${index} was expected to be known, but isn't.`
+        );
+      node = empty(level);
+    }
+    return node;
+  }
 }
 
-// cache of zero hashes
-const zeroes = [0n];
-function zero(level: number) {
-  for (let i = zeroes.length; i <= level; i++) {
-    let zero = zeroes[i - 1];
-    zeroes[i] = PoseidonBigint.hash([zero, zero]);
+// cache of empty nodes (=: zero leaves and nodes with only empty nodes below them)
+const emptyNodes = [0n];
+
+function empty(level: number) {
+  for (let i = emptyNodes.length; i <= level; i++) {
+    let zero = emptyNodes[i - 1];
+    emptyNodes[i] = PoseidonBigint.hash([zero, zero]);
   }
-  return zeroes[level];
+  return emptyNodes[level];
 }

--- a/src/lib/provable/merkle-tree-indexed.ts
+++ b/src/lib/provable/merkle-tree-indexed.ts
@@ -1,8 +1,13 @@
-import { Field } from './field.js';
+import { Poseidon as PoseidonBigint } from '../../bindings/crypto/poseidon.js';
+import { Field } from './wrapped.js';
 import { Option } from './option.js';
 import { Struct } from './types/struct.js';
+import { InferValue } from 'src/bindings/lib/provable-generic.js';
+import { assert } from './gadgets/common.js';
 
 type IndexedMerkleMapBase = {
+  root: Field;
+
   // (lower-level) method to insert a new leaf `(key, value)`. proves that `key` doesn't exist yet
   insert(key: Field, value: Field): void;
 
@@ -27,3 +32,53 @@ class Leaf extends Struct({
   nextKey: Field,
   nextIndex: Field,
 }) {}
+
+class IndexedMerkleMap implements IndexedMerkleMapBase {
+  // data defining the provable interface of a tree
+  root: Field;
+  readonly height: number;
+
+  // the raw data stored in the tree
+  readonly leaves: InferValue<typeof Leaf>[] = [];
+
+  // helpers structures
+  length: number; // length of the leaves array
+  readonly nodes: Field[][] = []; // for every level, an array of hashes
+
+  /**
+   * Creates a new, empty Indexed Merkle Map, given its height.
+   */
+  constructor(height: number) {
+    this.root = Field(zero(height - 1));
+  }
+
+  insert(key: Field, value: Field) {
+    assert(false, 'not implemented');
+  }
+
+  update(key: Field, value: Field) {
+    assert(false, 'not implemented');
+  }
+
+  set(key: Field, value: Field) {
+    assert(false, 'not implemented');
+  }
+
+  get(key: Field): Option<Field> {
+    assert(false, 'not implemented');
+  }
+
+  remove(key: Field) {
+    assert(false, 'not implemented');
+  }
+}
+
+// cache of zero hashes
+const zeroes = [0n];
+function zero(level: number) {
+  for (let i = zeroes.length; i <= level; i++) {
+    let zero = zeroes[i - 1];
+    zeroes[i] = PoseidonBigint.hash([zero, zero]);
+  }
+  return zeroes[level];
+}

--- a/src/lib/provable/merkle-tree-indexed.ts
+++ b/src/lib/provable/merkle-tree-indexed.ts
@@ -135,3 +135,47 @@ function empty(level: number) {
   }
   return emptyNodes[level];
 }
+
+// helper
+
+/**
+ * Bisect indices in an array of unique values that is sorted in ascending order.
+ *
+ * `getValue()` returns the value at the given index.
+ *
+ * We return
+ * `lowIndex` := max { i in [0, length) | getValue(i) <= target }
+ * `foundValue` := whether `getValue(lowIndex) == target`
+ */
+function bisectUnique(
+  target: bigint,
+  getValue: (index: number) => bigint,
+  length: number
+): {
+  lowIndex: number;
+  foundValue: boolean;
+} {
+  // invariants: iLow <= (target index) <= iHigh and 0 <= iLow < length
+  let [iLow, iHigh] = [0, length];
+  while (true) {
+    if (iHigh === iLow) {
+      let foundValue = getValue(iLow) === target;
+      return { lowIndex: iLow, foundValue };
+    } else if (iHigh - iLow === 1) {
+      // this gets us to the iHigh = iLow case in the next iteration
+      if (getValue(iHigh) <= target) iLow = iHigh;
+      else iHigh = iLow;
+    } else {
+      // because of the other cases, we know that iLow < iMid < iHigh
+      let iMid = Math.floor((iLow + iHigh) / 2);
+      if (getValue(iMid) <= target) {
+        iLow = iMid;
+      } else {
+        // we can use iMid - 1 because
+        // - iMid > iLow >= 0, and
+        // - iMid is no longer a candidate index that we can return
+        iHigh = iMid - 1;
+      }
+    }
+  }
+}

--- a/src/lib/provable/merkle-tree-indexed.ts
+++ b/src/lib/provable/merkle-tree-indexed.ts
@@ -85,7 +85,6 @@ class IndexedMerkleMap implements IndexedMerkleMapBase {
       height < 53,
       'height must be less than 53, so that we can use 64-bit floats to represent indices.'
     );
-    this.root = Field(empty(height - 1));
 
     let nodes: (bigint | undefined)[][] = Array(height);
     for (let level = 0; level < height; level++) {
@@ -101,7 +100,9 @@ class IndexedMerkleMap implements IndexedMerkleMapBase {
       nextIndex: 0n, // TODO: ok?
       sortedIndex: Unconstrained.from(0),
     };
-    this.setLeafNode(0, Leaf.hashNode(Leaf.fromValue(firstLeaf)).toBigInt());
+    let firstNode = Leaf.hashNode(Leaf.fromValue(firstLeaf));
+    this.setLeafNode(0, firstNode.toBigInt());
+    this.root = Field(this.getNode(height - 1, 0, true));
 
     this.length = Field(1);
     let leaves: LeafValue[] = [firstLeaf];

--- a/src/lib/provable/merkle-tree-indexed.ts
+++ b/src/lib/provable/merkle-tree-indexed.ts
@@ -98,6 +98,19 @@ class IndexedMerkleMapBase {
     readonly sortedLeaves: StoredLeaf[];
   }>;
 
+  clone() {
+    let cloned = new (this.constructor as typeof IndexedMerkleMapBase)();
+    cloned.root = this.root;
+    cloned.length = this.length;
+    cloned.data.updateAsProver(({ nodes, sortedLeaves }) => {
+      return {
+        nodes: nodes.map((row) => [...row]),
+        sortedLeaves: [...sortedLeaves],
+      };
+    });
+    return cloned;
+  }
+
   // we'd like to do `abstract static provable` here but that's not supported
   static provable: Provable<
     IndexedMerkleMapBase,
@@ -626,10 +639,10 @@ class Leaf extends Struct({
 }
 
 type StoredLeaf = {
-  value: bigint;
-  key: bigint;
-  nextKey: bigint;
-  index: number;
+  readonly value: bigint;
+  readonly key: bigint;
+  readonly nextKey: bigint;
+  readonly index: number;
 };
 
 class LeafPair extends Struct({ low: Leaf, self: Leaf }) {}

--- a/src/lib/provable/merkle-tree-indexed.ts
+++ b/src/lib/provable/merkle-tree-indexed.ts
@@ -94,21 +94,22 @@ abstract class IndexedMerkleMapAbstract {
       nodes[level] = [];
     }
 
-    let firstLeaf = {
-      key: 0n,
-      value: 0n,
-      // maximum, which is always greater than any key that is a hash
-      nextKey: Field.ORDER - 1n,
-      index: 0n,
-      nextIndex: 0n, // TODO: ok?
-    };
-    let firstNode = Leaf.hashNode(firstLeaf);
+    let firstLeaf = IndexedMerkleMapAbstract._firstLeaf;
+    let firstNode = Leaf.hashNode(IndexedMerkleMapAbstract._firstLeaf);
     let root = Nodes.setLeafNode(nodes, 0, firstNode.toBigInt());
     this.root = Field(root);
     this.length = Field(1);
 
     this.data = Unconstrained.from({ nodes, sortedLeaves: [firstLeaf] });
   }
+  static _firstLeaf = {
+    key: 0n,
+    value: 0n,
+    // maximum, which is always greater than any key that is a hash
+    nextKey: Field.ORDER - 1n,
+    index: 0n,
+    nextIndex: 0n, // TODO: ok?
+  };
 
   /**
    * Insert a new leaf `(key, value)`.

--- a/src/lib/provable/merkle-tree.ts
+++ b/src/lib/provable/merkle-tree.ts
@@ -11,7 +11,7 @@ import { Provable } from './provable.js';
 export { Witness, MerkleTree, MerkleWitness, BaseMerkleWitness };
 
 // internal API
-export { maybeSwap };
+export { conditionalSwap };
 
 type Witness = { isLeft: boolean; sibling: Field }[];
 
@@ -207,7 +207,7 @@ class BaseMerkleWitness extends CircuitValue {
 
     for (let i = 1; i < n; ++i) {
       let isLeft = this.isLeft[i - 1];
-      const [left, right] = maybeSwap(isLeft, hash, this.path[i - 1]);
+      const [left, right] = conditionalSwap(isLeft, hash, this.path[i - 1]);
       hash = Poseidon.hash([left, right]);
     }
 
@@ -248,7 +248,7 @@ function MerkleWitness(height: number): typeof BaseMerkleWitness {
 
 // swap two values if the boolean is false, otherwise keep them as they are
 // more efficient than 2x `Provable.if()` by reusing an intermediate variable
-function maybeSwap(b: Bool, x: Field, y: Field): [Field, Field] {
+function conditionalSwap(b: Bool, x: Field, y: Field): [Field, Field] {
   let m = b.toField().mul(x.sub(y)); // b*(x - y)
   const x_ = y.add(m); // y + b*(x - y)
   const y_ = x.sub(m); // x - b*(x - y) = x + b*(y - x)

--- a/src/lib/provable/merkle-tree.ts
+++ b/src/lib/provable/merkle-tree.ts
@@ -246,6 +246,7 @@ function MerkleWitness(height: number): typeof BaseMerkleWitness {
   return MerkleWitness_;
 }
 
+// swap two values if the boolean is false, otherwise keep them as they are
 // more efficient than 2x `Provable.if()` by reusing an intermediate variable
 function maybeSwap(b: Bool, x: Field, y: Field): [Field, Field] {
   let m = b.toField().mul(x.sub(y)); // b*(x - y)

--- a/src/lib/provable/option.ts
+++ b/src/lib/provable/option.ts
@@ -39,19 +39,23 @@ function Option<A extends Provable<any, any>>(
 ): Provable<
   Option<InferProvable<A>, InferValue<A>>,
   InferValue<A> | undefined
-> & {
-  fromValue(
-    value:
-      | { isSome: boolean | Bool; value: InferProvable<A> | InferValue<A> }
-      | InferProvable<A>
-      | InferValue<A>
-      | undefined
-  ): Option<InferProvable<A>, InferValue<A>>;
-  from(
-    value?: InferProvable<A> | InferValue<A>
-  ): Option<InferProvable<A>, InferValue<A>>;
-  none(): Option<InferProvable<A>, InferValue<A>>;
-} {
+> &
+  (new (option: { isSome: Bool; value: InferProvable<A> }) => Option<
+    InferProvable<A>,
+    InferValue<A>
+  >) & {
+    fromValue(
+      value:
+        | { isSome: boolean | Bool; value: InferProvable<A> | InferValue<A> }
+        | InferProvable<A>
+        | InferValue<A>
+        | undefined
+    ): Option<InferProvable<A>, InferValue<A>>;
+    from(
+      value?: InferProvable<A> | InferValue<A>
+    ): Option<InferProvable<A>, InferValue<A>>;
+    none(): Option<InferProvable<A>, InferValue<A>>;
+  } {
   type T = InferProvable<A>;
   type V = InferValue<A>;
   let strictType: Provable<T, V> = type;

--- a/src/lib/provable/test/merkle-tree.unit-test.ts
+++ b/src/lib/provable/test/merkle-tree.unit-test.ts
@@ -3,6 +3,12 @@ import { conditionalSwap } from '../merkle-tree.js';
 import { Random, test } from '../../testing/property.js';
 import { expect } from 'expect';
 import { MerkleMap } from '../merkle-map.js';
+import { IndexedMerkleMap } from '../merkle-tree-indexed.js';
+import { Provable } from '../provable.js';
+
+let map = new IndexedMerkleMap(32);
+let x = map.get(0n);
+Provable.log('value at 0', x);
 
 test(Random.bool, Random.field, Random.field, (b, x, y) => {
   let [x0, y0] = conditionalSwap(Bool(!!b), Field(x), Field(y));

--- a/src/lib/provable/test/merkle-tree.unit-test.ts
+++ b/src/lib/provable/test/merkle-tree.unit-test.ts
@@ -1,11 +1,11 @@
 import { Bool, Field } from '../wrapped.js';
-import { maybeSwap } from '../merkle-tree.js';
+import { conditionalSwap } from '../merkle-tree.js';
 import { Random, test } from '../../testing/property.js';
 import { expect } from 'expect';
 import { MerkleMap } from '../merkle-map.js';
 
 test(Random.bool, Random.field, Random.field, (b, x, y) => {
-  let [x0, y0] = maybeSwap(Bool(!!b), Field(x), Field(y));
+  let [x0, y0] = conditionalSwap(Bool(!!b), Field(x), Field(y));
 
   // if the boolean is true, it shouldn't swap the fields; otherwise, it should
   if (b) {

--- a/src/lib/provable/test/merkle-tree.unit-test.ts
+++ b/src/lib/provable/test/merkle-tree.unit-test.ts
@@ -1,5 +1,5 @@
 import { Bool, Field } from '../wrapped.js';
-import { conditionalSwap } from '../merkle-tree.js';
+import { MerkleTree, conditionalSwap } from '../merkle-tree.js';
 import { Random, test } from '../../testing/property.js';
 import { expect } from 'expect';
 import { MerkleMap } from '../merkle-map.js';
@@ -35,12 +35,20 @@ import { IndexedMerkleMap, Leaf } from '../merkle-tree-indexed.js';
   // can't insert more than 2^(height - 1) = 2^2 = 4 keys
   expect(() => map.insert(8n, 19n)).toThrow('4 does not fit in 2 bits');
 
-  // check nodes against `MerkleTree` implementation
+  // check that internal nodes exactly match `MerkleTree` implementation
   let keys = [0n, 2n, 1n, 4n]; // insertion order
   let leaves = keys.map((key) => Leaf.hashNode(map._findLeaf(key).self));
+  let tree = new MerkleTree(3);
+  tree.fill(leaves);
+  let nodes = map.data.get().nodes;
+
+  for (let level = 0; level < 3; level++) {
+    for (let i = 0; i < 2 ** (2 - level); i++) {
+      expect(nodes[level][i]).toEqual(tree.nodes[level][i].toBigInt());
+    }
+  }
 
   console.dir(map.data.get().sortedLeaves, { depth: null });
-  console.dir(map.data.get().nodes, { depth: null });
 }
 
 test(Random.bool, Random.field, Random.field, (b, x, y) => {

--- a/src/lib/provable/test/merkle-tree.unit-test.ts
+++ b/src/lib/provable/test/merkle-tree.unit-test.ts
@@ -4,11 +4,29 @@ import { Random, test } from '../../testing/property.js';
 import { expect } from 'expect';
 import { MerkleMap } from '../merkle-map.js';
 import { IndexedMerkleMap } from '../merkle-tree-indexed.js';
-import { Provable } from '../provable.js';
 
-let map = new IndexedMerkleMap(32);
-let x = map.get(0n);
-Provable.log('value at 0', x);
+console.log('new map');
+let map = new IndexedMerkleMap(3);
+
+console.log('insert 2 and 1');
+map.insert(2n, 14n);
+map.insert(1n, 13n);
+// console.dir(map.findLeaf(2n), { depth: null });
+
+console.log('test');
+expect(map.get(1n).assertSome().toBigInt()).toEqual(13n);
+expect(map.get(2n).assertSome().toBigInt()).toEqual(14n);
+
+console.dir(map.data.get().sortedLeaves, { depth: null });
+
+console.log('update 2 and 0');
+map.update(2n, 15n);
+map.update(0n, 12n);
+// TODO get() doesn't work on 0n because the low node checks fail
+// expect(map.get(0n).assertSome().toBigInt()).toEqual(12n);
+expect(map.get(2n).assertSome().toBigInt()).toEqual(15n);
+
+console.dir(map.data.get().sortedLeaves, { depth: null });
 
 test(Random.bool, Random.field, Random.field, (b, x, y) => {
   let [x0, y0] = conditionalSwap(Bool(!!b), Field(x), Field(y));

--- a/src/lib/provable/test/merkle-tree.unit-test.ts
+++ b/src/lib/provable/test/merkle-tree.unit-test.ts
@@ -80,6 +80,25 @@ console.log(
   )
 );
 
+console.log(
+  '\nindexed merkle map (assert included)',
+  constraintSystem.size({ from: [field] }, (key) => {
+    indexedMap.assertIncluded(key);
+  })
+);
+console.log(
+  'indexed merkle map (assert not included)',
+  constraintSystem.size({ from: [field] }, (key) => {
+    indexedMap.assertNotIncluded(key);
+  })
+);
+console.log(
+  'indexed merkle map (is included)',
+  constraintSystem.size({ from: [field] }, (key) => {
+    indexedMap.isIncluded(key);
+  })
+);
+
 // some manual tests for IndexedMerkleMap
 {
   let map = new (IndexedMerkleMap(3))();

--- a/src/lib/provable/test/merkle-tree.unit-test.ts
+++ b/src/lib/provable/test/merkle-tree.unit-test.ts
@@ -22,6 +22,12 @@ console.log(
     indexedMap.get(key);
   })
 );
+console.log(
+  'indexed merkle map (get option)',
+  constraintSystem.size({ from: [field] }, (key) => {
+    indexedMap.getOption(key);
+  })
+);
 
 console.log(
   'sparse merkle map (get)',
@@ -93,13 +99,13 @@ console.log(
   expect(() => map.insert(-1n, 11n)).toThrow('Key already exists');
   expect(() => map.set(-1n, 12n)).toThrow('Invalid leaf');
 
-  expect(map.get(1n).assertSome().toBigInt()).toEqual(13n);
-  expect(map.get(2n).assertSome().toBigInt()).toEqual(14n);
-  expect(map.get(3n).isSome.toBoolean()).toEqual(false);
+  expect(map.getOption(1n).assertSome().toBigInt()).toEqual(13n);
+  expect(map.getOption(2n).assertSome().toBigInt()).toEqual(14n);
+  expect(map.getOption(3n).isSome.toBoolean()).toEqual(false);
 
   map.update(2n, 15n);
   map.update(0n, 12n);
-  expect(map.get(2n).assertSome().toBigInt()).toEqual(15n);
+  expect(map.getOption(2n).assertSome().toBigInt()).toEqual(15n);
 
   // TODO get() doesn't work on 0n because the low node checks fail
   // expect(map.get(0n).assertSome().toBigInt()).toEqual(12n);
@@ -112,9 +118,9 @@ console.log(
 
   map.set(4n, 16n);
   map.set(1n, 17n);
-  expect(map.get(4n).assertSome().toBigInt()).toEqual(16n);
-  expect(map.get(1n).assertSome().toBigInt()).toEqual(17n);
-  expect(map.get(5n).isSome.toBoolean()).toEqual(false);
+  expect(map.get(4n).toBigInt()).toEqual(16n);
+  expect(map.getOption(1n).assertSome().toBigInt()).toEqual(17n);
+  expect(map.getOption(5n).isSome.toBoolean()).toEqual(false);
 
   // can't insert more than 2^(height - 1) = 2^2 = 4 keys
   expect(() => map.insert(8n, 19n)).toThrow('4 does not fit in 2 bits');
@@ -192,10 +198,13 @@ test(
 
       for (let i = 0; i < n; i++) {
         // confirm we still have the same keys and values
-        map.get(initialKeysF[i]).assertSome().assertEquals(initialValues[i]);
+        map
+          .getOption(initialKeysF[i])
+          .assertSome()
+          .assertEquals(initialValues[i]);
 
         // new keys are not in the map
-        map.get(keysF[i]).isSome.assertFalse();
+        map.getOption(keysF[i]).isSome.assertFalse();
       }
 
       // can't update a non-existent key
@@ -211,8 +220,8 @@ test(
 
       // check that the updated keys and values are in the map
       for (let i = 0; i < n; i++) {
-        map.get(keysF[i]).assertSome().assertEquals(initialValues[i]);
-        map.get(initialKeysF[i]).assertSome().assertEquals(valuesF[i]);
+        map.getOption(keysF[i]).assertSome().assertEquals(initialValues[i]);
+        map.get(initialKeysF[i]).assertEquals(valuesF[i]);
       }
 
       // update the new keys with the new values
@@ -228,11 +237,13 @@ test(
 
     // check that the map is still the same
     for (let i = 0; i < n; i++) {
-      expect(map.get(keys[i]).assertSome()).toEqual(Field(values[i]));
-      expect(map.get(initialKeys[i]).assertSome()).toEqual(Field(values[i]));
+      expect(map.getOption(keys[i]).assertSome()).toEqual(Field(values[i]));
+      expect(map.getOption(initialKeys[i]).assertSome()).toEqual(
+        Field(values[i])
+      );
     }
     // random element is not in the map
-    expect(map.get(Field.random()).isSome).toEqual(Bool(false));
+    expect(map.getOption(Field.random()).isSome).toEqual(Bool(false));
     // length is as expected
     expect(map.length).toEqual(Field(2 * n + 1));
 

--- a/src/lib/provable/test/merkle-tree.unit-test.ts
+++ b/src/lib/provable/test/merkle-tree.unit-test.ts
@@ -178,7 +178,6 @@ console.log(
       value: sorted[i].value,
       nextKey: sorted[i + 1]?.key ?? Field.ORDER - 1n,
       index: sorted[i].index,
-      nextIndex: sorted[i + 1]?.index ?? 0n,
     });
   }
 }

--- a/src/lib/provable/test/merkle-tree.unit-test.ts
+++ b/src/lib/provable/test/merkle-tree.unit-test.ts
@@ -43,9 +43,9 @@ import { IndexedMerkleMap, Leaf } from '../merkle-tree-indexed.js';
 
   // check that internal nodes exactly match `MerkleTree` implementation
   let keys = [0n, 2n, 1n, 4n]; // insertion order
-  let leaves = keys.map((key) => Leaf.hashNode(map._findLeaf(key).self));
+  let leafNodes = keys.map((key) => Leaf.hashNode(map._findLeaf(key).self));
   let tree = new MerkleTree(3);
-  tree.fill(leaves);
+  tree.fill(leafNodes);
   let nodes = map.data.get().nodes;
 
   for (let level = 0; level < 3; level++) {
@@ -54,7 +54,26 @@ import { IndexedMerkleMap, Leaf } from '../merkle-tree-indexed.js';
     }
   }
 
-  console.dir(map.data.get().sortedLeaves, { depth: null });
+  // check that internal `sortedLeaves` are as expected
+
+  // data sorted by key:
+  let sorted = [
+    { key: 0n, value: 12n, index: 0n },
+    { key: 1n, value: 17n, index: 2n },
+    { key: 2n, value: 15n, index: 1n },
+    { key: 4n, value: 16n, index: 3n },
+  ];
+  let sortedLeaves = map.data.get().sortedLeaves;
+
+  for (let i = 0; i < 4; i++) {
+    expect(sortedLeaves[i]).toEqual({
+      key: sorted[i].key,
+      value: sorted[i].value,
+      nextKey: sorted[i + 1]?.key ?? Field.ORDER - 1n,
+      index: sorted[i].index,
+      nextIndex: sorted[i + 1]?.index ?? 0n,
+    });
+  }
 }
 
 test(Random.bool, Random.field, Random.field, (b, x, y) => {

--- a/src/lib/provable/test/merkle-tree.unit-test.ts
+++ b/src/lib/provable/test/merkle-tree.unit-test.ts
@@ -9,6 +9,13 @@ import { IndexedMerkleMap, Leaf } from '../merkle-tree-indexed.js';
 {
   let map = new (IndexedMerkleMap(3))();
 
+  // there's 1 element in the map at the beginning
+  // check initial root against `MerkleTree` implementation
+  expect(map.length.toBigInt()).toEqual(1n);
+  let initialTree = new MerkleTree(3);
+  initialTree.setLeaf(0n, Leaf.hashNode(IndexedMerkleMap(3)._firstLeaf));
+  expect(map.root).toEqual(initialTree.getRoot());
+
   map.insert(2n, 14n);
   map.insert(1n, 13n);
 
@@ -31,6 +38,9 @@ import { IndexedMerkleMap, Leaf } from '../merkle-tree-indexed.js';
   // can't insert the same key twice
   expect(() => map.insert(1n, 17n)).toThrow('Key already exists');
 
+  // can't update a non-existent key
+  expect(() => map.update(3n, 16n)).toThrow('Key does not exist');
+
   map.set(4n, 16n);
   map.set(1n, 17n);
   expect(map.get(4n).assertSome().toBigInt()).toEqual(16n);
@@ -40,6 +50,9 @@ import { IndexedMerkleMap, Leaf } from '../merkle-tree-indexed.js';
   // can't insert more than 2^(height - 1) = 2^2 = 4 keys
   expect(() => map.insert(8n, 19n)).toThrow('4 does not fit in 2 bits');
   expect(() => map.set(8n, 19n)).toThrow('4 does not fit in 2 bits');
+
+  // check that length is as expected
+  expect(map.length.toBigInt()).toEqual(4n);
 
   // check that internal nodes exactly match `MerkleTree` implementation
   let keys = [0n, 2n, 1n, 4n]; // insertion order

--- a/src/lib/provable/test/merkle-tree.unit-test.ts
+++ b/src/lib/provable/test/merkle-tree.unit-test.ts
@@ -6,18 +6,15 @@ import { MerkleMap } from '../merkle-map.js';
 import { IndexedMerkleMap } from '../merkle-tree-indexed.js';
 
 console.log('new map');
-let map = new IndexedMerkleMap(3);
+let map = new (IndexedMerkleMap(3))();
 
 console.log('insert 2 and 1');
 map.insert(2n, 14n);
 map.insert(1n, 13n);
 // console.dir(map.findLeaf(2n), { depth: null });
 
-console.log('test');
 expect(map.get(1n).assertSome().toBigInt()).toEqual(13n);
 expect(map.get(2n).assertSome().toBigInt()).toEqual(14n);
-
-console.dir(map.data.get().sortedLeaves, { depth: null });
 
 console.log('update 2 and 0');
 map.update(2n, 15n);

--- a/src/lib/provable/test/merkle-tree.unit-test.ts
+++ b/src/lib/provable/test/merkle-tree.unit-test.ts
@@ -10,11 +10,11 @@ import { constraintSystem } from '../../testing/constraint-system.js';
 import { field } from '../../testing/equivalent.js';
 import { throwError } from './test-utils.js';
 
-const height = 32;
-const IndexedMap32 = IndexedMerkleMap(height);
-const indexedMap = new IndexedMap32();
+const height = 31;
+const IndexedMap30 = IndexedMerkleMap(height);
+const indexedMap = new IndexedMap30();
 
-// compare constraints used by indexed merkle map vs sparse merkle map
+// compare constraints used by indexed merkle map (with 1B leaves) vs sparse merkle map
 
 console.log(
   'indexed merkle map (get)',

--- a/src/lib/provable/test/merkle-tree.unit-test.ts
+++ b/src/lib/provable/test/merkle-tree.unit-test.ts
@@ -165,10 +165,10 @@ console.log(
 
   // data sorted by key:
   let sorted = [
-    { key: 0n, value: 12n, index: 0n },
-    { key: 1n, value: 17n, index: 2n },
-    { key: 2n, value: 15n, index: 1n },
-    { key: 4n, value: 16n, index: 3n },
+    { key: 0n, value: 12n, index: 0 },
+    { key: 1n, value: 17n, index: 2 },
+    { key: 2n, value: 15n, index: 1 },
+    { key: 4n, value: 16n, index: 3 },
   ];
   let sortedLeaves = map.data.get().sortedLeaves;
 

--- a/src/lib/provable/test/merkle-tree.unit-test.ts
+++ b/src/lib/provable/test/merkle-tree.unit-test.ts
@@ -12,6 +12,11 @@ import { IndexedMerkleMap, Leaf } from '../merkle-tree-indexed.js';
   map.insert(2n, 14n);
   map.insert(1n, 13n);
 
+  // -1 (the max value) can't be inserted, because there's always a value pointing to it,
+  // and yet it's not included as a leaf
+  expect(() => map.insert(-1n, 11n)).toThrow('Key already exists');
+  expect(() => map.set(-1n, 12n)).toThrow('Invalid leaf');
+
   expect(map.get(1n).assertSome().toBigInt()).toEqual(13n);
   expect(map.get(2n).assertSome().toBigInt()).toEqual(14n);
   expect(map.get(3n).isSome.toBoolean()).toEqual(false);
@@ -34,6 +39,7 @@ import { IndexedMerkleMap, Leaf } from '../merkle-tree-indexed.js';
 
   // can't insert more than 2^(height - 1) = 2^2 = 4 keys
   expect(() => map.insert(8n, 19n)).toThrow('4 does not fit in 2 bits');
+  expect(() => map.set(8n, 19n)).toThrow('4 does not fit in 2 bits');
 
   // check that internal nodes exactly match `MerkleTree` implementation
   let keys = [0n, 2n, 1n, 4n]; // insertion order

--- a/src/lib/provable/types/provable-derivers.ts
+++ b/src/lib/provable/types/provable-derivers.ts
@@ -58,7 +58,7 @@ const { provable } = createDerivers<Field>();
 
 function provablePure<A>(
   typeObj: A
-): ProvablePureExtended<InferProvable<A>, InferJson<A>> {
+): ProvablePureExtended<InferProvable<A>, InferValue<A>, InferJson<A>> {
   return provable(typeObj, { isPure: true }) as any;
 }
 
@@ -70,8 +70,8 @@ function provableFromClass<A, T extends InferProvable<A>>(
   Class: Constructor<T> & { check?: (x: T) => void; empty?: () => T },
   typeObj: A
 ): IsPure<A> extends true
-  ? ProvablePureExtended<T, InferJson<A>>
-  : ProvableExtended<T, InferJson<A>> {
+  ? ProvablePureExtended<T, InferValue<A>, InferJson<A>>
+  : ProvableExtended<T, InferValue<A>, InferJson<A>> {
   let raw = provable(typeObj);
   return {
     sizeInFields: raw.sizeInFields,

--- a/src/lib/provable/types/unconstrained.ts
+++ b/src/lib/provable/types/unconstrained.ts
@@ -86,7 +86,8 @@ and Provable.asProver() blocks, which execute outside the proof.
    * let xWrapped = Unconstrained.witness(() => Provable.toConstant(type, x));
    * ```
    */
-  static from<T>(value: T) {
+  static from<T>(value: T | Unconstrained<T>) {
+    if (value instanceof Unconstrained) return value;
     return new Unconstrained(true, value);
   }
 

--- a/src/lib/provable/types/unconstrained.ts
+++ b/src/lib/provable/types/unconstrained.ts
@@ -134,11 +134,11 @@ and Provable.asProver() blocks, which execute outside the proof.
     Unconstrained<T>,
     Unconstrained<T>
   > & {
-    toInput: (x: Unconstrained<any>) => {
+    toInput: (x: Unconstrained<T>) => {
       fields?: Field[];
       packed?: [Field, number][];
     };
-    empty: () => Unconstrained<any>;
+    empty: () => Unconstrained<T>;
   } {
     return {
       ...Unconstrained.provable,

--- a/src/lib/testing/constraint-system.ts
+++ b/src/lib/testing/constraint-system.ts
@@ -15,6 +15,7 @@ import { test } from './property.js';
 import { Undefined, ZkProgram } from '../proof-system/zkprogram.js';
 import {
   printGates,
+  summarizeGates,
   synchronousRunners,
 } from '../provable/core/provable-context.js';
 
@@ -350,6 +351,11 @@ constraintSystem.size = map((gates) => gates.length);
  * Print constraint system.
  */
 constraintSystem.print = map(printGates);
+
+/**
+ * Get constraint system summary.
+ */
+constraintSystem.summary = map(summarizeGates);
 
 function repeat(
   n: number,

--- a/src/lib/testing/equivalent.ts
+++ b/src/lib/testing/equivalent.ts
@@ -284,6 +284,11 @@ function spec<T, S>(spec: {
 }): Spec<T, S>;
 function spec<T>(spec: {
   rng: Random<T>;
+  provable: Provable<T>;
+  assertEqual?: (x: T, y: T, message: string) => void;
+}): ProvableSpec<T, T>;
+function spec<T>(spec: {
+  rng: Random<T>;
   assertEqual?: (x: T, y: T, message: string) => void;
 }): Spec<T, T>;
 function spec<T, S>(spec: {
@@ -327,7 +332,7 @@ let bool: ProvableSpec<boolean, Bool> = {
 };
 let boolean: Spec<boolean, boolean> = fromRandom(Random.boolean);
 
-function fieldWithRng(rng: Random<bigint>): Spec<bigint, Field> {
+function fieldWithRng(rng: Random<bigint>): ProvableSpec<bigint, Field> {
   return { ...field, rng };
 }
 

--- a/src/lib/util/errors.ts
+++ b/src/lib/util/errors.ts
@@ -4,6 +4,7 @@ export {
   prettifyStacktrace,
   prettifyStacktracePromise,
   assert,
+  assertDefined,
 };
 
 /**
@@ -279,4 +280,15 @@ function assert(
   message = 'Failed assertion.'
 ): asserts condition {
   if (!condition) throw Bug(message);
+}
+
+/**
+ * Assert that the value is not undefined, return the value.
+ */
+function assertDefined<T>(
+  value: T | undefined,
+  message = 'Input value is undefined.'
+): T {
+  if (value !== undefined) throw Bug(message);
+  return value as T;
 }


### PR DESCRIPTION
closes https://github.com/o1-labs/o1js/issues/1655

This PR introduces `IndexedMerkleMap`, an all around better version of `MerkleMap`. See #1655 for a detailed description, including the API which this PR implements.

In short, there are two motivations to introduce a new Merkle storage primitive:
* The old primitives didn't cleanly map to provable types, and are appallingly hard to use in circuits
* The old Merkle map is a sparse tree of height 256, which meant a large number of in-circuit hashes.

`IndexedMerkleMap` uses about 4-8x fewer constraints than `MerkleMap` when used with height 31 (which supports 1 billion entries). Here are some constraint counts for different operations:

```
indexed merkle map (get) 461
indexed merkle map (get option) 975
sparse merkle map (get) 4208

indexed merkle map (insert) 1696
indexed merkle map (update) 905
indexed merkle map (set) 1878
sparse merkle map (set) 8160

indexed merkle map (assert included) 460
indexed merkle map (assert not included) 507
indexed merkle map (is included) 508
```

EDIT: Based on feedback from @dfstio, the API was expanded to be useful for cases where only inclusion of a key (but not the value) is important, see discussion below.