### PR TITLE
First Pass at Non-provable `SelfProof` Counting + Event

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,0 @@
-{
-  "cSpell.words": ["mina", "struct"]
-}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+  "cSpell.words": ["mina", "struct"]
+}

--- a/src/examples/zkprogram/addition.ts
+++ b/src/examples/zkprogram/addition.ts
@@ -1,0 +1,39 @@
+import { Field, ZkProgram, SelfProof, Void } from 'o1js';
+
+export const Addition = ZkProgram({
+  name: 'addition',
+  publicOutput: Field,
+
+  methods: {
+    baseCase: {
+      privateInputs: [],
+
+      async method() {
+        return new Field(0);
+      },
+    },
+
+    step: {
+      privateInputs: [SelfProof],
+      async method(earlierProof: SelfProof<void, Field>) {
+        earlierProof.verify();
+
+        return earlierProof.publicOutput.add(1);
+      },
+    },
+  },
+});
+
+await Addition.compile();
+
+console.log('count 1: ', Addition.getCallsCount()); // 1
+const base = await Addition.baseCase();
+console.log('count 2: ', Addition.getCallsCount()); // 1 (because no self proof)
+const proof1 = await Addition.step(base);
+console.log('count 3: ', Addition.getCallsCount()); // 2
+const proof2 = await Addition.step(proof1);
+console.log('count 4: ', Addition.getCallsCount()); // 3
+const proof3 = await Addition.step(proof2);
+console.log('count 5: ', Addition.getCallsCount()); // 4
+const proof4 = await Addition.step(proof3);
+console.log('count 6: ', Addition.getCallsCount()); // 5

--- a/src/examples/zkprogram/addition.ts
+++ b/src/examples/zkprogram/addition.ts
@@ -1,23 +1,19 @@
-import { Field, ZkProgram, SelfProof, Void } from 'o1js';
+import { Field, ZkProgram, SelfProof } from 'o1js';
 
 export const Addition = ZkProgram({
   name: 'addition',
   publicOutput: Field,
-
   methods: {
     baseCase: {
       privateInputs: [],
-
       async method() {
         return new Field(0);
       },
     },
-
     step: {
       privateInputs: [SelfProof],
       async method(earlierProof: SelfProof<void, Field>) {
         earlierProof.verify();
-
         return earlierProof.publicOutput.add(1);
       },
     },

--- a/src/examples/zkprogram/dynamic-keys-merkletree.ts
+++ b/src/examples/zkprogram/dynamic-keys-merkletree.ts
@@ -174,3 +174,6 @@ const proof3 = await mainProgram.validateUsingTree(
 
 const validProof3 = await verify(proof2, mainVk);
 console.log('ok?', validProof2);
+
+console.log('main count:', mainProgram.getCallsCount());
+console.log('sideloaded count:', sideloadedProgram.getCallsCount());

--- a/src/lib/mina/zkapp.ts
+++ b/src/lib/mina/zkapp.ts
@@ -581,7 +581,6 @@ function computeCallData(
 }
 
 export class MetadataEvent extends Struct({ callsCount: Field }) {
-  static index = Field.ORDER - 1n;
   static key = 'unsafe-metadata-event';
 }
 

--- a/src/lib/proof-system/zkprogram.ts
+++ b/src/lib/proof-system/zkprogram.ts
@@ -534,7 +534,7 @@ function ZkProgram<
   }
 ): {
   name: string;
-  callsCount: number;
+  getCallsCount: () => number;
   resetCallsCount: () => void;
   compile: (options?: { cache?: Cache; forceRecompile?: boolean }) => Promise<{
     verificationKey: { data: string; hash: Field };
@@ -581,12 +581,12 @@ function ZkProgram<
       k,
       {
         ...v,
-        method: (publicInput: any, ...privateInputs: any[]) => {
-          const hasSelfProof = privateInputs.filter(
+        method: (...inputs: any[]) => {
+          let hasSelfProof = inputs.filter(
             (input) => input instanceof SelfProof
           ).length;
           if (hasSelfProof) callsCountContainer.count++;
-          return v.method(publicInput, ...privateInputs);
+          return v.method(...inputs);
         },
       },
     ])
@@ -659,6 +659,7 @@ function ZkProgram<
       forceRecompile,
       overrideWrapDomain: config.overrideWrapDomain,
     });
+    resetCallsCount();
     compileOutput = { provers, verify };
     return { verificationKey };
   }
@@ -747,7 +748,7 @@ function ZkProgram<
       compile,
       verify,
       digest,
-      callsCount: callsCountContainer.count,
+      getCallsCount: () => callsCountContainer.count,
       resetCallsCount,
       analyzeMethods,
       publicInputType: publicInputType as ProvableOrUndefined<


### PR DESCRIPTION
Co-authored by @yunus433

Heavily WIP: updates `ZkProgram` and the `method` decorator such that the number of aggregated proofs is tracked and then emitted within a standard event, of which block explorers and other such services could make use.