### PR TITLE
Compute feature flag from list of zkProgram

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,8 +20,9 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 ### Added
 
 - **SHA256 low-level API** exposed via `Gadgets.SHA256`. https://github.com/o1-labs/o1js/pull/1689 [@Shigoto-dev19](https://github.com/Shigoto-dev19)
-- Added the option to specify custom feature flags for sided loaded proofs in the `DynamicProof` class.
-  - Feature flags are requires to tell Pickles what proof structure it should expect when side loading dynamic proofs and verification keys. https://github.com/o1-labs/o1js/pull/1688
+- Added the option to specify custom feature flags for sided loaded proofs in the `DynamicProof` class. https://github.com/o1-labs/o1js/pull/1688
+  - Feature flags are required to tell Pickles what proof structure it should expect when side loading dynamic proofs and verification keys.
+  - `FeatureFlags` is now exported and provides a set of helper functions to compute feature flags correctly.
 
 ## [1.3.1](https://github.com/o1-labs/o1js/compare/1ad7333e9e...40c597775) - 2024-06-11
 

--- a/src/lib/proof-system/zkprogram.ts
+++ b/src/lib/proof-system/zkprogram.ts
@@ -154,7 +154,7 @@ const FeatureFlags = {
 async function fromZkProgramList(programs: Array<AnalysableProgram>) {
   let flatMethodIntfs: Array<UnwrapPromise<ReturnType<typeof analyzeMethod>>> =
     [];
-  for await (const program of programs) {
+  for (const program of programs) {
     let methodInterface = await program.analyzeMethods();
     flatMethodIntfs.push(...Object.values(methodInterface));
   }

--- a/src/lib/proof-system/zkprogram.ts
+++ b/src/lib/proof-system/zkprogram.ts
@@ -145,7 +145,7 @@ const FeatureFlags = {
     await fromZkProgramList([program]),
 
   /**
-   * Given a list of ZkPrograms, return the feature flag configuration that fits the given set of program.
+   * Given a list of ZkPrograms, return the feature flag configuration that fits the given set of programs.
    * This function considers all methods of all specified ZkPrograms and finds a configuration that fits all.
    */
   fromZkProgramList,

--- a/src/lib/proof-system/zkprogram.ts
+++ b/src/lib/proof-system/zkprogram.ts
@@ -142,26 +142,26 @@ const FeatureFlags = {
    * This function considers all methods of the specified ZkProgram and finds a configuration that fits all.
    */
   fromZkProgram: async (program: AnalysableProgram) => {
-    let methodIntfs = await program.analyzeMethods();
-    return featureFlagsfromFlatMethodIntfs(Object.values(methodIntfs));
+    return await fromZkProgramList([program]);
   },
 
   /**
    * Given a list of ZkPrograms, return the feature flag configuration that fits the given set of program.
    * This function considers all methods of all specified ZkPrograms and finds a configuration that fits all.
    */
-  fromZkProgramList: async (programs: Array<AnalysableProgram>) => {
-    let flatMethodIntfs: Array<
-      UnwrapPromise<ReturnType<typeof analyzeMethod>>
-    > = [];
-    for await (const program of programs) {
-      let methodInterface = await program.analyzeMethods();
-      flatMethodIntfs.push(...Object.values(methodInterface));
-    }
-
-    return featureFlagsfromFlatMethodIntfs(flatMethodIntfs);
-  },
+  fromZkProgramList,
 };
+
+async function fromZkProgramList(programs: Array<AnalysableProgram>) {
+  let flatMethodIntfs: Array<UnwrapPromise<ReturnType<typeof analyzeMethod>>> =
+    [];
+  for await (const program of programs) {
+    let methodInterface = await program.analyzeMethods();
+    flatMethodIntfs.push(...Object.values(methodInterface));
+  }
+
+  return featureFlagsfromFlatMethodIntfs(flatMethodIntfs);
+}
 
 async function featureFlagsfromFlatMethodIntfs(
   methodIntfs: Array<UnwrapPromise<ReturnType<typeof analyzeMethod>>>

--- a/src/lib/proof-system/zkprogram.ts
+++ b/src/lib/proof-system/zkprogram.ts
@@ -141,9 +141,8 @@ const FeatureFlags = {
    * Given a ZkProgram, return the feature flag configuration that fits the given program.
    * This function considers all methods of the specified ZkProgram and finds a configuration that fits all.
    */
-  fromZkProgram: async (program: AnalysableProgram) => {
-    return await fromZkProgramList([program]);
-  },
+  fromZkProgram: async (program: AnalysableProgram) =>
+    await fromZkProgramList([program]),
 
   /**
    * Given a list of ZkPrograms, return the feature flag configuration that fits the given set of program.

--- a/src/lib/proof-system/zkprogram.ts
+++ b/src/lib/proof-system/zkprogram.ts
@@ -81,6 +81,12 @@ const Empty = Undefined;
 type Void = undefined;
 const Void: ProvablePureExtended<void, void, null> = EmptyVoid<Field>();
 
+type AnalysableProgram = {
+  analyzeMethods: () => Promise<{
+    [I in keyof any]: UnwrapPromise<ReturnType<typeof analyzeMethod>>;
+  }>;
+};
+
 type FeatureFlags = {
   rangeCheck0: boolean | undefined;
   rangeCheck1: boolean | undefined;
@@ -135,23 +141,35 @@ const FeatureFlags = {
    * Given a ZkProgram, return the feature flag configuration that fits the given program.
    * This function considers all methods of the specified ZkProgram and finds a configuration that fits all.
    */
-  fromZkProgram: featureFlagsfromZkProgram,
+  fromZkProgram: async (program: AnalysableProgram) => {
+    let methodIntfs = await program.analyzeMethods();
+    return featureFlagsfromFlatMethodIntfs(Object.values(methodIntfs));
+  },
+
+  /**
+   * Given a list of ZkPrograms, return the feature flag configuration that fits the given set of program.
+   * This function considers all methods of all specified ZkPrograms and finds a configuration that fits all.
+   */
+  fromZkProgramList: async (programs: Array<AnalysableProgram>) => {
+    let flatMethodIntfs: Array<
+      UnwrapPromise<ReturnType<typeof analyzeMethod>>
+    > = [];
+    for await (const program of programs) {
+      let methodInterface = await program.analyzeMethods();
+      flatMethodIntfs.push(...Object.values(methodInterface));
+    }
+
+    return featureFlagsfromFlatMethodIntfs(flatMethodIntfs);
+  },
 };
 
-async function featureFlagsfromZkProgram<
-  P extends {
-    analyzeMethods: () => Promise<{
-      [I in keyof any]: UnwrapPromise<ReturnType<typeof analyzeMethod>>;
-    }>;
-  }
->(program: P): Promise<FeatureFlags> {
-  let methodIntfs = await program.analyzeMethods();
-
+async function featureFlagsfromFlatMethodIntfs(
+  methodIntfs: Array<UnwrapPromise<ReturnType<typeof analyzeMethod>>>
+): Promise<FeatureFlags> {
   // compute feature flags that belong to each method
-  let flags = Object.entries(methodIntfs).map(([_, { gates }]) => {
+  let flags = methodIntfs.map(({ gates }) => {
     return featureFlagsFromGates(gates);
   });
-
   if (flags.length === 0)
     throw Error(
       'The ZkProgram has no methods, in order to calculate feature flags, please attach a method to your ZkProgram.'


### PR DESCRIPTION
Many use cases require side loading to load proofs from a list of various zkPrograms. In order to do that, we have to provide the correct feature flags that fit all these zkPrograms - this PR introduces a function that does that 