### PR TITLE
avoid overwriting `proofsEnabled` through default parameter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,10 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
   - Added `fromEthers` method for parsing and converting Ethereum public keys into `ForeignCurve` points, supporting both compressed and uncompressed formats.
   - Added `fromHex` method for converting hexadecimal strings into `ForeignCurve` points.
 
+### Fixes
+
+- Fix incorrect behavior of optional proving for zkPrograms where `myProgram.setProofsEnabled(false)` wouldn't work when called before `myProgram.compile()` https://github.com/o1-labs/o1js/pull/1827
+
 ## [1.7.0](https://github.com/o1-labs/o1js/compare/d6abf1d97...5006e4f) - 2024-09-04
 
 ### Added

--- a/src/lib/proof-system/zkprogram.ts
+++ b/src/lib/proof-system/zkprogram.ts
@@ -666,9 +666,9 @@ function ZkProgram<
   async function compile({
     cache = Cache.FileSystemDefault,
     forceRecompile = false,
-    proofsEnabled = true,
+    proofsEnabled = undefined,
   } = {}) {
-    doProving = proofsEnabled;
+    doProving = proofsEnabled ?? doProving;
 
     if (doProving) {
       let methodsMeta = await analyzeMethods();


### PR DESCRIPTION
```ts
MyProgram.setProofsEnabled(false);
await MyProgram.compile();
```

Wouldn't work because `compile()` sets the internal flag to `true` no matter what since that's the default parameter. The fix is to specify no default parameter (`undefined` by default) and only setting the internal flag if the developer actually passes in a value. This is backwards compatible because 1) the API doesn't change and 2) the internal flag is still initiated with `true` so its behavior stays the same 

thanks for pointing this out @rpanic 