### PR TITLE
Use IndexedMerkleMap for OffchainState

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -52,7 +52,10 @@ export { Gadgets } from './lib/provable/gadgets/gadgets.js';
 export { Types } from './bindings/mina-transaction/types.js';
 
 export { MerkleList, MerkleListIterator } from './lib/provable/merkle-list.js';
-import { IndexedMerkleMap } from './lib/provable/merkle-tree-indexed.js';
+import {
+  IndexedMerkleMap,
+  IndexedMerkleMapBase,
+} from './lib/provable/merkle-tree-indexed.js';
 export { Option } from './lib/provable/option.js';
 
 export * as Mina from './lib/mina/mina.js';
@@ -146,6 +149,7 @@ namespace Experimental {
 
   // indexed merkle map
   export let IndexedMerkleMap = Experimental_.IndexedMerkleMap;
+  export type IndexedMerkleMap = IndexedMerkleMapBase;
 
   // offchain state
   export let OffchainState = OffchainState_.OffchainState;

--- a/src/lib/mina/actions/offchain-contract.unit-test.ts
+++ b/src/lib/mina/actions/offchain-contract.unit-test.ts
@@ -2,7 +2,6 @@ import {
   SmartContract,
   method,
   Mina,
-  State,
   state,
   PublicKey,
   UInt64,
@@ -14,10 +13,13 @@ const proofsEnabled = true;
 
 const { OffchainState, OffchainStateCommitments } = Experimental;
 
-const offchainState = OffchainState({
-  accounts: OffchainState.Map(PublicKey, UInt64),
-  totalSupply: OffchainState.Field(UInt64),
-});
+const offchainState = OffchainState(
+  {
+    accounts: OffchainState.Map(PublicKey, UInt64),
+    totalSupply: OffchainState.Field(UInt64),
+  },
+  { logTotalCapacity: 10, maxActionsPerProof: 5 }
+);
 
 class StateProof extends offchainState.Proof {}
 
@@ -26,9 +28,7 @@ class StateProof extends offchainState.Proof {}
 class ExampleContract extends SmartContract {
   // TODO could have sugar for this like
   // @OffchainState.commitment offchainState = OffchainState.Commitment();
-  @state(OffchainStateCommitments) offchainState = State(
-    OffchainStateCommitments.empty()
-  );
+  @state(OffchainStateCommitments) offchainState = offchainState.commitments();
 
   @method
   async createAccount(address: PublicKey, amountToMint: UInt64) {

--- a/src/lib/mina/actions/offchain-contract.unit-test.ts
+++ b/src/lib/mina/actions/offchain-contract.unit-test.ts
@@ -11,7 +11,7 @@ import assert from 'assert';
 
 const proofsEnabled = true;
 
-const { OffchainState, OffchainStateCommitments } = Experimental;
+const { OffchainState } = Experimental;
 
 const offchainState = OffchainState(
   {
@@ -26,9 +26,7 @@ class StateProof extends offchainState.Proof {}
 // example contract that interacts with offchain state
 
 class ExampleContract extends SmartContract {
-  // TODO could have sugar for this like
-  // @OffchainState.commitment offchainState = OffchainState.Commitment();
-  @state(OffchainStateCommitments) offchainState = offchainState.commitments();
+  @state(OffchainState.Commitments) offchainState = offchainState.commitments();
 
   @method
   async createAccount(address: PublicKey, amountToMint: UInt64) {

--- a/src/lib/mina/actions/offchain-state-rollup.ts
+++ b/src/lib/mina/actions/offchain-state-rollup.ts
@@ -15,7 +15,6 @@ import {
   MerkleLeaf,
   updateMerkleMap,
 } from './offchain-state-serialization.js';
-import { MerkleMap } from '../../provable/merkle-map.js';
 import { getProofsEnabled } from '../mina.js';
 
 export { OffchainStateRollup, OffchainStateCommitments };
@@ -27,6 +26,9 @@ class ActionIterator extends MerkleListIterator.create(
   // we don't have to care about the initial hash here because we will just step forward
   Actions.emptyActionState()
 ) {}
+
+const TREE_HEIGHT = 256;
+class MerkleMapWitness extends MerkleWitness(TREE_HEIGHT) {}
 
 /**
  * Commitments that keep track of the current state of an offchain Merkle tree constructed from actions.
@@ -44,16 +46,13 @@ class OffchainStateCommitments extends Struct({
   actionState: Field,
 }) {
   static empty() {
-    let emptyMerkleRoot = new MerkleMap().getRoot();
+    let emptyMerkleRoot = new MerkleTree(TREE_HEIGHT).getRoot();
     return new OffchainStateCommitments({
       root: emptyMerkleRoot,
       actionState: Actions.emptyActionState(),
     });
   }
 }
-
-const TREE_HEIGHT = 256;
-class MerkleMapWitness extends MerkleWitness(TREE_HEIGHT) {}
 
 // TODO: it would be nice to abstract the logic for proving a chain of state transition proofs
 

--- a/src/lib/mina/actions/offchain-state-rollup.ts
+++ b/src/lib/mina/actions/offchain-state-rollup.ts
@@ -286,6 +286,11 @@ function OffchainStateRollup({
       let slice = sliceActions(iterator, maxActionsPerProof);
       let proof = await offchainStateRollup.firstBatch(inputState, slice, tree);
 
+      // update tree root/length again, they aren't mutated :(
+      // TODO: this shows why the full tree should be the public output
+      tree.root = proof.publicOutput.root;
+      tree.length = Field(tree.data.get().sortedLeaves.length);
+
       // recursive proofs
       let nProofs = 1;
       for (let i = 1; ; i++) {
@@ -299,6 +304,10 @@ function OffchainStateRollup({
           tree,
           proof
         );
+
+        // update tree root/length again, they aren't mutated :(
+        tree.root = proof.publicOutput.root;
+        tree.length = Field(tree.data.get().sortedLeaves.length);
       }
 
       return { proof, tree, nProofs };

--- a/src/lib/mina/actions/offchain-state-rollup.ts
+++ b/src/lib/mina/actions/offchain-state-rollup.ts
@@ -98,7 +98,7 @@ function merkleUpdateBatch(
   actions.assertAtEnd();
 
   // tree must match the public Merkle root; the method operates on the tree internally
-  // TODO: this would be simpler if the tree was the public input direcetly
+  // TODO: this would be simpler if the tree was the public input directly
   stateA.root.assertEquals(tree.root);
 
   let intermediateTree = tree.clone();
@@ -175,7 +175,7 @@ function OffchainStateRollup({
           tree: IndexedMerkleMapN
         ): Promise<OffchainStateCommitments> {
           return merkleUpdateBatch(
-            { maxActionsPerProof: maxActionsPerProof, maxActionsPerUpdate },
+            { maxActionsPerProof, maxActionsPerUpdate },
             stateA,
             actions,
             tree
@@ -215,7 +215,7 @@ function OffchainStateRollup({
           let stateB = recursiveProof.publicOutput;
 
           return merkleUpdateBatch(
-            { maxActionsPerProof: maxActionsPerProof, maxActionsPerUpdate },
+            { maxActionsPerProof, maxActionsPerUpdate },
             stateB,
             actions,
             tree

--- a/src/lib/mina/actions/offchain-state-rollup.ts
+++ b/src/lib/mina/actions/offchain-state-rollup.ts
@@ -153,13 +153,20 @@ function merkleUpdateBatch(
  * This program represents a proof that we can go from OffchainStateCommitments A -> B
  */
 function OffchainStateRollup({
-  // 1 action uses about 7.5k constraints
-  // we can fit at most 7 * 7.5k = 52.5k constraints in one method next to proof verification
-  // => we use `maxActionsPerBatch = 6` to safely stay below the constraint limit
-  // the second parameter `maxActionsPerUpdate` only weakly affects # constraints, but has to be <= `maxActionsPerBatch`
-  // => so we set it to the same value
-  maxActionsPerBatch = 6,
-  maxActionsPerUpdate = 6,
+  /**
+   * the constraints used in one batch proof with a height-31 tree are:
+   *
+   * 1967*A + 87*A*U + 2
+   *
+   * where A = maxActionsPerBatch and U = maxActionsPerUpdate.
+   *
+   * To determine defaults, we set U=4 which should cover most use cases while ensuring
+   * that the main loop which is independent of U dominates.
+   *
+   * Targeting ~50k constraints, to leave room for recursive verification, yields A=22.
+   */
+  maxActionsPerBatch = 22,
+  maxActionsPerUpdate = 4,
 } = {}) {
   let offchainStateRollup = ZkProgram({
     name: 'merkle-map-rollup',

--- a/src/lib/mina/actions/offchain-state-serialization.ts
+++ b/src/lib/mina/actions/offchain-state-serialization.ts
@@ -39,13 +39,15 @@ export {
   fetchMerkleMap,
   updateMerkleMap,
   Actionable,
+  TREE_HEIGHT,
 };
 
 type Action = [...Field[], Field, Field];
 type Actionable<T, V = any> = ProvableHashable<T, V> & ProvablePure<T, V>;
 
 // TODO: make 31 a parameter
-class IndexedMerkleMap31 extends IndexedMerkleMap(31) {}
+const TREE_HEIGHT = 31;
+class IndexedMerkleMap31 extends IndexedMerkleMap(TREE_HEIGHT) {}
 
 function toKeyHash<K, KeyType extends Actionable<K> | undefined>(
   prefix: Field,
@@ -299,9 +301,9 @@ function updateMerkleMap(
         MerkleLeaf.toValue(leaf);
 
       // the update is invalid if there is an unsatisfied precondition
+      let previous = intermediateTree.getOption(key).orElse(0n);
       let isValidAction =
-        !usesPreviousValue ||
-        intermediateTree.get(key).toBigInt() === previousValue;
+        !usesPreviousValue || previous.toBigInt() === previousValue;
 
       if (!isValidAction) {
         isValidUpdate = false;

--- a/src/lib/mina/actions/offchain-state-serialization.ts
+++ b/src/lib/mina/actions/offchain-state-serialization.ts
@@ -24,8 +24,8 @@ import * as Mina from '../mina.js';
 import { PublicKey } from '../../provable/crypto/signature.js';
 import { Provable } from '../../provable/provable.js';
 import { Actions } from '../account-update.js';
-import { MerkleTree } from '../../provable/merkle-tree.js';
 import { Option } from '../../provable/option.js';
+import { IndexedMerkleMap } from '../../provable/merkle-tree-indexed.js';
 
 export {
   toKeyHash,
@@ -43,6 +43,9 @@ export {
 
 type Action = [...Field[], Field, Field];
 type Actionable<T, V = any> = ProvableHashable<T, V> & ProvablePure<T, V>;
+
+// TODO: make 31 a parameter
+class IndexedMerkleMap31 extends IndexedMerkleMap(31) {}
 
 function toKeyHash<K, KeyType extends Actionable<K> | undefined>(
   prefix: Field,
@@ -258,7 +261,7 @@ async function fetchMerkleLeaves(
 async function fetchMerkleMap(
   contract: { address: PublicKey; tokenId: Field },
   endActionState?: Field
-): Promise<{ merkleMap: MerkleTree; valueMap: Map<bigint, Field[]> }> {
+): Promise<{ merkleMap: IndexedMerkleMap31; valueMap: Map<bigint, Field[]> }> {
   let result = await Mina.fetchActions(
     contract.address,
     { endActionState },
@@ -272,7 +275,7 @@ async function fetchMerkleMap(
       .reverse()
   );
 
-  let merkleMap = new MerkleTree(256);
+  let merkleMap = new IndexedMerkleMap31();
   let valueMap = new Map<bigint, Field[]>();
 
   updateMerkleMap(leaves, merkleMap, valueMap);
@@ -282,14 +285,14 @@ async function fetchMerkleMap(
 
 function updateMerkleMap(
   updates: MerkleLeaf[][],
-  tree: MerkleTree,
+  tree: IndexedMerkleMap31,
   valueMap?: Map<bigint, Field[]>
 ) {
   let intermediateTree = tree.clone();
 
   for (let leaves of updates) {
     let isValidUpdate = true;
-    let updates: { key: bigint; value: bigint; fullValue: Field[] }[] = [];
+    let updates: { key: bigint; fullValue: Field[] }[] = [];
 
     for (let leaf of leaves) {
       let { key, value, usesPreviousValue, previousValue, prefix } =
@@ -298,28 +301,27 @@ function updateMerkleMap(
       // the update is invalid if there is an unsatisfied precondition
       let isValidAction =
         !usesPreviousValue ||
-        intermediateTree.getLeaf(key).toBigInt() === previousValue;
+        intermediateTree.get(key).toBigInt() === previousValue;
 
       if (!isValidAction) {
         isValidUpdate = false;
-
         break;
       }
 
       // update the intermediate tree, save updates for final tree
-      intermediateTree.setLeaf(key, Field(value));
-      updates.push({ key, value, fullValue: prefix.get() });
+      intermediateTree.set(key, value);
+      updates.push({ key, fullValue: prefix.get() });
     }
 
     if (isValidUpdate) {
       // if the update was valid, we can commit the updates
-      for (let { key, value, fullValue } of updates) {
-        tree.setLeaf(key, Field(value));
+      tree.overwrite(intermediateTree);
+      for (let { key, fullValue } of updates) {
         if (valueMap) valueMap.set(key, fullValue);
       }
     } else {
       // if the update was invalid, we have to roll back the intermediate tree
-      intermediateTree = tree.clone();
+      intermediateTree.overwrite(tree);
     }
   }
 }

--- a/src/lib/mina/actions/offchain-state.ts
+++ b/src/lib/mina/actions/offchain-state.ts
@@ -1,6 +1,7 @@
 import { InferProvable } from '../../provable/types/struct.js';
 import {
   Actionable,
+  TREE_HEIGHT,
   fetchMerkleLeaves,
   fetchMerkleMap,
   fromActionWithoutHashes,
@@ -98,7 +99,7 @@ type OffchainStateContract = SmartContract & {
   offchainState: State<OffchainStateCommitments>;
 };
 
-class IndexedMerkleMap31 extends IndexedMerkleMap(31) {}
+class IndexedMerkleMap31 extends IndexedMerkleMap(TREE_HEIGHT) {}
 
 /**
  * Offchain state for a `SmartContract`.

--- a/src/lib/mina/actions/offchain-state.ts
+++ b/src/lib/mina/actions/offchain-state.ts
@@ -428,6 +428,7 @@ function OffchainState<
 
 OffchainState.Map = OffchainMap;
 OffchainState.Field = OffchainField;
+OffchainState.Commitments = OffchainStateCommitments;
 
 // type helpers
 

--- a/src/lib/provable/merkle-tree-indexed.ts
+++ b/src/lib/provable/merkle-tree-indexed.ts
@@ -146,7 +146,8 @@ class IndexedMerkleMapBase {
     let cloned = new (this.constructor as typeof IndexedMerkleMapBase)();
     cloned.root = this.root;
     cloned.length = this.length;
-    cloned.data.updateAsProver(({ nodes, sortedLeaves }) => {
+    cloned.data.updateAsProver(() => {
+      let { nodes, sortedLeaves } = this.data.get();
       return {
         nodes: nodes.map((row) => [...row]),
         sortedLeaves: [...sortedLeaves],

--- a/src/lib/provable/merkle-tree-indexed.ts
+++ b/src/lib/provable/merkle-tree-indexed.ts
@@ -11,7 +11,7 @@ import { conditionalSwap } from './merkle-tree.js';
 import { provableFromClass } from './types/provable-derivers.js';
 
 // external API
-export { IndexedMerkleMap };
+export { IndexedMerkleMap, IndexedMerkleMapBase };
 
 // internal API
 export { Leaf };

--- a/src/lib/provable/merkle-tree-indexed.ts
+++ b/src/lib/provable/merkle-tree-indexed.ts
@@ -196,8 +196,10 @@ class IndexedMerkleMapBase {
    * Update an existing leaf `(key, value)`.
    *
    * Proves that the `key` exists.
+   *
+   * Returns the previous value.
    */
-  update(key: Field | bigint, value: Field | bigint) {
+  update(key: Field | bigint, value: Field | bigint): Field {
     key = Field(key);
     value = Field(value);
 
@@ -212,6 +214,8 @@ class IndexedMerkleMapBase {
     let newSelf = { ...self, value };
     this.root = this._computeRoot(self.index, Leaf.hashNode(newSelf));
     this._setLeafUnconstrained(true, newSelf);
+
+    return self.value;
   }
 
   /**
@@ -221,8 +225,10 @@ class IndexedMerkleMapBase {
    * can use it if you don't know whether the key exists or not.
    *
    * However, this comes at an efficiency cost, so prefer to use `insert()` or `update()` if you know whether the key exists.
+   *
+   * Returns the previous value, as an option (which is `None` if the key didn't exist before).
    */
-  set(key: Field | bigint, value: Field | bigint) {
+  set(key: Field | bigint, value: Field | bigint): Option<Field, bigint> {
     key = Field(key);
     value = Field(value);
 
@@ -260,6 +266,9 @@ class IndexedMerkleMapBase {
     this.root = this._computeRoot(indexBits, Leaf.hashNode(newLeaf));
     this.length = Provable.if(keyExists, this.length, this.length.add(1));
     this._setLeafUnconstrained(keyExists, newLeaf);
+
+    // return the previous value
+    return new OptionField({ isSome: keyExists, value: self.value });
   }
 
   /**

--- a/src/lib/provable/merkle-tree-indexed.ts
+++ b/src/lib/provable/merkle-tree-indexed.ts
@@ -103,6 +103,19 @@ class IndexedMerkleMapBase {
     readonly sortedLeaves: LeafValue[];
   }>;
 
+  clone() {
+    let cloned = new (this.constructor as typeof IndexedMerkleMapBase)();
+    cloned.root = this.root;
+    cloned.length = this.length;
+    cloned.data.updateAsProver(({ nodes, sortedLeaves }) => {
+      return {
+        nodes: nodes.map((row) => [...row]),
+        sortedLeaves: [...sortedLeaves],
+      };
+    });
+    return cloned;
+  }
+
   // we'd like to do `abstract static provable` here but that's not supported
   static provable: Provable<
     IndexedMerkleMapBase,
@@ -559,13 +572,13 @@ class Leaf extends Struct({
 }
 
 type LeafValue = {
-  value: bigint;
+  readonly value: bigint;
 
-  key: bigint;
-  nextKey: bigint;
+  readonly key: bigint;
+  readonly nextKey: bigint;
 
-  index: bigint;
-  nextIndex: bigint;
+  readonly index: bigint;
+  readonly nextIndex: bigint;
 };
 
 class LeafPair extends Struct({ low: Leaf, self: Leaf }) {}


### PR DESCRIPTION
This follows #1666 and #1671 and uses the new `IndexedMerkleMap` for `OffchainState`.

Also:
* ~~Fixes `IndexedMerkleMap.clone()`~~ (cherry-picked in previous PR)
* Adds `IndexedMerkleMap.{overwrite, overwriteIf}`

TODO:
* [x] Make tree height, actions per update and actions per batch parameters that can be overriden
* [x] Fix proving when there are multiple settlement proofs in a row
