### PR TITLE
Specify feature flags for `Pickles.sideLoaded`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,11 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased](https://github.com/o1-labs/o1js/compare/40c597775...HEAD)
 
+### Added
+
+- Added the option to specify custom feature flags for sided loaded proofs in the `DynamicProof` class.
+  - Feature flags are requires to tell Pickles what proof structure it should expect when side loading dynamic proofs and verification keys. https://github.com/o1-labs/o1js/pull/1688
+
 ## [1.3.1](https://github.com/o1-labs/o1js/compare/1ad7333e9e...40c597775) - 2024-06-11
 
 ### Breaking Changes

--- a/src/examples/zkprogram/dynamic-keys-merkletree.ts
+++ b/src/examples/zkprogram/dynamic-keys-merkletree.ts
@@ -42,6 +42,7 @@ const sideloadedProgram = ZkProgram({
   },
 });
 
+// given a zkProgram, we compute the feature flags that we need in order to verify proofs that were generated
 const featureFlags = await FeatureFlags.fromZkProgram(sideloadedProgram);
 
 class SideloadedProgramProof extends DynamicProof<Field, Field> {
@@ -49,7 +50,7 @@ class SideloadedProgramProof extends DynamicProof<Field, Field> {
   static publicOutputType = Field;
   static maxProofsVerified = 0 as const;
 
-  // we configure this side loaded proof to only accept proofs that doesn't use any feature flags (custom gates)
+  // we use the feature flags that we computed from the `sideloadedProgram` ZkProgram
   static featureFlags = featureFlags;
 }
 

--- a/src/examples/zkprogram/dynamic-keys-merkletree.ts
+++ b/src/examples/zkprogram/dynamic-keys-merkletree.ts
@@ -1,5 +1,6 @@
 import {
   DynamicProof,
+  FeatureFlags,
   Field,
   MerkleTree,
   MerkleWitness,
@@ -37,6 +38,9 @@ class SideloadedProgramProof extends DynamicProof<Field, Field> {
   static publicInputType = Field;
   static publicOutputType = Field;
   static maxProofsVerified = 0 as const;
+
+  // we configure this side loaded proof to only accept proofs that doesn't use any feature flags (custom gates)
+  static featureFlags = FeatureFlags.allNone;
 }
 
 const tree = new MerkleTree(64);

--- a/src/index.ts
+++ b/src/index.ts
@@ -83,6 +83,7 @@ export {
   Undefined,
   Void,
   VerificationKey,
+  FeatureFlags,
 } from './lib/proof-system/zkprogram.js';
 export { Cache, CacheHeader } from './lib/proof-system/cache.js';
 

--- a/src/lib/ml/base.ts
+++ b/src/lib/ml/base.ts
@@ -14,6 +14,7 @@ export {
   MlUnit,
   MlString,
   MlTuple,
+  MlArrayMaybeElements,
 };
 
 // ocaml types
@@ -25,6 +26,11 @@ type MlOption<T> = 0 | [0, T];
 type MlBool = 0 | 1;
 type MlResult<T, E> = [0, T] | [1, E];
 type MlUnit = 0;
+
+// custom types
+type MlArrayMaybeElements<MlArray extends any[]> = {
+  [K in keyof MlArray]: MlArray[K] extends 0 ? 0 : MlOption<MlArray[K]>;
+};
 
 /**
  * js_of_ocaml representation of a byte array,

--- a/src/lib/ml/base.ts
+++ b/src/lib/ml/base.ts
@@ -14,7 +14,7 @@ export {
   MlUnit,
   MlString,
   MlTuple,
-  MlArrayMaybeElements,
+  MlArrayOptionalElements,
 };
 
 // ocaml types
@@ -28,7 +28,7 @@ type MlResult<T, E> = [0, T] | [1, E];
 type MlUnit = 0;
 
 // custom types
-type MlArrayMaybeElements<MlArray extends any[]> = {
+type MlArrayOptionalElements<MlArray extends any[]> = {
   [K in keyof MlArray]: MlArray[K] extends 0 ? 0 : MlOption<MlArray[K]>;
 };
 

--- a/src/lib/proof-system/zkprogram.ts
+++ b/src/lib/proof-system/zkprogram.ts
@@ -37,7 +37,6 @@ import {
 import { ProvablePure } from '../provable/types/provable-intf.js';
 import { prefixToField } from '../../bindings/lib/binable.js';
 import { prefixes } from '../../bindings/crypto/constants.js';
-import { rangeCheck0 } from '../provable/gates.js';
 
 // public API
 export {

--- a/src/lib/proof-system/zkprogram.ts
+++ b/src/lib/proof-system/zkprogram.ts
@@ -24,7 +24,7 @@ import {
   MlResult,
   MlPair,
   MlOption,
-  MlArrayMaybeElements,
+  MlArrayOptionalElements,
 } from '../ml/base.js';
 import { MlFieldArray, MlFieldConstArray } from '../ml/fields.js';
 import { FieldVar, FieldConst } from '../provable/core/fieldvar.js';
@@ -1070,7 +1070,7 @@ function picklesRuleFromFunction(
           ...Object.entries(Proof.featureFlags).map(([_, flag]) =>
             MlOption.mapTo(flag, MlBool)
           ),
-        ] as MlArrayMaybeElements<MlFeatureFlags>;
+        ] as MlArrayOptionalElements<MlFeatureFlags>;
 
         computedTag = Pickles.sideLoaded.create(
           tag.name,

--- a/src/lib/proof-system/zkprogram.ts
+++ b/src/lib/proof-system/zkprogram.ts
@@ -97,6 +97,9 @@ type FeatureFlags = {
   runtimeTables: MaybeFeatureFlag;
 };
 const FeatureFlags = {
+  /**
+   * Returns a feature flag configuration where all flags are set to false.
+   */
   allNone: {
     rangeCheck0: false,
     rangeCheck1: false,
@@ -107,6 +110,9 @@ const FeatureFlags = {
     lookup: false,
     runtimeTables: false,
   },
+  /**
+   * Returns a feature flag configuration where all flags are optional.
+   */
   allMaybe: {
     rangeCheck0: undefined,
     rangeCheck1: undefined,
@@ -117,6 +123,11 @@ const FeatureFlags = {
     lookup: undefined,
     runtimeTables: undefined,
   },
+
+  /**
+   * Given a list of gates, returns the feature flag configuration that the gates use.
+   */
+  fromGates: (gates: Gate[]) => featureFlagsFromGates(gates),
 };
 
 class ProofBase<Input, Output> {
@@ -1096,7 +1107,7 @@ function picklesRuleFromFunction(
     }
   });
 
-  let featureFlags = computeFeatureFlags(gates);
+  let featureFlags = featureFlagsToMl(featureFlagsFromGates(gates));
 
   return {
     identifier: methodName,
@@ -1274,7 +1285,7 @@ const gateToFlag: Partial<Record<GateType, keyof FeatureFlags>> = {
   Lookup: 'lookup',
 };
 
-function computeFeatureFlags(gates: Gate[]): MlFeatureFlags {
+function featureFlagsFromGates(gates: Gate[]) {
   let flags: FeatureFlags = {
     rangeCheck0: false,
     rangeCheck1: false,
@@ -1289,6 +1300,10 @@ function computeFeatureFlags(gates: Gate[]): MlFeatureFlags {
     let flag = gateToFlag[gate.type];
     if (flag !== undefined) flags[flag] = true;
   }
+  return flags;
+}
+
+function featureFlagsToMl(flags: FeatureFlags): MlFeatureFlags {
   return [
     0,
     ...Object.entries(flags).map(([_, flag]) =>

--- a/src/lib/proof-system/zkprogram.ts
+++ b/src/lib/proof-system/zkprogram.ts
@@ -130,7 +130,7 @@ const FeatureFlags = {
   /**
    * Given a list of gates, returns the feature flag configuration that the gates use.
    */
-  fromGates: (gates: Gate[]) => featureFlagsFromGates(gates),
+  fromGates: featureFlagsFromGates,
 
   /**
    * Given a ZkProgram, return the feature flag configuration that fits the given program.

--- a/src/lib/proof-system/zkprogram.ts
+++ b/src/lib/proof-system/zkprogram.ts
@@ -1065,13 +1065,19 @@ function picklesRuleFromFunction(
       let computedTag: unknown;
       // Only create the tag if it hasn't already been created for this specific Proof class
       if (SideloadedTag.get(tag.name) === undefined) {
-        console.log('feature flags', Proof.featureFlags);
+        let featureFlags = [
+          0,
+          ...Object.entries(Proof.featureFlags).map(([_, flag]) =>
+            MlOption.mapTo(flag, MlBool)
+          ),
+        ] as MlArrayMaybeElements<MlFeatureFlags>;
+
         computedTag = Pickles.sideLoaded.create(
           tag.name,
           Proof.maxProofsVerified,
           Proof.publicInputType?.sizeInFields() ?? 0,
           Proof.publicOutputType?.sizeInFields() ?? 0,
-          featureFlagsToOptionalMl(Proof.featureFlags)
+          featureFlags
         );
         SideloadedTag.store(tag.name, computedTag);
       } else {
@@ -1267,15 +1273,6 @@ const gateToFlag: Partial<Record<GateType, keyof FeatureFlags>> = {
   Rot64: 'rot',
   Lookup: 'lookup',
 };
-
-function featureFlagsToOptionalMl(
-  flags: FeatureFlags
-): MlArrayMaybeElements<MlFeatureFlags> {
-  return [
-    0,
-    ...Object.entries(flags).map(([_, flag]) => MlOption.mapTo(flag, MlBool)),
-  ] as MlArrayMaybeElements<MlFeatureFlags>;
-}
 
 function computeFeatureFlags(gates: Gate[]): MlFeatureFlags {
   let flags: FeatureFlags = {

--- a/src/lib/proof-system/zkprogram.ts
+++ b/src/lib/proof-system/zkprogram.ts
@@ -1160,7 +1160,7 @@ function picklesRuleFromFunction(
     }
   });
 
-  let featureFlags = featureFlagsToMl(featureFlagsFromGates(gates));
+  let featureFlags = featureFlagsToMlOption(featureFlagsFromGates(gates));
 
   return {
     identifier: methodName,
@@ -1354,31 +1354,6 @@ function featureFlagsFromGates(gates: Gate[]): FeatureFlags {
     if (flag !== undefined) flags[flag] = true;
   }
   return flags;
-}
-
-function featureFlagsToMl(flags: FeatureFlags): MlFeatureFlags {
-  const {
-    rangeCheck0,
-    rangeCheck1,
-    foreignFieldAdd,
-    foreignFieldMul,
-    xor,
-    rot,
-    lookup,
-    runtimeTables,
-  } = flags;
-
-  return [
-    0,
-    MlBool(rangeCheck0 ?? false),
-    MlBool(rangeCheck1 ?? false),
-    MlBool(foreignFieldAdd ?? false),
-    MlBool(foreignFieldMul ?? false),
-    MlBool(xor ?? false),
-    MlBool(rot ?? false),
-    MlBool(lookup ?? false),
-    MlBool(runtimeTables ?? false),
-  ];
 }
 
 function featureFlagsToMlOption(

--- a/src/snarky.d.ts
+++ b/src/snarky.d.ts
@@ -630,7 +630,7 @@ declare namespace Pickles {
     /**
      * Feature flags which enable certain custom gates
      */
-    featureFlags: MlFeatureFlags;
+    featureFlags: MlArrayOptionalElements<MlFeatureFlags>;
     /**
      * Description of previous proofs to verify in this rule
      */

--- a/src/snarky.d.ts
+++ b/src/snarky.d.ts
@@ -18,6 +18,7 @@ import type {
   MlUnit,
   MlString,
   MlTuple,
+  MlArrayMaybeElements,
 } from './lib/ml/base.js';
 import type { MlHashInput } from './lib/ml/conversion.js';
 import type {
@@ -45,7 +46,6 @@ export {
   JsonGate,
   MlPublicKey,
   MlPublicKeyVar,
-  FeatureFlags,
   MlFeatureFlags,
 };
 
@@ -598,17 +598,6 @@ type Test = {
   };
 };
 
-type FeatureFlags = {
-  rangeCheck0: boolean;
-  rangeCheck1: boolean;
-  foreignFieldAdd: boolean;
-  foreignFieldMul: boolean;
-  xor: boolean;
-  rot: boolean;
-  lookup: boolean;
-  runtimeTables: boolean;
-};
-
 type MlFeatureFlags = [
   _: 0,
   rangeCheck0: MlBool,
@@ -747,7 +736,8 @@ declare const Pickles: {
       name: string,
       numProofsVerified: 0 | 1 | 2,
       publicInputLength: number,
-      publicOutputLength: number
+      publicOutputLength: number,
+      featureFlags: MlArrayMaybeElements<MlFeatureFlags>
     ) => unknown /* tag */;
     // Instantiate the verification key inside the circuit (required).
     inCircuit: (tag: unknown, verificationKey: unknown) => undefined;

--- a/src/snarky.d.ts
+++ b/src/snarky.d.ts
@@ -18,7 +18,7 @@ import type {
   MlUnit,
   MlString,
   MlTuple,
-  MlArrayMaybeElements,
+  MlArrayOptionalElements,
 } from './lib/ml/base.js';
 import type { MlHashInput } from './lib/ml/conversion.js';
 import type {
@@ -737,7 +737,7 @@ declare const Pickles: {
       numProofsVerified: 0 | 1 | 2,
       publicInputLength: number,
       publicOutputLength: number,
-      featureFlags: MlArrayMaybeElements<MlFeatureFlags>
+      featureFlags: MlArrayOptionalElements<MlFeatureFlags>
     ) => unknown /* tag */;
     // Instantiate the verification key inside the circuit (required).
     inCircuit: (tag: unknown, verificationKey: unknown) => undefined;


### PR DESCRIPTION
Allows of custom specification of feature flags under the `DynamicProof` class 

bindings https://github.com/o1-labs/o1js-bindings/pull/277

closes https://github.com/o1-labs/o1js/issues/1686