### PR TITLE
Meaningful error message in case of failed GQL zkApp command (stale verification key case).

### DIFF
--- a/src/lib/mina/errors.ts
+++ b/src/lib/mina/errors.ts
@@ -44,6 +44,13 @@ ${(-Number(accountCreationFee) * 1e-9).toFixed(
 )} times the number of newly created accounts.`;
   },
 };
+const defaultErrorReplacementRules: ErrorReplacementRule[] = [
+  {
+    pattern: /\(invalid \(Invalid_proof \\"In progress\\"\)\)/g,
+    replacement:
+      'Stale verification key detected. Please make sure that deployed verification key reflects latest zkApp changes.',
+  },
+];
 
 type ErrorHandlerArgs = {
   transaction: Types.ZkappCommand;
@@ -110,7 +117,7 @@ function invalidTransactionError(
 
 function humanizeErrors(
   errors: string[],
-  replacements: ErrorReplacementRule[]
+  replacements: ErrorReplacementRule[] = defaultErrorReplacementRules
 ): string[] {
   return errors.map((error) => {
     let modifiedError = error;

--- a/src/lib/mina/errors.ts
+++ b/src/lib/mina/errors.ts
@@ -1,7 +1,7 @@
 import { Types } from '../../bindings/mina-transaction/types.js';
 import { TokenId } from './account-update.js';
 
-export { invalidTransactionError };
+export { humanizeErrors, invalidTransactionError };
 
 const ErrorHandlers = {
   Invalid_fee_excess({
@@ -50,6 +50,11 @@ type ErrorHandlerArgs = {
   accountUpdateIndex: number;
   isFeePayer: boolean;
   accountCreationFee: string | number;
+};
+
+type ErrorReplacementRule = {
+  pattern: RegExp;
+  replacement: string;
 };
 
 function invalidTransactionError(
@@ -101,4 +106,17 @@ function invalidTransactionError(
   }
   // fallback if we don't have a good error message yet
   return rawErrors;
+}
+
+function humanizeErrors(
+  errors: string[],
+  replacements: ErrorReplacementRule[]
+): string[] {
+  return errors.map((error) => {
+    let modifiedError = error;
+    replacements.forEach(({ pattern, replacement }) => {
+      modifiedError = modifiedError.replace(pattern, replacement);
+    });
+    return modifiedError;
+  });
 }

--- a/src/lib/mina/mina.ts
+++ b/src/lib/mina/mina.ts
@@ -260,13 +260,7 @@ function Network(
         } else if (response && response.errors && response.errors.length > 0) {
           response?.errors.forEach((e: any) => errors.push(JSON.stringify(e)));
         }
-        const updatedErrors = humanizeErrors(errors, [
-          {
-            pattern: /\(invalid \(Invalid_proof \\"In progress\\"\)\)/g,
-            replacement:
-              'Stale verification key detected. Please make sure that deployed verification key reflects latest zkApp changes.',
-          },
-        ]);
+        const updatedErrors = humanizeErrors(errors);
 
         const status: PendingTransactionStatus =
           errors.length === 0 ? 'pending' : 'rejected';

--- a/src/lib/mina/mina.ts
+++ b/src/lib/mina/mina.ts
@@ -4,7 +4,7 @@ import { UInt64 } from '../provable/int.js';
 import { PublicKey } from '../provable/crypto/signature.js';
 import { TokenId, Authorization } from './account-update.js';
 import * as Fetch from './fetch.js';
-import { invalidTransactionError } from './errors.js';
+import { humanizeErrors, invalidTransactionError } from './errors.js';
 import { Types } from '../../bindings/mina-transaction/types.js';
 import { Account } from './account.js';
 import { NetworkId } from '../../mina-signer/src/types.js';
@@ -260,6 +260,13 @@ function Network(
         } else if (response && response.errors && response.errors.length > 0) {
           response?.errors.forEach((e: any) => errors.push(JSON.stringify(e)));
         }
+        const updatedErrors = humanizeErrors(errors, [
+          {
+            pattern: /\(invalid \(Invalid_proof \\"In progress\\"\)\)/g,
+            replacement:
+              'Stale verification key detected. Please make sure that deployed verification key reflects latest zkApp changes.',
+          },
+        ]);
 
         const status: PendingTransactionStatus =
           errors.length === 0 ? 'pending' : 'rejected';
@@ -271,7 +278,7 @@ function Network(
         > = {
           status,
           data: response?.data,
-          errors,
+          errors: updatedErrors,
           transaction: txn.transaction,
           hash,
           toJSON: txn.toJSON,


### PR DESCRIPTION
Converts this:

```log
Error: Transaction failed with errors:
- {"statusCode":200,"statusText":"Couldn't send zkApp command: (invalid (Invalid_proof \"In progress\"))"}
    at file:///Users/serhii/projects/o1labs/o1js/dist/node/lib/mina/transaction.js:162:27
    at process.processTicksAndRejections (node:internal/process/task_queues:95:5)
    at async file:///Users/serhii/projects/o1labs/zkapp-cli/deploy-me/build/src/interact.js:59:20
```

Into this:

```log
Error: Transaction failed with errors:
- {"statusCode":200,"statusText":"Couldn't send zkApp command: Stale verification key detected. Please make sure that deployed verification key reflects latest zkApp changes."}
    at file:///Users/serhii/projects/o1labs/o1js/dist/node/lib/mina/transaction.js:162:27
    at process.processTicksAndRejections (node:internal/process/task_queues:95:5)
    at async file:///Users/serhii/projects/o1labs/zkapp-cli/deploy-me/build/src/interact.js:59:20
```