### PR TITLE
ScalarField and ShiftedScalar conversions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,10 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased](https://github.com/o1-labs/o1js/compare/ed198f305...HEAD)
 
+### Added
+
+- `ForeignField`-based representation of scalars via `ScalarField` https://github.com/o1-labs/o1js/pull/1705
+
 ## [1.4.0](https://github.com/o1-labs/o1js/compare/40c597775...ed198f305) - 2024-06-25
 
 ### Added

--- a/src/index.ts
+++ b/src/index.ts
@@ -15,7 +15,7 @@ export {
   createEcdsa,
   EcdsaSignature,
 } from './lib/provable/crypto/foreign-ecdsa.js';
-export { ScalarField } from './lib/provable/scalar.js';
+export { ScalarField } from './lib/provable/scalar-field.js';
 export {
   Poseidon,
   TokenSymbol,

--- a/src/index.ts
+++ b/src/index.ts
@@ -15,6 +15,7 @@ export {
   createEcdsa,
   EcdsaSignature,
 } from './lib/provable/crypto/foreign-ecdsa.js';
+export { ScalarField } from './lib/provable/scalar.js';
 export {
   Poseidon,
   TokenSymbol,

--- a/src/lib/provable/scalar-field.ts
+++ b/src/lib/provable/scalar-field.ts
@@ -1,0 +1,44 @@
+import { createField } from './core/field-constructor.js';
+import { createForeignField } from './foreign-field.js';
+import { field3ToShiftedScalar } from './gadgets/native-curve.js';
+import { Provable } from './provable.js';
+import { Scalar } from './scalar.js';
+
+export { ScalarField };
+
+/**
+ * ForeignField representing the scalar field of Pallas and the base field of Vesta
+ */
+class ScalarField extends createForeignField(
+  28948022309329048855892746252171976963363056481941647379679742748393362948097n
+) {
+  /**
+   * Provable method to conver a {@link ScalarField} into a {@link Scalar}
+   *
+   * This is always possible and unambiguous, since the scalar field is larger than the base field.
+   */
+  public toScalar(): Scalar {
+    const field3 = this.value;
+    const shiftedScalar = field3ToShiftedScalar(field3);
+    return Scalar.fromShiftedScalar(shiftedScalar);
+  }
+
+  /**
+   * Converts this {@link Scalar} into a {@link ScalarField}
+   */
+  static fromScalar(s: Scalar): ScalarField {
+    if (s.lowBit.isConstant() && s.high254.isConstant()) {
+      return new ScalarField(
+        ScalarField.fromBits(createField(s.toBigInt()).toBits())
+      );
+    }
+    const field = Provable.witness(ScalarField.provable, () => {
+      return ScalarField.fromBits(createField(s.toBigInt()).toBits())
+    });
+    const foreignField = new ScalarField(field);
+    const scalar = foreignField.toScalar();
+    Provable.assertEqual(Scalar, s, scalar);
+
+    return foreignField;
+  }
+}

--- a/src/lib/provable/scalar-field.ts
+++ b/src/lib/provable/scalar-field.ts
@@ -1,6 +1,5 @@
 import { Fq } from '../../bindings/crypto/finite-field.js';
-import { createField } from './core/field-constructor.js';
-import { createForeignField } from './foreign-field.js';
+import { ForeignField, createForeignField } from './foreign-field.js';
 import { field3ToShiftedScalar } from './gadgets/native-curve.js';
 import { Provable } from './provable.js';
 import { Scalar } from './scalar.js';
@@ -10,14 +9,21 @@ export { ScalarField };
 /**
  * ForeignField representing the scalar field of Pallas and the base field of Vesta
  */
-class ScalarField extends createForeignField(
-  Fq.modulus
-) {
+class ScalarField extends createForeignField(Fq.modulus) {
   /**
    * Provable method to convert a {@link ScalarField} into a {@link Scalar}
    */
   public toScalar(): Scalar {
-    const field3 = this.value;
+    return ScalarField.toScalar(this);
+  }
+
+  public static toScalar(field: ForeignField) {
+    if (field.modulus !== Fq.modulus) {
+      throw new Error(
+        'Only ForeignFields with Fq modulus are convertable into a scalar'
+      );
+    }
+    const field3 = field.value;
     const shiftedScalar = field3ToShiftedScalar(field3);
     return Scalar.fromShiftedScalar(shiftedScalar);
   }
@@ -27,12 +33,10 @@ class ScalarField extends createForeignField(
    */
   static fromScalar(s: Scalar): ScalarField {
     if (s.lowBit.isConstant() && s.high254.isConstant()) {
-      return new ScalarField(
-        ScalarField.from(s.toBigInt())
-      );
+      return new ScalarField(s.toBigInt());
     }
     const field = Provable.witness(ScalarField.provable, () => {
-      return s.toBigInt()
+      return s.toBigInt();
     });
     const foreignField = new ScalarField(field);
     const scalar = foreignField.toScalar();

--- a/src/lib/provable/scalar-field.ts
+++ b/src/lib/provable/scalar-field.ts
@@ -1,3 +1,4 @@
+import { Fq } from '../../bindings/crypto/finite-field.js';
 import { createField } from './core/field-constructor.js';
 import { createForeignField } from './foreign-field.js';
 import { field3ToShiftedScalar } from './gadgets/native-curve.js';
@@ -10,12 +11,10 @@ export { ScalarField };
  * ForeignField representing the scalar field of Pallas and the base field of Vesta
  */
 class ScalarField extends createForeignField(
-  28948022309329048855892746252171976963363056481941647379679742748393362948097n
+  Fq.modulus
 ) {
   /**
-   * Provable method to conver a {@link ScalarField} into a {@link Scalar}
-   *
-   * This is always possible and unambiguous, since the scalar field is larger than the base field.
+   * Provable method to convert a {@link ScalarField} into a {@link Scalar}
    */
   public toScalar(): Scalar {
     const field3 = this.value;
@@ -29,11 +28,11 @@ class ScalarField extends createForeignField(
   static fromScalar(s: Scalar): ScalarField {
     if (s.lowBit.isConstant() && s.high254.isConstant()) {
       return new ScalarField(
-        ScalarField.fromBits(createField(s.toBigInt()).toBits())
+        ScalarField.from(s.toBigInt())
       );
     }
     const field = Provable.witness(ScalarField.provable, () => {
-      return ScalarField.fromBits(createField(s.toBigInt()).toBits())
+      return s.toBigInt()
     });
     const foreignField = new ScalarField(field);
     const scalar = foreignField.toScalar();

--- a/src/lib/provable/scalar.ts
+++ b/src/lib/provable/scalar.ts
@@ -13,18 +13,10 @@ import { Provable } from './provable.js';
 import { assert } from '../util/assert.js';
 import type { HashInput } from './types/provable-derivers.js';
 import { field3FromBits } from './gadgets/foreign-field.js';
-import { createForeignField } from './foreign-field.js';
 
-export { Scalar, ScalarConst, ScalarField };
+export { Scalar, ScalarConst };
 
 type ScalarConst = [0, bigint];
-
-/**
- * ForeignField representing the scalar field of Pallas and the base field of Vesta
- */
-class ScalarField extends createForeignField(
-  28948022309329048855892746252171976963363056481941647379679742748393362948097n
-) {}
 
 /**
  * Represents a {@link Scalar}.
@@ -59,23 +51,19 @@ class Scalar implements ShiftedScalar {
   }
 
   /**
+   * Provable method to convert a {@link ShiftedScalar} to a {@link Scalar}.
+   */
+  static fromShiftedScalar(s: ShiftedScalar) {
+    return new Scalar(s.lowBit, s.high254);
+  }
+
+  /**
    * Provable method to convert a {@link Field} into a {@link Scalar}.
    *
    * This is always possible and unambiguous, since the scalar field is larger than the base field.
    */
   static fromField(s: Field): Scalar {
     let { lowBit, high254 } = fieldToShiftedScalar(s);
-    return new Scalar(lowBit, high254);
-  }
-
-  /**
-   * Provable method to conver a {@link ScalarField} into a {@link Scalar}
-   *
-   * This is always possible and unambiguous, since the scalar field is larger than the base field.
-   */
-  static fromScalarField(s: ScalarField): Scalar {
-    const field3 = s.value;
-    const { lowBit, high254 } = field3ToShiftedScalar(field3);
     return new Scalar(lowBit, high254);
   }
 
@@ -107,13 +95,6 @@ class Scalar implements ShiftedScalar {
     let { lowBit, high254 } = this.toConstant();
     let t = lowBit.toField().toBigInt() + 2n * high254.toBigInt();
     return Fq.mod(t + (1n << 255n));
-  }
-
-  /**
-   * Converts this {@link Scalar} into a {@link ScalarField}
-   */
-  toScalarField(): ScalarField {
-    return ScalarField.fromBits([this.lowBit, ...this.high254.toBits(254)]);
   }
 
   /**

--- a/src/lib/provable/test/scalar.test.ts
+++ b/src/lib/provable/test/scalar.test.ts
@@ -33,6 +33,18 @@ describe('scalar', () => {
         });
       });
 
+      describe.only("toScalarField / fromScalarField", () => {
+        it("should return the same", async () => {
+          const s = Scalar.random();
+          await Provable.runAndCheck(() => {
+            const scalar = Provable.witness(Scalar, () => s);
+            const scalarField = scalar.toScalarField();
+            const scalar2 = Scalar.fromScalarField(scalarField);
+            Provable.assertEqual(scalar, scalar2);
+          })
+        })
+      })
+
       describe('random', () => {
         it('two different calls should be different', async () => {
           await Provable.runAndCheck(() => {

--- a/src/lib/provable/test/scalar.test.ts
+++ b/src/lib/provable/test/scalar.test.ts
@@ -1,4 +1,4 @@
-import { Field, Provable, Scalar } from 'o1js';
+import { Field, Provable, Scalar, ScalarField } from 'o1js';
 
 describe('scalar', () => {
   describe('scalar', () => {
@@ -33,17 +33,17 @@ describe('scalar', () => {
         });
       });
 
-      describe.only("toScalarField / fromScalarField", () => {
-        it("should return the same", async () => {
+      describe('toScalarField / fromScalarField', () => {
+        it('should return the same', async () => {
           const s = Scalar.random();
           await Provable.runAndCheck(() => {
             const scalar = Provable.witness(Scalar, () => s);
-            const scalarField = scalar.toScalarField();
-            const scalar2 = Scalar.fromScalarField(scalarField);
+            const scalarField = ScalarField.fromScalar(scalar);
+            const scalar2 = scalarField.toScalar();
             Provable.assertEqual(scalar, scalar2);
-          })
-        })
-      })
+          });
+        });
+      });
 
       describe('random', () => {
         it('two different calls should be different', async () => {


### PR DESCRIPTION
This PR adds `ScalarField`, which enabled ForeignField-based representation of Pallas scalars and implements conversion functions between `ScalarField` and `Scalar` (the shifted representation)