### PR TITLE
Expose SHA256 low-level API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,10 +19,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ### Added
 
-- **SHA256 low-level API** exposed via `Gadgets.SHA256`. https://github.com/o1-labs/o1js/pull/1689
-
-### Added
-
+- **SHA256 low-level API** exposed via `Gadgets.SHA256`. https://github.com/o1-labs/o1js/pull/1689 [@Shigoto-dev19](https://github.com/Shigoto-dev19)
 - Added the option to specify custom feature flags for sided loaded proofs in the `DynamicProof` class.
   - Feature flags are requires to tell Pickles what proof structure it should expect when side loading dynamic proofs and verification keys. https://github.com/o1-labs/o1js/pull/1688
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
     _Security_ in case of vulnerabilities.
  -->
 
-## [Unreleased](https://github.com/o1-labs/o1js/compare/f16e26a20...HEAD)
+## [Unreleased](https://github.com/o1-labs/o1js/compare/40c597775...HEAD)
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,11 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
     _Security_ in case of vulnerabilities.
  -->
 
-## [Unreleased](https://github.com/o1-labs/o1js/compare/40c597775...HEAD)
+## [Unreleased](https://github.com/o1-labs/o1js/compare/f16e26a20...HEAD)
+
+### Added
+
+- **SHA256 low-level API** exposed via `Gadgets.SHA256`. https://github.com/o1-labs/o1js/pull/1689
 
 ## [1.3.1](https://github.com/o1-labs/o1js/compare/1ad7333e9e...40c597775) - 2024-06-11
 

--- a/src/lib/provable/gadgets/sha256.ts
+++ b/src/lib/provable/gadgets/sha256.ts
@@ -88,7 +88,7 @@ const SHA256 = {
     // padding the message $5.1.1 into blocks that are a multiple of 512
     let messageBlocks = padding(data);
 
-    let H = SHA256Constants.H.map((x) => UInt32.from(x));
+    let H = SHA256.initialState;
     const N = messageBlocks.length;
 
     for (let i = 0; i < N; i++) {
@@ -102,6 +102,9 @@ const SHA256 = {
   },
   compression: sha256Compression,
   createMessageSchedule,
+  get initialState() {
+    return SHA256Constants.H.map((x) => UInt32.from(x));
+  },
 };
 
 function Ch(x: UInt32, y: UInt32, z: UInt32) {

--- a/src/lib/provable/gadgets/sha256.ts
+++ b/src/lib/provable/gadgets/sha256.ts
@@ -89,13 +89,11 @@ const SHA256 = {
     let messageBlocks = padding(data);
 
     let H = SHA256Constants.H.map((x) => UInt32.from(x));
-    const K = SHA256Constants.K.map((x) => UInt32.from(x));
-
     const N = messageBlocks.length;
 
     for (let i = 0; i < N; i++) {
       const W = computeMessageSchedule(messageBlocks[i]);
-      H = sha256Compression(H, W, K);
+      H = sha256Compression(H, W);
     }
 
     // the working variables H[i] are 32bit, however we want to decompose them into bytes to be more compatible
@@ -235,10 +233,10 @@ function sigma(u: UInt32, bits: TupleN<number, 3>, firstShifted = false) {
  *
  * @param H - The initial or intermediate hash values (8-element array of UInt32).
  * @param W - The message schedule (64-element array of UInt32).
- * @param K - The constants used in the SHA-256 algorithm (64-element array of UInt32).
+ *
  * @returns The updated intermediate hash values after compression.
  */
-function sha256Compression(H: UInt32[], W: UInt32[], K: UInt32[]) {
+function sha256Compression(H: UInt32[], W: UInt32[]) {
   // initialize working variables
   let a = H[0];
   let b = H[1];
@@ -255,7 +253,7 @@ function sha256Compression(H: UInt32[], W: UInt32[], K: UInt32[]) {
     const unreducedT1 = h.value
       .add(SigmaOne(e).value)
       .add(Ch(e, f, g).value)
-      .add(K[t].value)
+      .add(SHA256Constants.K[t])
       .add(W[t].value)
       .seal();
 

--- a/src/lib/provable/gadgets/sha256.ts
+++ b/src/lib/provable/gadgets/sha256.ts
@@ -88,7 +88,7 @@ const SHA256 = {
     // padding the message $5.1.1 into blocks that are a multiple of 512
     let messageBlocks = padding(data);
 
-    const H = SHA256Constants.H.map((x) => UInt32.from(x));
+    let H = SHA256Constants.H.map((x) => UInt32.from(x));
     const K = SHA256Constants.K.map((x) => UInt32.from(x));
 
     const N = messageBlocks.length;
@@ -110,58 +110,14 @@ const SHA256 = {
         W[t] = UInt32.Unsafe.fromField(divMod32(unreduced, 16).remainder);
       }
 
-      // initialize working variables
-      let a = H[0];
-      let b = H[1];
-      let c = H[2];
-      let d = H[3];
-      let e = H[4];
-      let f = H[5];
-      let g = H[6];
-      let h = H[7];
-
-      // main loop
-      for (let t = 0; t <= 63; t++) {
-        // T1 is unreduced and not proven to be 32bit, we will do this later to save constraints
-        const unreducedT1 = h.value
-          .add(SigmaOne(e).value)
-          .add(Ch(e, f, g).value)
-          .add(K[t].value)
-          .add(W[t].value)
-          .seal();
-
-        // T2 is also unreduced
-        const unreducedT2 = SigmaZero(a).value.add(Maj(a, b, c).value);
-
-        h = g;
-        g = f;
-        f = e;
-        e = UInt32.Unsafe.fromField(
-          divMod32(d.value.add(unreducedT1), 16).remainder
-        ); // mod 32bit the unreduced field element
-        d = c;
-        c = b;
-        b = a;
-        a = UInt32.Unsafe.fromField(
-          divMod32(unreducedT2.add(unreducedT1), 16).remainder
-        ); // mod 32bit
-      }
-
-      // new intermediate hash value
-      H[0] = H[0].addMod32(a);
-      H[1] = H[1].addMod32(b);
-      H[2] = H[2].addMod32(c);
-      H[3] = H[3].addMod32(d);
-      H[4] = H[4].addMod32(e);
-      H[5] = H[5].addMod32(f);
-      H[6] = H[6].addMod32(g);
-      H[7] = H[7].addMod32(h);
+      H = sha256Compression(H, W, K);
     }
 
     // the working variables H[i] are 32bit, however we want to decompose them into bytes to be more compatible
     // wordToBytes expects little endian, so we reverse the bytes
     return Bytes.from(H.map((x) => wordToBytes(x.value, 4).reverse()).flat());
   },
+  compression: sha256Compression,
 };
 
 function Ch(x: UInt32, y: UInt32, z: UInt32) {
@@ -286,4 +242,63 @@ function sigma(u: UInt32, bits: TupleN<number, 3>, firstShifted = false) {
   return UInt32.Unsafe.fromField(xRotR0)
     .xor(UInt32.Unsafe.fromField(xRotR1))
     .xor(UInt32.Unsafe.fromField(xRotR2));
+}
+
+/**
+ * Performs the SHA-256 compression function on the given hash values and message schedule.
+ *
+ * @param H - The initial or intermediate hash values (8-element array of UInt32).
+ * @param W - The message schedule (64-element array of UInt32).
+ * @param K - The constants used in the SHA-256 algorithm (64-element array of UInt32).
+ * @returns The updated intermediate hash values after compression.
+ */
+function sha256Compression(H: UInt32[], W: UInt32[], K: UInt32[]) {
+  // initialize working variables
+  let a = H[0];
+  let b = H[1];
+  let c = H[2];
+  let d = H[3];
+  let e = H[4];
+  let f = H[5];
+  let g = H[6];
+  let h = H[7];
+
+  // main loop
+  for (let t = 0; t <= 63; t++) {
+    // T1 is unreduced and not proven to be 32bit, we will do this later to save constraints
+    const unreducedT1 = h.value
+      .add(SigmaOne(e).value)
+      .add(Ch(e, f, g).value)
+      .add(K[t].value)
+      .add(W[t].value)
+      .seal();
+
+    // T2 is also unreduced
+    const unreducedT2 = SigmaZero(a).value.add(Maj(a, b, c).value);
+
+    h = g;
+    g = f;
+    f = e;
+    e = UInt32.Unsafe.fromField(
+      divMod32(d.value.add(unreducedT1), 16).remainder
+    ); // mod 32bit the unreduced field element
+    d = c;
+    c = b;
+    b = a;
+    a = UInt32.Unsafe.fromField(
+      divMod32(unreducedT2.add(unreducedT1), 16).remainder
+    ); // mod 32bit
+  }
+
+  // new intermediate hash value
+  H[0] = H[0].addMod32(a);
+  H[1] = H[1].addMod32(b);
+  H[2] = H[2].addMod32(c);
+  H[3] = H[3].addMod32(d);
+  H[4] = H[4].addMod32(e);
+  H[5] = H[5].addMod32(f);
+  H[6] = H[6].addMod32(g);
+  H[7] = H[7].addMod32(h);
+
+  return H;
 }

--- a/src/lib/provable/gadgets/sha256.ts
+++ b/src/lib/provable/gadgets/sha256.ts
@@ -92,7 +92,7 @@ const SHA256 = {
     const N = messageBlocks.length;
 
     for (let i = 0; i < N; i++) {
-      const W = computeMessageSchedule(messageBlocks[i]);
+      const W = createMessageSchedule(messageBlocks[i]);
       H = sha256Compression(H, W);
     }
 
@@ -101,7 +101,7 @@ const SHA256 = {
     return Bytes.from(H.map((x) => wordToBytes(x.value, 4).reverse()).flat());
   },
   compression: sha256Compression,
-  computeMessageSchedule,
+  createMessageSchedule,
 };
 
 function Ch(x: UInt32, y: UInt32, z: UInt32) {
@@ -293,7 +293,7 @@ function sha256Compression(H: UInt32[], W: UInt32[]) {
  * @param M - The 512-bit message block (16-element array of UInt32).
  * @returns The message schedule (64-element array of UInt32).
  */
-function computeMessageSchedule(M: UInt32[]) {
+function createMessageSchedule(M: UInt32[]) {
   // for each message block of 16 x 32bit do:
   const W: UInt32[] = [];
 


### PR DESCRIPTION
## Description

- This PR exposes the low-level API of the SHA-256 hash function in o1js.
- It supports the development of `partialSHA` and `dynamicSHA` as external packages while leveraging the efficiencies of the low-level API.
- Closes #1668.

## Changes

- Separated the low-level SHA-256 functions and exported them as part of the SHA-256 gadgets in o1js.
- Added 2 importable functions and 1 constant:
  - **SHA-256 Compression Function**
    - Enables flexible block hashing with better control of `initial` and `intermediate` hashes.
  - **Message Schedule Computation Function** 
    - Computes the message schedule from `message blocks` to prepare it as input to the compression function.
  - **SHA256 Initial State Constant**
    - The initial hash values, also known as the SHA256 nothing-up-my-sleeve constants, are now exposed for enhanced flexibility in constructing SHA256 hashes.
