### PR TITLE
IndexedMerkleMap: Support 0 and -1 keys

### DIFF
--- a/src/lib/provable/field.ts
+++ b/src/lib/provable/field.ts
@@ -654,7 +654,7 @@ class Field {
    * Assert that this {@link Field} is less than another "field-like" value.
    *
    * Note: This uses fewer constraints than `x.lessThan(y).assertTrue()`.
-   * See {@link Field.lessThan} for more details.
+   * See {@link lessThan} for more details.
    *
    * **Important**: If an assertion fails, the code throws an error.
    *

--- a/src/lib/provable/merkle-tree-indexed.ts
+++ b/src/lib/provable/merkle-tree-indexed.ts
@@ -102,19 +102,6 @@ class IndexedMerkleMapBase {
     readonly sortedLeaves: StoredLeaf[];
   }>;
 
-  clone() {
-    let cloned = new (this.constructor as typeof IndexedMerkleMapBase)();
-    cloned.root = this.root;
-    cloned.length = this.length;
-    cloned.data.updateAsProver(({ nodes, sortedLeaves }) => {
-      return {
-        nodes: nodes.map((row) => [...row]),
-        sortedLeaves: [...sortedLeaves],
-      };
-    });
-    return cloned;
-  }
-
   // we'd like to do `abstract static provable` here but that's not supported
   static provable: Provable<
     IndexedMerkleMapBase,
@@ -149,6 +136,25 @@ class IndexedMerkleMapBase {
     nextKey: 0n,
     index: 0,
   };
+
+  /**
+   * Clone the entire Merkle map.
+   *
+   * This method is provable.
+   */
+  clone() {
+    let cloned = new (this.constructor as typeof IndexedMerkleMapBase)();
+    cloned.root = this.root;
+    cloned.length = this.length;
+    cloned.data.updateAsProver(() => {
+      let { nodes, sortedLeaves } = this.data.get();
+      return {
+        nodes: nodes.map((row) => [...row]),
+        sortedLeaves: [...sortedLeaves],
+      };
+    });
+    return cloned;
+  }
 
   /**
    * Insert a new leaf `(key, value)`.

--- a/src/lib/provable/merkle-tree-indexed.ts
+++ b/src/lib/provable/merkle-tree-indexed.ts
@@ -49,6 +49,10 @@ export { Leaf };
  *   }
  * })
  * ```
+ *
+ * Initially, every `IndexedMerkleMap` is populated by a single key-value pair: `(0, 0)`. The value for key `0` can be updated like any other.
+ * When keys and values are hash outputs, `(0, 0)` can serve as a convenient way to represent a dummy update to the tree, since 0 is not
+ * effciently computable as a hash image, and this update doesn't affect the Merkle root.
  */
 function IndexedMerkleMap(height: number): typeof IndexedMerkleMapBase {
   assert(height > 0, 'height must be positive');

--- a/src/lib/provable/merkle-tree-indexed.ts
+++ b/src/lib/provable/merkle-tree-indexed.ts
@@ -528,7 +528,9 @@ class IndexedMerkleMapBase {
       let iSorted = leaf.sortedIndex.get();
 
       if (Bool(leafExists).toBoolean()) {
-        sortedLeaves[iSorted] = leafValue;
+        // for key=0, the sorted index overflows the length because we compute it as low.sortedIndex + 1
+        // in that case, it should wrap back to 0
+        sortedLeaves[iSorted % sortedLeaves.length] = leafValue;
       } else {
         sortedLeaves.splice(iSorted, 0, leafValue);
       }
@@ -714,7 +716,6 @@ function assertInRangeStrict(
   high: Field,
   message?: string
 ) {
-  Provable.log('assertInRangeStrict', { low, x, high });
   // exclude x=0
   x.assertNotEquals(0n, message ?? '0 is not in any range');
 
@@ -740,8 +741,6 @@ function assertInRangeStrict(
  * - note: 0 in (n, 0] succeeds for any n!
  */
 function assertInRange(low: Field, x: Field, high: Field, message?: string) {
-  Provable.log('assertInRange', { low, x, high });
-
   // for low < x, we need to handle the x=0 case separately
   let xIsZero = x.equals(0n);
   let lowSafe = Provable.witness(Field, () => (xIsZero.toBoolean() ? 0n : low));

--- a/src/lib/provable/test/merkle-tree.unit-test.ts
+++ b/src/lib/provable/test/merkle-tree.unit-test.ts
@@ -111,6 +111,9 @@ console.log(
   initialTree.setLeaf(0n, Leaf.hashNode(IndexedMerkleMap(3)._firstLeaf));
   expect(map.root).toEqual(initialTree.getRoot());
 
+  // the initial value at key 0 is 0
+  expect(map.getOption(0n).assertSome().toBigInt()).toEqual(0n);
+
   map.insert(-1n, 14n); // -1 is the largest possible value
   map.insert(1n, 13n);
 

--- a/src/lib/provable/test/merkle-tree.unit-test.ts
+++ b/src/lib/provable/test/merkle-tree.unit-test.ts
@@ -112,11 +112,13 @@ console.log(
 
   map.insert(2n, 14n);
   map.insert(1n, 13n);
+  // map.insert(-1n, 11n);
+  // map.set(-1n, 12n);
 
-  // -1 (the max value) can't be inserted, because there's always a value pointing to it,
-  // and yet it's not included as a leaf
-  expect(() => map.insert(-1n, 11n)).toThrow('Key already exists');
-  expect(() => map.set(-1n, 12n)).toThrow('Invalid leaf');
+  // // -1 (the max value) can't be inserted, because there's always a value pointing to it,
+  // // and yet it's not included as a leaf
+  // expect(() => map.insert(-1n, 11n)).toThrow('Key already exists');
+  // expect(() => map.set(-1n, 12n)).toThrow('Invalid leaf');
 
   expect(map.getOption(1n).assertSome().toBigInt()).toEqual(13n);
   expect(map.getOption(2n).assertSome().toBigInt()).toEqual(14n);
@@ -127,7 +129,11 @@ console.log(
   expect(map.getOption(2n).assertSome().toBigInt()).toEqual(15n);
 
   // TODO get() doesn't work on 0n because the low node checks fail
-  // expect(map.get(0n).assertSome().toBigInt()).toEqual(12n);
+  expect(map.get(0n).toBigInt()).toEqual(12n);
+  expect(map.getOption(0n).assertSome().toBigInt()).toEqual(12n);
+
+  // TODO set() doesn't work on 0n because the low node checks fail
+  map.set(0n, 12n);
 
   // can't insert the same key twice
   expect(() => map.insert(1n, 17n)).toThrow('Key already exists');


### PR DESCRIPTION
Stacked after https://github.com/o1-labs/o1js/pull/1666

## Why

This refactors how `IndexedMerkleMap` represents the maximum possible key. Previously, there was a hard-coded entry of `nextKey: -1`, i.e. the largest possible value, that was present from the beginning.

This had two limitations:
* you couldn't ever insert -1 as a key because according to the `nextKey` it was already included
* you couldn't properly use 0 as a key (e.g., you couldn't `set()` its value), because it didn't have a low node associated with it.

The first point is minor (we probably don't need -1 as a key) but the second point is very annoying, because 0 is the natural value for a dummy key. Setting key=0 to value=0 (the initial value) is a very convenient way to represent a dummy update, because it doesn't affect the tree at all. So with this PR, dummy updates of the Merkle map are supported out of the box without any additional logic.

## How

The changes here make both 0 and -1 usable like any other keys. (As before, the Merkle map is initially populated with (0, 0) as the only key-value pair.)

The issue is solved by doing the same [as the Aztec implementation](https://docs.aztec.network/aztec/concepts/storage/trees/indexed_merkle_tree) and making 0 act as both the smallest _and_ the largest key simultaneously. So, we always have `nextKey: 0` in the node with the largest currently stored key, and that node acts as a valid low node for the 0 key.

Implementation-wise, it just means adding a couple of special cases to the key comparison functions. The constraints increase but not significantly:
```
indexed merkle map (get) 461
indexed merkle map (get option) 990
sparse merkle map (get) 4208

indexed merkle map (insert) 1706
indexed merkle map (update) 905
indexed merkle map (set) 1893
sparse merkle map (set) 8160

indexed merkle map (assert included) 460
indexed merkle map (assert not included) 517
indexed merkle map (is included) 523
```