### PR TITLE
attempt CI fix

### DIFF
--- a/.github/workflows/build-action.yml
+++ b/.github/workflows/build-action.yml
@@ -164,29 +164,10 @@ jobs:
 
           set -o pipefail
 
-          success=true
-          failed_tests=""
-          failed_count=0
-
           for ((i=start_index; i<end_index && i<${#test_files[@]}; i++)); do
               echo "Running test: ${test_files[$i]}"
               node --enable-source-maps "${test_files[$i]}" | tee -a profiling.md
-
-              if [ $? -eq 1 ]; then
-                  success=false
-                  failed_tests+="test failed: ${test_files[$i]}"
-                  failed_tests+=$'\n'
-                  failed_count=$((failed_count + 1))
-              fi
           done
-
-          if [ $success == false ]; then
-              echo "${failed_count} tests failed"
-              echo "$failed_tests"
-              exit 1;
-          else
-              echo "all tests succeeded"
-          fi
         continue-on-error: false
 
       - name: Upload test results

--- a/.github/workflows/build-action.yml
+++ b/.github/workflows/build-action.yml
@@ -174,7 +174,7 @@ jobs:
 
               if [ $? -eq 1 ]; then
                   success=false
-                  failed_tests+="test failed: ${test_files[$i]}${NEWLINE}"
+                  failed_tests+="test failed: ${test_files[$i]}"
                   failed_tests+=$'\n'
                   failed_count=$((failed_count + 1))
               fi

--- a/.github/workflows/build-action.yml
+++ b/.github/workflows/build-action.yml
@@ -162,10 +162,29 @@ jobs:
           shopt -s globstar
           test_files=(./dist/node/**/*.unit-test.js)
 
+          set -o pipefail
+
+          success=true
+          failed_tests=""
+          failed_count=0
+
           for ((i=start_index; i<end_index && i<${#test_files[@]}; i++)); do
-            echo "Running test: ${test_files[$i]}"
-            node --enable-source-maps "${test_files[$i]}" | tee -a profiling.md
+              echo "Running test: ${test_files[$i]}"
+              node --enable-source-maps "${test_files[$i]}" | tee -a profiling.md
+
+              if [ $? -eq 1 ]; then
+                  success=false
+                  failed_tests+="test failed: ${test_files[$i]}${NEWLINE}"
+                  failed_tests+=$'\n'
+                  failed_count=$((failed_count + 1))
+              fi
           done
+
+          if [ $success == false ]; then
+              echo "${failed_count} tests failed"
+              echo "$failed_tests"
+              exit 1;
+          fi
         continue-on-error: false
 
       - name: Upload test results

--- a/.github/workflows/build-action.yml
+++ b/.github/workflows/build-action.yml
@@ -184,6 +184,8 @@ jobs:
               echo "${failed_count} tests failed"
               echo "$failed_tests"
               exit 1;
+          else
+              echo "all tests succeeded"
           fi
         continue-on-error: false
 


### PR DESCRIPTION
The test's exit status code was not properly relayed, as it was being silently consumed by the pipe. This caused the CI to incorrectly report success, regardless of test outcomes. I have now updated the process to store the exit status in an intermediate variable, allowing all tests to run, and ensuring that the failure is captured and reported only at the end

companion https://github.com/o1-labs/o1js-bindings/pull/303