### PR TITLE
Adding zk regex to community packages

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,5 +56,6 @@ High-quality community packages from open source developers are available for yo
 
 - **o1js-elgamal** A partially homomorphic encryption library for o1js based on Elgamal encryption: [GitHub](https://github.com/Trivo25/o1js-elgamal) and [npm](https://www.npmjs.com/package/o1js-elgamal)
 - **o1js-pack** A library for o1js that allows a zkApp developer to pack extra data into a single Field. [GitHub](https://github.com/45930/o1js-pack) and [npm](https://www.npmjs.com/package/o1js-pack)
+- **zk-regex-o1js** A library for building regex matchers for use within a circuit. [Github](https://github.com/Shigoto-dev19/zk-regex-o1js) and [npm](https://www.npmjs.com/package/zk-regex-o1js)
 
 To include your package, see [Creating high-quality community packages](https://github.com/o1-labs/o1js/blob/main/CONTRIBUTING.md#creating-high-quality-community-packages).


### PR DESCRIPTION
I suggest we add [zk-regex-o1js](https://github.com/Shigoto-dev19) to our community packages list in the readme.  It is a high-quality package with good documentation and many use cases.

It may need to add some tests within provable code before meeting the [criteria](https://github.com/o1-labs/o1js/blob/main/CONTRIBUTING.md#creating-high-quality-community-packages).