### PR TITLE
Bringing back CircuitValue, prop and arrayProp

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -25,6 +25,8 @@ export { Hash } from './lib/provable/crypto/hash.js';
 
 export { assert } from './lib/provable/gadgets/common.js';
 
+export { CircuitValue, prop, arrayProp } from './lib/provable/types/circuit-value.js';
+
 export * from './lib/provable/crypto/signature.js';
 export type {
   ProvableExtended,


### PR DESCRIPTION
Ref: https://discord.com/channels/484437221055922177/1254021497727746088

After this change I am able to correctly inherit `CircuitValue` and use `prop`