### PR TITLE
Fix: Do not support small foreign curves

### DIFF
--- a/src/lib/provable/crypto/foreign-curve.ts
+++ b/src/lib/provable/crypto/foreign-curve.ts
@@ -11,7 +11,7 @@ import { Field3 } from '../gadgets/foreign-field.js';
 import { assert } from '../gadgets/common.js';
 import { Provable } from '../provable.js';
 import { provableFromClass } from '../types/provable-derivers.js';
-import { multiRangeCheck } from '../gadgets/range-check.js';
+import { l2Mask, multiRangeCheck } from '../gadgets/range-check.js';
 
 // external API
 export {
@@ -307,6 +307,11 @@ class ForeignCurveV2 extends ForeignCurve {
  * @deprecated `createForeignCurve` is now deprecated and will be removed in a future release. Please use {@link createForeignCurveV2} instead.
  */
 function createForeignCurve(params: CurveParams): typeof ForeignCurve {
+  assert(
+    params.modulus > l2Mask + 1n,
+    'Base field moduli smaller than 2^176 are not supported'
+  );
+
   const FieldUnreduced = createForeignField(params.modulus);
   const ScalarUnreduced = createForeignField(params.order);
   class Field extends FieldUnreduced.AlmostReduced {}
@@ -343,6 +348,11 @@ function createForeignCurve(params: CurveParams): typeof ForeignCurve {
  * {@link ForeignCurveV2} also includes to associated foreign fields: `ForeignCurve.Field` and `ForeignCurve.Scalar`, see {@link createForeignFieldV2}.
  */
 function createForeignCurveV2(params: CurveParams): typeof ForeignCurveV2 {
+  assert(
+    params.modulus > l2Mask + 1n,
+    'Base field moduli smaller than 2^176 are not supported'
+  );
+
   const FieldUnreduced = createForeignField(params.modulus);
   const ScalarUnreduced = createForeignField(params.order);
   class Field extends FieldUnreduced.AlmostReduced {}

--- a/src/lib/provable/gadgets/elliptic-curve.ts
+++ b/src/lib/provable/gadgets/elliptic-curve.ts
@@ -3,7 +3,7 @@ import { Field } from '../field.js';
 import { Provable } from '../provable.js';
 import { assert } from './common.js';
 import { Field3, ForeignField, split, weakBound } from './foreign-field.js';
-import { l, l2, multiRangeCheck } from './range-check.js';
+import { l, l2, l2Mask, multiRangeCheck } from './range-check.js';
 import { sha256 } from 'js-sha256';
 import {
   bigIntToBytes,
@@ -64,6 +64,11 @@ function add(p1: Point, p2: Point, Curve: { modulus: bigint }) {
     let p3 = affineAdd(Point.toBigint(p1), Point.toBigint(p2), f);
     return Point.from(p3);
   }
+
+  assert(
+    Curve.modulus > l2Mask + 1n,
+    'Base field moduli smaller than 2^176 are not supported'
+  );
 
   // witness and range-check slope, x3, y3
   let witnesses = exists(9, () => {


### PR DESCRIPTION
Don't support curves on base fields smaller than 2^176, because the implementation of addition is unsound

These curves won't be needed in practice as far as I can tell.

I think this is effectively not a breaking change because nobody will have used those curves, and addition might have thrown an error for them