### PR TITLE
Properly handle missing accounts after fetching, and other fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,10 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
   - Also deprecated `Int64.neg()` in favor of `Int64.negV2()`, for compatibility with v2 version of `Int64` that will use `Int64.checkV2()`
 - `Ecdsa.verify()` and `Ecdsa.verifySignedHash()` deprecated in favor of `Ecdsa.verifyV2()` and `Ecdsa.verifySignedHashV2()` due to a security vulnerability found in the current implementation https://github.com/o1-labs/o1js/pull/1669
 
+### Fixed
+
+- Fix handling of fetch response for non-existing accounts https://github.com/o1-labs/o1js/pull/1679
+
 ## [1.3.0](https://github.com/o1-labs/o1js/compare/6a1012162...54d6545bf)
 
 ### Added

--- a/src/lib/mina/account-update.ts
+++ b/src/lib/mina/account-update.ts
@@ -37,8 +37,8 @@ import {
 } from '../proof-system/zkprogram.js';
 import { Memo } from '../../mina-signer/src/memo.js';
 import {
-  Events,
-  Actions,
+  Events as BaseEvents,
+  Actions as BaseActions,
 } from '../../bindings/mina-transaction/transaction-leaves.js';
 import { TokenId as Base58TokenId } from './base58-encodings.js';
 import {
@@ -132,6 +132,31 @@ type AccountUpdateBody = Types.AccountUpdate['body'];
 type Update = AccountUpdateBody['update'];
 
 type MayUseToken = AccountUpdateBody['mayUseToken'];
+
+type Events = BaseEvents;
+const Events = {
+  ...BaseEvents,
+  pushEvent(events: Events, event: Field[]): Events {
+    events = BaseEvents.pushEvent(events, event);
+    Provable.asProver(() => {
+      // make sure unconstrained data is stored as constants
+      events.data[0] = events.data[0].map((e) => Field(Field.toBigint(e)));
+    });
+    return events;
+  },
+};
+type Actions = BaseActions;
+const Actions = {
+  ...BaseActions,
+  pushEvent(actions: Actions, action: Field[]): Actions {
+    actions = BaseActions.pushEvent(actions, action);
+    Provable.asProver(() => {
+      // make sure unconstrained data is stored as constants
+      actions.data[0] = actions.data[0].map((e) => Field(Field.toBigint(e)));
+    });
+    return actions;
+  },
+};
 
 /**
  * Either set a value or keep it the same.

--- a/src/lib/mina/account.ts
+++ b/src/lib/mina/account.ts
@@ -35,7 +35,7 @@ type PartialAccount = Omit<Partial<Account>, 'zkapp'> & {
 };
 
 // convert FetchedAccount (from graphql) to Account (internal representation both here and in Mina)
-function parseFetchedAccount({ account }: FetchedAccount): Account {
+function parseFetchedAccount(account: FetchedAccount): Account {
   const {
     publicKey,
     nonce,

--- a/src/lib/mina/events.ts
+++ b/src/lib/mina/events.ts
@@ -4,7 +4,6 @@ import {
   GenericProvableExtended,
   GenericSignableField,
 } from '../../bindings/lib/generic.js';
-import { Provable } from '../provable/provable.js';
 
 export { createEvents, dataAsHash };
 
@@ -49,11 +48,7 @@ function createEvents<Field>({
     pushEvent(events: Events, event: Event): Events {
       let eventHash = hashWithPrefix(prefixes.event, event);
       let hash = hashWithPrefix(prefixes.events, [events.hash, eventHash]);
-      let data = [...events.data];
-      Provable.asProver(() => {
-        data.unshift(event.map((e) => Field(Field.toBigint(e))));
-      });
-      return { hash, data };
+      return { hash, data: [event, ...events.data] };
     },
     fromList(events: Event[]): Events {
       return [...events].reverse().reduce(Events.pushEvent, Events.empty());
@@ -96,11 +91,7 @@ function createEvents<Field>({
         actions.hash,
         eventHash,
       ]);
-      let data = [...actions.data];
-      Provable.asProver(() => {
-        data.unshift(event.map((e) => Field(Field.toBigint(e))));
-      });
-      return { hash, data };
+      return { hash, data: [event, ...actions.data] };
     },
     fromList(events: Event[]): Events {
       return [...events].reverse().reduce(Actions.pushEvent, Actions.empty());

--- a/src/lib/mina/events.ts
+++ b/src/lib/mina/events.ts
@@ -4,6 +4,7 @@ import {
   GenericProvableExtended,
   GenericSignableField,
 } from '../../bindings/lib/generic.js';
+import { Provable } from '../provable/provable.js';
 
 export { createEvents, dataAsHash };
 
@@ -48,7 +49,11 @@ function createEvents<Field>({
     pushEvent(events: Events, event: Event): Events {
       let eventHash = hashWithPrefix(prefixes.event, event);
       let hash = hashWithPrefix(prefixes.events, [events.hash, eventHash]);
-      return { hash, data: [event, ...events.data] };
+      let data = [...events.data];
+      Provable.asProver(() => {
+        data.unshift(event.map((e) => Field(Field.toBigint(e))));
+      });
+      return { hash, data };
     },
     fromList(events: Event[]): Events {
       return [...events].reverse().reduce(Events.pushEvent, Events.empty());
@@ -91,7 +96,11 @@ function createEvents<Field>({
         actions.hash,
         eventHash,
       ]);
-      return { hash, data: [event, ...actions.data] };
+      let data = [...actions.data];
+      Provable.asProver(() => {
+        data.unshift(event.map((e) => Field(Field.toBigint(e))));
+      });
+      return { hash, data };
     },
     fromList(events: Event[]): Events {
       return [...events].reverse().reduce(Actions.pushEvent, Actions.empty());

--- a/src/lib/mina/fetch.ts
+++ b/src/lib/mina/fetch.ts
@@ -24,7 +24,7 @@ import {
   type ActionQueryResponse,
   type EventActionFilterOptions,
   type SendZkAppResponse,
-  type FetchedAccount,
+  type FetchedAccountResponse,
   type CurrentSlotResponse,
   sendZkappQuery,
   lastBlockQuery,
@@ -202,14 +202,14 @@ async function fetchAccountInternal(
   config?: FetchConfig
 ) {
   const { publicKey, tokenId } = accountInfo;
-  let [response, error] = await makeGraphqlRequest<FetchedAccount>(
+  let [response, error] = await makeGraphqlRequest<FetchedAccountResponse>(
     accountQuery(publicKey, tokenId ?? TokenId.toBase58(TokenId.default)),
     graphqlEndpoint,
     networkConfig.minaFallbackEndpoints,
     config
   );
   if (error !== undefined) return { account: undefined, error };
-  let fetchedAccount = response?.data;
+  let fetchedAccount = response?.data?.account;
   if (!fetchedAccount) {
     return {
       account: undefined,

--- a/src/lib/mina/fetch.ts
+++ b/src/lib/mina/fetch.ts
@@ -289,12 +289,15 @@ type GenesisConstants = {
 };
 let genesisConstantsCache = {} as Record<string, GenesisConstants>;
 
+const emptyKey = PublicKey.empty().toBase58();
+
 function markAccountToBeFetched(
   publicKey: PublicKey,
   tokenId: Field,
   graphqlEndpoint: string
 ) {
   let publicKeyBase58 = publicKey.toBase58();
+  if (publicKeyBase58 === emptyKey) return;
   let tokenBase58 = TokenId.toBase58(tokenId);
   accountsToFetch[`${publicKeyBase58};${tokenBase58};${graphqlEndpoint}`] = {
     publicKey: publicKeyBase58,

--- a/src/lib/mina/graphql.ts
+++ b/src/lib/mina/graphql.ts
@@ -17,6 +17,7 @@ export {
   type EventActionFilterOptions,
   type SendZkAppResponse,
   type FetchedAccount,
+  type FetchedAccountResponse,
   type CurrentSlotResponse,
   getEventsQuery,
   getActionsQuery,
@@ -39,46 +40,47 @@ function removeJsonQuotes(json: string) {
 type AuthRequired = Types.Json.AuthRequired;
 // TODO auto-generate this type and the query
 type FetchedAccount = {
-  account: {
-    publicKey: string;
-    token: string;
-    nonce: string;
-    balance: { total: string };
-    tokenSymbol: string | null;
-    receiptChainHash: string | null;
-    timing: {
-      initialMinimumBalance: string | null;
-      cliffTime: string | null;
-      cliffAmount: string | null;
-      vestingPeriod: string | null;
-      vestingIncrement: string | null;
-    };
-    permissions: {
-      editState: AuthRequired;
-      access: AuthRequired;
-      send: AuthRequired;
-      receive: AuthRequired;
-      setDelegate: AuthRequired;
-      setPermissions: AuthRequired;
-      setVerificationKey: {
-        auth: AuthRequired;
-        txnVersion: string;
-      };
-      setZkappUri: AuthRequired;
-      editActionState: AuthRequired;
-      setTokenSymbol: AuthRequired;
-      incrementNonce: AuthRequired;
-      setVotingFor: AuthRequired;
-      setTiming: AuthRequired;
-    } | null;
-    delegateAccount: { publicKey: string } | null;
-    votingFor: string | null;
-    zkappState: string[] | null;
-    verificationKey: { verificationKey: string; hash: string } | null;
-    actionState: string[] | null;
-    provedState: boolean | null;
-    zkappUri: string | null;
+  publicKey: string;
+  token: string;
+  nonce: string;
+  balance: { total: string };
+  tokenSymbol: string | null;
+  receiptChainHash: string | null;
+  timing: {
+    initialMinimumBalance: string | null;
+    cliffTime: string | null;
+    cliffAmount: string | null;
+    vestingPeriod: string | null;
+    vestingIncrement: string | null;
   };
+  permissions: {
+    editState: AuthRequired;
+    access: AuthRequired;
+    send: AuthRequired;
+    receive: AuthRequired;
+    setDelegate: AuthRequired;
+    setPermissions: AuthRequired;
+    setVerificationKey: {
+      auth: AuthRequired;
+      txnVersion: string;
+    };
+    setZkappUri: AuthRequired;
+    editActionState: AuthRequired;
+    setTokenSymbol: AuthRequired;
+    incrementNonce: AuthRequired;
+    setVotingFor: AuthRequired;
+    setTiming: AuthRequired;
+  } | null;
+  delegateAccount: { publicKey: string } | null;
+  votingFor: string | null;
+  zkappState: string[] | null;
+  verificationKey: { verificationKey: string; hash: string } | null;
+  actionState: string[] | null;
+  provedState: boolean | null;
+  zkappUri: string | null;
+};
+type FetchedAccountResponse = {
+  account: FetchedAccount;
 };
 
 type EpochData = {

--- a/tsconfig.mina-signer.json
+++ b/tsconfig.mina-signer.json
@@ -6,7 +6,7 @@
     "outDir": "src/mina-signer/dist/node",
     "baseUrl": ".", // affects where output files end up
     "target": "es2020", // goal: ship *the most modern syntax* that is supported by *all* browsers that support our Wasm
-    "module": "es2022", // allow top-level await
+    "module": "nodenext", // allow top-level await
     "moduleResolution": "nodenext", // comply with node + "type": "module"
     "esModuleInterop": true, // to silence jest
 


### PR DESCRIPTION
- fix handling of non-existing accounts in fetch logic
- don't try to fetch accounts with dummy public keys
- fix event pushing: transform unconstrained data to constants
