### PR TITLE
adding docs

### DIFF
--- a/README-dev.md
+++ b/README-dev.md
@@ -21,6 +21,7 @@ Before starting, ensure you have the following tools installed:
 After cloning the repository, you need to fetch the submodules:
 
 ```sh
+export GIT_LFS_SKIP_SMUDGE=1
 git submodule update --init --recursive
 ```
 


### PR DESCRIPTION
GIT_LFS_SKIP_SMUDGE=1 needed in the docs
```
Downloading rfcs/res/hard-fork-package-generation-buildkite-pipeline.dot.png (30 KB)
Error downloading object: rfcs/res/hard-fork-package-generation-buildkite-pipeline.dot.png (646e541): Smudge error: Er\
ror downloading rfcs/res/hard-fork-package-generation-buildkite-pipeline.dot.png (646e541b20428322a85dac4f07aa67ad2e66\
b732ca3b3ba1932410c7b64d2c0d): batch response: This repository is over its data quota. Account responsible for LFS ban\
dwidth should purchase more data packs to restore access.
```
fixes #1819 