### PR TITLE
Disable LFS during submodules fetching.

### DIFF
--- a/.github/actions/live-tests-shared/action.yml
+++ b/.github/actions/live-tests-shared/action.yml
@@ -21,7 +21,7 @@ runs:
       env:
         USE_CUSTOM_LOCAL_NETWORK: 'true'
       run: |
-        git submodule update --init --recursive
+        GIT_LFS_SKIP_SMUDGE=1 git submodule update --init --recursive
         npm ci
         npm run build
         touch profiling.md

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -33,7 +33,7 @@ jobs:
           METRICS_SOURCE_ENVIRONMENT: 'o1js GitHub Actions'
           METRICS_BASE_BRANCH_FOR_COMPARISON: 'main'
         run: |
-          git submodule update --init --recursive
+          GIT_LFS_SKIP_SMUDGE=1 git submodule update --init --recursive
           npm ci
           npm run build
           echo 'Running o1js benchmarks.'

--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -16,7 +16,7 @@ jobs:
           node-version: '18'
       - name: Run typedoc
         run: |
-          git submodule update --init --recursive
+          GIT_LFS_SKIP_SMUDGE=1 git submodule update --init --recursive
           npm ci
           npx typedoc --tsconfig tsconfig.node.json src/index.ts
       - name: Deploy

--- a/.github/workflows/pkg-pr-new-publish.yml
+++ b/.github/workflows/pkg-pr-new-publish.yml
@@ -24,7 +24,7 @@ jobs:
           node-version: ${{ matrix.node }}
       - name: Build o1js and mina-signer
         run: |
-          git submodule update --init --recursive
+          GIT_LFS_SKIP_SMUDGE=1 git submodule update --init --recursive
           npm ci
           npm run prepublishOnly
           cd src/mina-signer


### PR DESCRIPTION
This should fix CI issues caused by LFS problems with Mina repo as submodule.
Setting up the `GIT_LFS_SKIP_SMUDGE=1` environment variable on the repository level didn't work for some reason with  explicit `git submodule update --init --recursive` usage in one of the workflow steps.