### PR TITLE
Optional proving for zkProgram

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - Added `Encryption.encryptV2()` and `Encryption.decryptV2()` for an updated encryption algorithm that guarantees cipher text integrity.
   - Also added `Encryption.encryptBytes()` and `Encryption.decryptBytes()` using the same algorithm.
 - New option `proofsEnabled` for `zkProgram` (default value: `true`), to quickly test circuit logic with proofs disabled https://github.com/o1-labs/o1js/pull/1805
+  - Additionally added `MyProgram.proofsEnabled` to get the internal value of `proofsEnabled` and `MyProgram.setProofsEnabled(proofsEnabled)` to set the value dynamically.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - `SmartContract.emitEventIf()` to conditionally emit an event https://github.com/o1-labs/o1js/pull/1746
 - Added `Encryption.encryptV2()` and `Encryption.decryptV2()` for an updated encryption algorithm that guarantees cipher text integrity.
   - Also added `Encryption.encryptBytes()` and `Encryption.decryptBytes()` using the same algorithm.
+- New option `proofsEnabled` for `zkProgram` (default value: `true`), to quickly test circuit logic with proofs disabled https://github.com/o1-labs/o1js/pull/1805
 
 ### Changed
 

--- a/src/examples/zkprogram/program-no-proving.ts
+++ b/src/examples/zkprogram/program-no-proving.ts
@@ -26,13 +26,25 @@ let MyProgram = ZkProgram({
 
 console.log('program digest', await MyProgram.digest());
 
-// disable proofs to accelerate iteration during development
-const proofsEnabled = false;
+// enable proofs to compile the program
+const proofsEnabled = true;
 
 await MyProgram.compile({
   proofsEnabled,
 });
 
-console.log('proving base case...');
+console.log('proofs enabled?', MyProgram.proofsEnabled);
+
+console.log('proving base case... (proofs enabled)');
+console.time('proving');
 let proof = await MyProgram.baseCase(Field(2));
+console.timeEnd('proving');
+proof.publicOutput.assertEquals(Field(2).add(4));
+
+console.log('disable proofs, generate dummy proof');
+MyProgram.setProofsEnabled(false);
+console.log('proofs enabled?', MyProgram.proofsEnabled);
+console.time('noProving');
+proof = await MyProgram.baseCase(Field(2));
+console.timeEnd('noProving');
 proof.publicOutput.assertEquals(Field(2).add(4));

--- a/src/examples/zkprogram/program-no-proving.ts
+++ b/src/examples/zkprogram/program-no-proving.ts
@@ -1,0 +1,36 @@
+import {
+  SelfProof,
+  Field,
+  ZkProgram,
+  verify,
+  Proof,
+  JsonProof,
+  Provable,
+  Empty,
+  Cache,
+} from 'o1js';
+
+let MyProgram = ZkProgram({
+  name: 'example-without-proving',
+  publicOutput: Field,
+  publicInput: Field,
+  methods: {
+    baseCase: {
+      privateInputs: [],
+      async method(publicInput: Field) {
+        return publicInput.add(4);
+      },
+    },
+  },
+});
+
+console.log('program digest', await MyProgram.digest());
+let cs = await MyProgram.analyzeMethods();
+console.log(cs);
+let { verificationKey } = await MyProgram.compile({
+  proofsEnabled: false,
+});
+
+console.log('proving base case...');
+let proof = await MyProgram.baseCase(Field(2));
+proof.publicOutput.assertEquals(Field(2).add(4));

--- a/src/examples/zkprogram/program-no-proving.ts
+++ b/src/examples/zkprogram/program-no-proving.ts
@@ -26,10 +26,10 @@ let MyProgram = ZkProgram({
 
 console.log('program digest', await MyProgram.digest());
 
-// disable proving for iterating quicker
+// disable proofs to accelerate iteration during development
 const proofsEnabled = false;
 
-let { verificationKey } = await MyProgram.compile({
+await MyProgram.compile({
   proofsEnabled,
 });
 

--- a/src/examples/zkprogram/program-no-proving.ts
+++ b/src/examples/zkprogram/program-no-proving.ts
@@ -25,10 +25,12 @@ let MyProgram = ZkProgram({
 });
 
 console.log('program digest', await MyProgram.digest());
-let cs = await MyProgram.analyzeMethods();
-console.log(cs);
+
+// disable proving for iterating quicker
+const proofsEnabled = false;
+
 let { verificationKey } = await MyProgram.compile({
-  proofsEnabled: false,
+  proofsEnabled,
 });
 
 console.log('proving base case...');

--- a/src/lib/proof-system/zkprogram.ts
+++ b/src/lib/proof-system/zkprogram.ts
@@ -615,12 +615,6 @@ function ZkProgram<
 
   let selfTag = {
     name: config.name,
-    get proofsEnabled() {
-      return doProving;
-    },
-    setProofsEnabled(proofsEnabled: boolean) {
-      doProving = proofsEnabled;
-    },
   };
   type PublicInput = InferProvableOrUndefined<
     Get<StatementType, 'publicInput'>
@@ -798,9 +792,8 @@ function ZkProgram<
     return hashConstant(digests).toBigInt().toString(16);
   }
 
-  return Object.assign(
+  const program = Object.assign(
     selfTag,
-
     {
       compile,
       verify,
@@ -818,9 +811,19 @@ function ZkProgram<
       rawMethods: Object.fromEntries(
         methodKeys.map((key) => [key, methods[key].method])
       ) as any,
+      setProofsEnabled(proofsEnabled: boolean) {
+        doProving = proofsEnabled;
+      },
     },
     provers
   );
+
+  // Object.assign only shallow-copies, hence we cant use this getter and have to define it explicitly
+  Object.defineProperty(program, 'proofsEnabled', {
+    get: () => doProving,
+  });
+
+  return program as ZkProgram<StatementType, Types>;
 }
 
 type ZkProgram<

--- a/src/lib/proof-system/zkprogram.ts
+++ b/src/lib/proof-system/zkprogram.ts
@@ -594,6 +594,8 @@ function ZkProgram<
       Types[I]
     >['method'];
   };
+  proofsEnabled: boolean;
+  setProofsEnabled(proofsEnabled: boolean): void;
 } & {
   [I in keyof Types]: Prover<
     InferProvableOrUndefined<Get<StatementType, 'publicInput'>>,
@@ -665,6 +667,7 @@ function ZkProgram<
     proofsEnabled = true,
   } = {}) {
     doProving = proofsEnabled;
+
     let methodsMeta = await analyzeMethods();
     let gates = methodKeys.map((k) => methodsMeta[k].gates);
 
@@ -721,7 +724,7 @@ function ZkProgram<
       if (picklesProver === undefined) {
         throw Error(
           `Cannot prove execution of program.${key}(), no prover found. ` +
-            `Try calling \`await program.compile()\` first, this will cache provers in the background.`
+            `Try calling \`await program.compile()\` first, this will cache provers in the background.\nIf you compiled your zkProgram with proofs disabled (\`proofsEnabled = false\`), you have to compile it with proofs enabled first.`
         );
       }
       let publicInputFields = toFieldConsts(publicInputType, publicInput);
@@ -789,7 +792,15 @@ function ZkProgram<
   }
 
   return Object.assign(
-    selfTag,
+    {
+      ...selfTag,
+      get proofsEnabled() {
+        return doProving;
+      },
+      setProofsEnabled(proofsEnabled: boolean) {
+        doProving = proofsEnabled;
+      },
+    },
     {
       compile,
       verify,

--- a/src/lib/proof-system/zkprogram.ts
+++ b/src/lib/proof-system/zkprogram.ts
@@ -763,8 +763,7 @@ function ZkProgram<
       (publicInputType as any) === Undefined ||
       (publicInputType as any) === Void
     ) {
-      prove = ((...args: TupleToInstances<Types[typeof key]>) =>
-        (prove_ as any)(undefined, ...(args as any))) as any;
+      prove = ((...args: any) => prove_(undefined as any, ...args)) as any;
     } else {
       prove = prove_ as any;
     }

--- a/src/lib/proof-system/zkprogram.ts
+++ b/src/lib/proof-system/zkprogram.ts
@@ -676,10 +676,10 @@ function ZkProgram<
   } = {}) {
     doProving = proofsEnabled;
 
-    let methodsMeta = await analyzeMethods();
-    let gates = methodKeys.map((k) => methodsMeta[k].gates);
-
     if (doProving) {
+      let methodsMeta = await analyzeMethods();
+      let gates = methodKeys.map((k) => methodsMeta[k].gates);
+
       let { provers, verify, verificationKey } = await compileProgram({
         publicInputType,
         publicOutputType,

--- a/src/lib/proof-system/zkprogram.ts
+++ b/src/lib/proof-system/zkprogram.ts
@@ -613,7 +613,15 @@ function ZkProgram<
     config.publicOutput ?? Void
   );
 
-  let selfTag = { name: config.name };
+  let selfTag = {
+    name: config.name,
+    get proofsEnabled() {
+      return doProving;
+    },
+    setProofsEnabled(proofsEnabled: boolean) {
+      doProving = proofsEnabled;
+    },
+  };
   type PublicInput = InferProvableOrUndefined<
     Get<StatementType, 'publicInput'>
   >;
@@ -792,15 +800,8 @@ function ZkProgram<
   }
 
   return Object.assign(
-    {
-      ...selfTag,
-      get proofsEnabled() {
-        return doProving;
-      },
-      setProofsEnabled(proofsEnabled: boolean) {
-        doProving = proofsEnabled;
-      },
-    },
+    selfTag,
+
     {
       compile,
       verify,

--- a/src/lib/proof-system/zkprogram.ts
+++ b/src/lib/proof-system/zkprogram.ts
@@ -601,7 +601,7 @@ function ZkProgram<
     Types[I]
   >;
 } {
-  let proofsEnabled_ = true;
+  let doProving = true;
 
   let methods = config.methods;
   let publicInputType: ProvablePure<any> = ProvableType.get(
@@ -664,11 +664,11 @@ function ZkProgram<
     forceRecompile = false,
     proofsEnabled = true,
   } = {}) {
-    proofsEnabled_ = proofsEnabled;
+    doProving = proofsEnabled;
     let methodsMeta = await analyzeMethods();
     let gates = methodKeys.map((k) => methodsMeta[k].gates);
 
-    if (proofsEnabled_) {
+    if (doProving) {
       let { provers, verify, verificationKey } = await compileProgram({
         publicInputType,
         publicOutputType,
@@ -704,7 +704,7 @@ function ZkProgram<
         static tag = () => selfTag;
       }
 
-      if (!proofsEnabled_) {
+      if (!doProving) {
         let previousProofs = MlArray.to(
           getPreviousProofsForProver(args, methodIntfs[i])
         );
@@ -765,6 +765,9 @@ function ZkProgram<
   };
 
   function verify(proof: Proof<PublicInput, PublicOutput>) {
+    if (!doProving) {
+      return Promise.resolve(true);
+    }
     if (compileOutput?.verify === undefined) {
       throw Error(
         `Cannot verify proof, verification key not found. Try calling \`await program.compile()\` first.`


### PR DESCRIPTION
Makes proving optional for zkProgram, similar to how a developer can disable proving for SmartContracts. Encourages faster iterations during development

closes #1718 