### PR TITLE
Two new zkApp examples

### DIFF
--- a/src/examples/zkapps/escrow/token-escrow.ts
+++ b/src/examples/zkapps/escrow/token-escrow.ts
@@ -1,0 +1,139 @@
+/**
+ * This example shows how to withdraw custom tokens from a zkApp.
+ *
+ * - Inside the zkapp, we use `this.send()` to move balance to a newly created receiver account update.
+ *   - see `withdraw()` and `withdrawOptimized()`
+ *   - we also have to ensure that the receiver account update inherits token permissions
+ *
+ * - Outside the zkapp, we pass the zkapp account update to `token.approveAccountUpdate()`
+ *   - see how we call `token.approveAccountUpdate(escrow.self)` in the test below
+ */
+import {
+  SmartContract,
+  method,
+  UInt64,
+  AccountUpdate,
+  PrivateKey,
+  Mina,
+  Bool,
+} from 'o1js';
+import { TrivialCoin } from '../dex/erc20.js';
+
+const admin = Mina.TestPublicKey(
+  PrivateKey.fromBase58('EKEs6QLnX9gpqpto6tiL3TBcd3C4xx8Pyrek9Figake1Vqov1thL')
+);
+
+class TokenEscrow extends SmartContract {
+  /**
+   * Method for an admin account to withdraw funds from the escrow.
+   */
+  @method async withdraw(amount: UInt64) {
+    // only the admin can withdraw
+    this.sender.getAndRequireSignature().assertEquals(admin);
+
+    // withdraw the amount
+    let receiverAU = this.send({ to: admin, amount });
+
+    // let the receiver update inherit token permissions from this contract
+    // TODO: .send() should do this automatically
+    receiverAU.body.mayUseToken = AccountUpdate.MayUseToken.InheritFromParent;
+  }
+
+  /**
+   * Optimized version of `withdraw()` which reuses the account update where we require the `sender` signature
+   */
+  @method async withdrawOptimized(amount: UInt64) {
+    // only the admin can withdraw
+    let adminAU = AccountUpdate.createSigned(admin, tokenId); // forces admin to sign
+    adminAU.body.useFullCommitment = Bool(true); // admin signs full tx so that the signature can't be reused against them
+
+    // withdraw the amount
+    this.send({ to: adminAU, amount });
+
+    // let the receiver update inherit token permissions from this contract
+    // TODO: .send() should do this automatically
+    adminAU.body.mayUseToken = AccountUpdate.MayUseToken.InheritFromParent;
+  }
+}
+
+// local test
+
+const tokenAccount = Mina.TestPublicKey(PrivateKey.random());
+
+let Local = await Mina.LocalBlockchain({ proofsEnabled: false });
+Mina.setActiveInstance(Local);
+let [sender, escrowAccount] = Local.testAccounts;
+let token = new TrivialCoin(tokenAccount);
+const tokenId = token.deriveTokenId();
+
+// prep: deploy token
+
+await Mina.transaction(sender, async () => {
+  // deploy token contract
+  await token.deploy();
+
+  // fund the token account creation, plus send 1 MINA to it
+  // so it can create the initial account which holds all tokens
+  AccountUpdate.fundNewAccount(sender, 1).send({ to: token.self, amount: 1e9 });
+})
+  .sign([sender.key, tokenAccount.key])
+  .prove()
+  .send();
+
+// prep: deploy token escrow contract, create admin account
+
+let escrow = new TokenEscrow(escrowAccount, tokenId);
+
+await Mina.transaction(sender, async () => {
+  // fund escrow and admin account creation
+  AccountUpdate.fundNewAccount(sender, 3);
+
+  // empty account updates to create both admin accounts
+  AccountUpdate.create(admin);
+  let adminToken = AccountUpdate.create(admin, tokenId);
+
+  // deploy token escrow contract (needs token approval)
+  await escrow.deploy();
+
+  // approve both token account updates
+  await token.approveAccountUpdates([adminToken, escrow.self]);
+})
+  .sign([sender.key, escrowAccount.key])
+  .prove()
+  .send();
+
+// deposit into escrow
+
+await Mina.transaction(tokenAccount, async () => {
+  await token.transfer(tokenAccount, escrowAccount, UInt64.from(1000));
+})
+  // note: this only needs the token account key because we happen to have minted the tokens there
+  .sign([tokenAccount.key])
+  .prove()
+  .send();
+
+// withdraw from escrow (creates 4 account updates)
+
+let tx1 = await Mina.transaction(admin, async () => {
+  await escrow.withdraw(UInt64.from(500));
+
+  // token-approve the withdrawal
+  await token.approveAccountUpdate(escrow.self);
+})
+  .sign([admin.key])
+  .prove();
+console.log('escrow withdraw tx', tx1.toPretty());
+await tx1.send();
+
+// withdraw from escrow (optimized, creates only 3 account updates)
+
+let tx2 = await Mina.transaction(admin, async () => {
+  await escrow.withdrawOptimized(UInt64.from(500));
+
+  // token-approve the withdrawal
+  await token.approveAccountUpdate(escrow.self);
+})
+  .sign([admin.key])
+  .prove();
+console.log('escrow withdraw tx (optimized)', tx2.toPretty());
+await tx2.send();

--- a/src/examples/zkapps/escrow/token-escrow.ts
+++ b/src/examples/zkapps/escrow/token-escrow.ts
@@ -44,7 +44,7 @@ class TokenEscrow extends SmartContract {
    */
   @method async withdrawOptimized(amount: UInt64) {
     // only the admin can withdraw
-    let adminAU = AccountUpdate.createSigned(admin, tokenId); // forces admin to sign
+    let adminAU = AccountUpdate.createSigned(admin, this.tokenId); // forces admin to sign
     adminAU.body.useFullCommitment = Bool(true); // admin signs full tx so that the signature can't be reused against them
 
     // withdraw the amount

--- a/src/examples/zkapps/joint-update.ts
+++ b/src/examples/zkapps/joint-update.ts
@@ -1,0 +1,76 @@
+/**
+ * This is an example for two zkapps that are guaranteed to update their states _together_.
+ *
+ * So, A's state will updated if and only if B's state is updated, and vice versa.
+ *
+ * The difficulty here is that, while zkApps know and prove which other zkApps they call themselves,
+ * there's nothing in the protocol that lets them know which other zkApps are calling _them_.
+ *
+ * In other words, while one-way interactions are easy to implement, two-way interactions require additional tricks.
+ *
+ * This example is supposed to give you an idea for how to implement two-way interactions.
+ *
+ * The idea is that the user calls B, which calls A, so B knows it's jointly updating with A.
+ * In addition, B sets a flag "insideBUpdate" to true on its onchain state, which A checks to make sure it's being called from B.
+ * This flag is also reset by the method that A calls, so it's guaranteed to always be false when we're not inside a B update.
+ * That way, both A and B can be sure that they're updating together.
+ *
+ * To understand the flow of this example in detail, keep in mind that zkApp updates are applied top-to-bottom:
+ * 1. First, the account update created by `B.updateWithA()` is applied. It sets `insideBUpdate = true`.
+ * 2. Then, `A.updateWithB()` is applied.
+ * 3. Finally, `B.assertInsideUpdate()` is applied. It checks that `insideBUpdate = true` and sets it back to false.
+ */
+import {
+  Bool,
+  Field,
+  PrivateKey,
+  SmartContract,
+  State,
+  method,
+  state,
+} from 'o1js';
+
+const aPubKey = PrivateKey.randomKeypair().publicKey;
+const bPubKey = PrivateKey.randomKeypair().publicKey;
+
+class A extends SmartContract {
+  @state(Field) N = State(Field(0));
+
+  @method async updateWithB() {
+    let N = this.N.getAndRequireEquals();
+    this.N.set(N.add(1));
+
+    // make sure that this can only be called from `B.updateWithA()`
+    // note: we need to hard-code B's pubkey for this to work, can't just take one from user input
+    let b = new B(bPubKey);
+    await b.assertInsideUpdate();
+  }
+}
+
+class B extends SmartContract {
+  @state(Field) twoToN = State(Field(1));
+
+  // boolean flag which is only active during `updateWithA()`
+  @state(Bool) insideBUpdate = State(Bool(false));
+
+  @method async updateWithA() {
+    // update field N in the A account with aPubKey by incrementing by 1
+    let a = new A(aPubKey);
+    await a.updateWithB();
+
+    // update our own state by multiplying by 2
+    let twoToN = this.twoToN.getAndRequireEquals();
+    this.twoToN.set(twoToN.mul(2));
+
+    // set up our state so that A knows it's called from here
+    this.insideBUpdate.set(Bool(true));
+  }
+
+  /**
+   * Method that can only be called from inside `B.updateWithA()`
+   */
+  @method async assertInsideUpdate() {
+    this.insideBUpdate.requireEquals(Bool(true));
+    this.insideBUpdate.set(Bool(false));
+  }
+}


### PR DESCRIPTION
This PR just adds two new examples for things that are not documented well
- example for withdrawing custom tokens from a zkapp
- example for linking of state between two zkapps
