### PR TITLE
Extract Proofs from any Provable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,12 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased](https://github.com/o1-labs/o1js/compare/450943...HEAD)
 
+### Changed
+
+- Make `Proof` a normal provable type, that can be witnessed and composed into Structs https://github.com/o1-labs/o1js/pull/1847, https://github.com/o1-labs/o1js/pull/1851
+  - ZkProgram and SmartContract now also support private inputs that are not proofs themselves, but contain proofs nested within a Struct or array
+  - Only `SelfProof` can still not be nested because it needs special treatment
+
 ## [1.8.0](https://github.com/o1-labs/o1js/compare/5006e4f...450943) - 2024-09-18
 
 ### Added

--- a/src/lib/mina/zkapp.ts
+++ b/src/lib/mina/zkapp.ts
@@ -46,8 +46,6 @@ import {
   compileProgram,
   Empty,
   getPreviousProofsForProver,
-  methodArgumentsToConstant,
-  methodArgumentTypesAndValues,
   MethodInterface,
   sortMethodArguments,
 } from '../proof-system/zkprogram.js';
@@ -383,7 +381,9 @@ function wrapMethod(
       let blindingValue = getBlindingValue();
 
       let runCalledContract = async () => {
-        let constantArgs = methodArgumentsToConstant(methodIntf, actualArgs);
+        let constantArgs = methodIntf.args.map((type, i) =>
+          Provable.toConstant(type, actualArgs[i])
+        );
         let constantBlindingValue = blindingValue.toConstant();
         let accountUpdate = this.self;
         accountUpdate.body.callDepth = parentAccountUpdate.body.callDepth + 1;
@@ -520,7 +520,9 @@ function computeCallData(
   blindingValue: Field
 ) {
   let { returnType, methodName } = methodIntf;
-  let args = methodArgumentTypesAndValues(methodIntf, argumentValues);
+  let args = methodIntf.args.map((type, i) => {
+    return { type: ProvableType.get(type), value: argumentValues[i] };
+  });
 
   let input: HashInput = { fields: [], packed: [] };
   for (let { type, value } of args) {

--- a/src/lib/mina/zkapp.ts
+++ b/src/lib/mina/zkapp.ts
@@ -313,7 +313,7 @@ function wrapMethod(
               method.apply(
                 this,
                 actualArgs.map((a, i) => {
-                  return Provable.witness(methodIntf.args[i].type, () => a);
+                  return Provable.witness(methodIntf.args[i], () => a);
                 })
               ),
               noPromiseError

--- a/src/lib/mina/zkapp.ts
+++ b/src/lib/mina/zkapp.ts
@@ -341,10 +341,7 @@ function wrapMethod(
                 methodName: methodIntf.methodName,
                 args: clonedArgs,
                 // proofs actually don't have to be cloned
-                previousProofs: getPreviousProofsForProver(
-                  actualArgs,
-                  methodIntf
-                ),
+                previousProofs: getPreviousProofsForProver(actualArgs),
                 ZkappClass,
                 memoized,
                 blindingValue,
@@ -433,10 +430,7 @@ function wrapMethod(
             {
               methodName: methodIntf.methodName,
               args: constantArgs,
-              previousProofs: getPreviousProofsForProver(
-                constantArgs,
-                methodIntf
-              ),
+              previousProofs: getPreviousProofsForProver(constantArgs),
               ZkappClass,
               memoized,
               blindingValue: constantBlindingValue,

--- a/src/lib/mina/zkapp.ts
+++ b/src/lib/mina/zkapp.ts
@@ -156,7 +156,7 @@ function method<K extends string, T extends SmartContract>(
   ZkappClass._maxProofsVerified ??= 0;
   ZkappClass._maxProofsVerified = Math.max(
     ZkappClass._maxProofsVerified,
-    methodEntry.proofs.length
+    methodEntry.numberOfProofs
   ) as 0 | 1 | 2;
   let func = descriptor.value as AsyncFunction;
   descriptor.value = wrapMethod(func, ZkappClass, internalMethodEntry);

--- a/src/lib/proof-system/proof-system.unit-test.ts
+++ b/src/lib/proof-system/proof-system.unit-test.ts
@@ -161,6 +161,12 @@ it('pickles rule creation: nested proof', async () => {
   });
 });
 
+it('fails with more than two (nested) proofs', async () => {
+  expect(() => {
+    sortMethodArguments('mock', 'main', [NestedProof2, NestedProof], Proof);
+  }).toThrowError('mock.main() has more than two proof arguments');
+});
+
 // compile works with large inputs
 
 const N = 100_000;

--- a/src/lib/proof-system/proof-system.unit-test.ts
+++ b/src/lib/proof-system/proof-system.unit-test.ts
@@ -4,6 +4,7 @@ import { UInt64 } from '../provable/int.js';
 import {
   CompiledTag,
   Empty,
+  Void,
   ZkProgram,
   picklesRuleFromFunction,
   sortMethodArguments,
@@ -18,7 +19,6 @@ import { Provable } from '../provable/provable.js';
 import { bool, equivalentAsync, field, record } from '../testing/equivalent.js';
 import { FieldVar, FieldConst } from '../provable/core/fieldvar.js';
 import { ProvablePure, ProvableType } from '../provable/types/provable-intf.js';
-import { sample } from '../testing/random.js';
 
 const EmptyProgram = ZkProgram({
   name: 'empty',
@@ -29,6 +29,7 @@ const EmptyProgram = ZkProgram({
 class EmptyProof extends ZkProgram.Proof(EmptyProgram) {}
 
 class NestedProof extends Struct({
+  // TODO this coercion should not be necessary
   proof: EmptyProof as any as ProvableType<Proof<Field, void>>,
   field: Field,
 }) {}
@@ -124,7 +125,7 @@ it('pickles rule creation: nested proof', async () => {
   // create pickles rule
   let rule: Pickles.Rule = picklesRuleFromFunction(
     Empty as ProvablePure<any>,
-    Field as ProvablePure<any>,
+    Void as ProvablePure<any>,
     main as AnyFunction,
     { name: 'mock' },
     methodIntf,

--- a/src/lib/proof-system/proof-system.unit-test.ts
+++ b/src/lib/proof-system/proof-system.unit-test.ts
@@ -44,11 +44,8 @@ it('pickles rule creation', async () => {
 
   expect(methodIntf).toEqual({
     methodName: 'main',
-    args: [
-      { type: EmptyProof, isProof: true },
-      { type: Bool, isProof: false },
-    ],
-    proofs: [EmptyProof],
+    args: [EmptyProof, Bool],
+    numberOfProofs: 1,
   });
 
   // store compiled tag

--- a/src/lib/proof-system/proof.ts
+++ b/src/lib/proof-system/proof.ts
@@ -12,7 +12,6 @@ import type { Provable } from '../provable/provable.js';
 import { assert } from '../util/assert.js';
 import { Unconstrained } from '../provable/types/unconstrained.js';
 import { ProvableType } from '../provable/types/provable-intf.js';
-import { emptyValue } from '../provable/types/util.js';
 
 // public API
 export { ProofBase, Proof, DynamicProof };
@@ -436,7 +435,7 @@ function extractProofsFromArray(value: unknown[]) {
 }
 
 function extractProofTypes(type: ProvableType) {
-  let value = emptyValue(type);
+  let value = ProvableType.synthesize(type);
   let proofValues = extractProofs(value);
   return proofValues.map((proof) => proof.constructor as typeof ProofBase);
 }

--- a/src/lib/proof-system/proof.ts
+++ b/src/lib/proof-system/proof.ts
@@ -17,14 +17,7 @@ import { ProvableType } from '../provable/types/provable-intf.js';
 export { ProofBase, Proof, DynamicProof };
 
 // internal API
-export {
-  dummyProof,
-  extractProofs,
-  extractProofsFromArray,
-  extractProofTypes,
-  extractProofTypesFromArray,
-  type ProofValue,
-};
+export { dummyProof, extractProofs, extractProofTypes, type ProofValue };
 
 type MaxProofs = 0 | 1 | 2;
 
@@ -430,16 +423,8 @@ function extractProofs(value: unknown): ProofBase[] {
   return [];
 }
 
-function extractProofsFromArray(value: unknown[]) {
-  return value.flatMap(extractProofs);
-}
-
 function extractProofTypes(type: ProvableType) {
   let value = ProvableType.synthesize(type);
   let proofValues = extractProofs(value);
   return proofValues.map((proof) => proof.constructor as typeof ProofBase);
-}
-
-function extractProofTypesFromArray(type: ProvableType[]) {
-  return type.flatMap(extractProofTypes);
 }

--- a/src/lib/proof-system/zkprogram.ts
+++ b/src/lib/proof-system/zkprogram.ts
@@ -54,7 +54,7 @@ import {
   featureFlagsFromGates,
   featureFlagsToMlOption,
 } from './feature-flags.js';
-import { emptyValue, emptyWitness } from '../provable/types/util.js';
+import { emptyWitness } from '../provable/types/util.js';
 import { InferValue } from '../../bindings/lib/provable-generic.js';
 
 // public API
@@ -78,7 +78,6 @@ export {
   picklesRuleFromFunction,
   compileProgram,
   analyzeMethod,
-  synthesizeMethodArguments,
   methodArgumentsToConstant,
   methodArgumentTypesAndValues,
   Prover,
@@ -679,7 +678,7 @@ function analyzeMethod(
   method: (...args: any) => unknown
 ) {
   return Provable.constraintSystem(() => {
-    let args = synthesizeMethodArguments(methodIntf, true);
+    let args = methodIntf.args.map(emptyWitness);
     let publicInput = emptyWitness(publicInputType);
     // note: returning the method result here makes this handle async methods
     if (publicInputType === Undefined || publicInputType === Void)
@@ -724,7 +723,7 @@ function picklesRuleFromFunction(
       let type = args[i];
       try {
         let value = Provable.witness(type, () => {
-          return argsWithoutPublicInput?.[i] ?? emptyValue(type);
+          return argsWithoutPublicInput?.[i] ?? ProvableType.synthesize(type);
         });
         finalArgs[i] = value;
 
@@ -835,11 +834,6 @@ function picklesRuleFromFunction(
     featureFlags,
     proofsToVerify: MlArray.to(proofsToVerify),
   };
-}
-
-function synthesizeMethodArguments(intf: MethodInterface, asVariables = false) {
-  let empty = asVariables ? emptyWitness : emptyValue;
-  return intf.args.map((type) => empty(type));
 }
 
 function methodArgumentsToConstant(intf: MethodInterface, args: any[]) {

--- a/src/lib/proof-system/zkprogram.ts
+++ b/src/lib/proof-system/zkprogram.ts
@@ -48,12 +48,14 @@ import {
   extractProofTypesFromArray,
   Proof,
   ProofBase,
+  ProofValue,
 } from './proof.js';
 import {
   featureFlagsFromGates,
   featureFlagsToMlOption,
 } from './feature-flags.js';
 import { emptyValue, emptyWitness } from '../provable/types/util.js';
+import { InferValue } from '../../bindings/lib/provable-generic.js';
 
 // public API
 export {
@@ -877,10 +879,16 @@ ZkProgram.Proof = function <
   name: string;
   publicInputType: PublicInputType;
   publicOutputType: PublicOutputType;
-}) {
-  type PublicInput = InferProvable<PublicInputType>;
-  type PublicOutput = InferProvable<PublicOutputType>;
-  return class ZkProgramProof extends Proof<PublicInput, PublicOutput> {
+}): typeof Proof<
+  InferProvable<PublicInputType>,
+  InferProvable<PublicOutputType>
+> & {
+  provable: Provable<
+    Proof<InferProvable<PublicInputType>, InferProvable<PublicOutputType>>,
+    ProofValue<InferValue<PublicInputType>, InferValue<PublicOutputType>>
+  >;
+} {
+  return class ZkProgramProof extends Proof<any, any> {
     static publicInputType = program.publicInputType;
     static publicOutputType = program.publicOutputType;
     static tag = () => program;

--- a/src/lib/proof-system/zkprogram.ts
+++ b/src/lib/proof-system/zkprogram.ts
@@ -44,8 +44,7 @@ import {
   dummyProof,
   DynamicProof,
   extractProofs,
-  extractProofsFromArray,
-  extractProofTypesFromArray,
+  extractProofTypes,
   Proof,
   ProofBase,
   ProofValue,
@@ -78,8 +77,6 @@ export {
   picklesRuleFromFunction,
   compileProgram,
   analyzeMethod,
-  methodArgumentsToConstant,
-  methodArgumentTypesAndValues,
   Prover,
   dummyBase64Proof,
 };
@@ -488,7 +485,7 @@ function sortMethodArguments(
   });
 
   // extract proofs to count them and for sanity checks
-  let proofs = extractProofTypesFromArray(args);
+  let proofs = args.flatMap(extractProofTypes);
   let numberOfProofs = proofs.length;
 
   // don't allow base classes for proofs
@@ -538,7 +535,7 @@ function isDynamicProof(
 }
 
 function getPreviousProofsForProver(methodArgs: any[]) {
-  return extractProofsFromArray(methodArgs).map((proof) => proof.proof);
+  return methodArgs.flatMap(extractProofs).map((proof) => proof.proof);
 }
 
 type MethodInterface = {
@@ -788,7 +785,7 @@ function picklesRuleFromFunction(
     };
   }
 
-  let proofs: Subclass<typeof ProofBase>[] = extractProofTypesFromArray(args);
+  let proofs: Subclass<typeof ProofBase>[] = args.flatMap(extractProofTypes);
   if (proofs.length > 2) {
     throw Error(
       `${proofSystemTag.name}.${methodName}() has more than two proof arguments, which is not supported.\n` +
@@ -834,18 +831,6 @@ function picklesRuleFromFunction(
     featureFlags,
     proofsToVerify: MlArray.to(proofsToVerify),
   };
-}
-
-function methodArgumentsToConstant(intf: MethodInterface, args: any[]) {
-  return intf.args.map((type, i) => Provable.toConstant(type, args[i]));
-}
-
-type TypeAndValue<T> = { type: Provable<T>; value: T };
-
-function methodArgumentTypesAndValues(intf: MethodInterface, args: unknown[]) {
-  return intf.args.map((type, i): TypeAndValue<any> => {
-    return { type: ProvableType.get(type), value: args[i] };
-  });
 }
 
 function getMaxProofsVerified(methodIntfs: MethodInterface[]) {

--- a/src/lib/provable/option.ts
+++ b/src/lib/provable/option.ts
@@ -1,5 +1,4 @@
 import { InferValue } from '../../bindings/lib/provable-generic.js';
-import { emptyValue } from './types/util.js';
 import { Provable } from './provable.js';
 import { InferProvable, Struct } from './types/struct.js';
 import { provable, ProvableInferPureFrom } from './types/provable-derivers.js';
@@ -77,7 +76,10 @@ function Option<A extends ProvableType>(
 
     fromValue(value: OptionOrValue<T, V>) {
       if (value === undefined)
-        return { isSome: Bool(false), value: emptyValue(strictType) };
+        return {
+          isSome: Bool(false),
+          value: ProvableType.synthesize(strictType),
+        };
       // TODO: this isn't 100% robust. We would need recursive type validation on any nested objects to make it work
       if (typeof value === 'object' && 'isSome' in value)
         return PlainOption.fromValue(value as any); // type-cast here is ok, matches implementation
@@ -103,7 +105,10 @@ function Option<A extends ProvableType>(
 
     static from(value?: V | T) {
       return value === undefined
-        ? new Option_({ isSome: Bool(false), value: emptyValue(strictType) })
+        ? new Option_({
+            isSome: Bool(false),
+            value: ProvableType.synthesize(strictType),
+          })
         : new Option_({
             isSome: Bool(true),
             value: strictType.fromValue(value),

--- a/src/lib/provable/option.ts
+++ b/src/lib/provable/option.ts
@@ -1,5 +1,5 @@
 import { InferValue } from '../../bindings/lib/provable-generic.js';
-import { emptyValue } from '../proof-system/zkprogram.js';
+import { emptyValue } from './types/util.js';
 import { Provable } from './provable.js';
 import { InferProvable, Struct } from './types/struct.js';
 import { provable, ProvableInferPureFrom } from './types/provable-derivers.js';

--- a/src/lib/provable/types/provable-intf.ts
+++ b/src/lib/provable/types/provable-intf.ts
@@ -1,3 +1,4 @@
+import { createField } from '../core/field-constructor.js';
 import type { Field } from '../field.js';
 
 export {
@@ -128,5 +129,15 @@ const ProvableType = {
         ? type.provable
         : type
     ) as ToProvable<A>;
+  },
+  /**
+   * Create some value of type `T` from its provable type description.
+   */
+  synthesize<T>(type: ProvableType<T>): T {
+    let provable = ProvableType.get(type);
+    return provable.fromFields(
+      Array(provable.sizeInFields()).fill(createField(0)),
+      provable.toAuxiliary()
+    );
   },
 };

--- a/src/lib/provable/types/struct.ts
+++ b/src/lib/provable/types/struct.ts
@@ -159,7 +159,7 @@ function Struct<
   } {
   class Struct_ {
     static type = provable<A>(type);
-    static _isStruct: true;
+    static _isStruct: true = true;
 
     constructor(value: T) {
       Object.assign(this, value);

--- a/src/lib/provable/types/util.ts
+++ b/src/lib/provable/types/util.ts
@@ -1,17 +1,8 @@
-import { createField } from '../core/field-constructor.js';
 import { ProvableType } from './provable-intf.js';
 import { witness } from './witness.js';
 
-export { emptyValue, emptyWitness };
-
-function emptyValue<T>(type: ProvableType<T>) {
-  let provable = ProvableType.get(type);
-  return provable.fromFields(
-    Array(provable.sizeInFields()).fill(createField(0)),
-    provable.toAuxiliary()
-  );
-}
+export { emptyWitness };
 
 function emptyWitness<T>(type: ProvableType<T>) {
-  return witness(type, () => emptyValue(type));
+  return witness(type, () => ProvableType.synthesize(type));
 }

--- a/src/lib/provable/types/util.ts
+++ b/src/lib/provable/types/util.ts
@@ -1,0 +1,17 @@
+import { createField } from '../core/field-constructor.js';
+import { ProvableType } from './provable-intf.js';
+import { witness } from './witness.js';
+
+export { emptyValue, emptyWitness };
+
+function emptyValue<T>(type: ProvableType<T>) {
+  let provable = ProvableType.get(type);
+  return provable.fromFields(
+    Array(provable.sizeInFields()).fill(createField(0)),
+    provable.toAuxiliary()
+  );
+}
+
+function emptyWitness<T>(type: ProvableType<T>) {
+  return witness(type, () => emptyValue(type));
+}

--- a/src/tests/fake-proof.ts
+++ b/src/tests/fake-proof.ts
@@ -8,6 +8,7 @@ import {
   verify,
   Struct,
   Field,
+  Proof,
 } from 'o1js';
 import assert from 'assert';
 
@@ -32,6 +33,7 @@ const FakeProgram = ZkProgram({
 });
 
 class RealProof extends ZkProgram.Proof(RealProgram) {}
+const Nested = Struct({ inner: RealProof });
 
 const RecursiveProgram = ZkProgram({
   name: 'recursive',
@@ -43,8 +45,9 @@ const RecursiveProgram = ZkProgram({
       },
     },
     verifyNested: {
-      privateInputs: [Field, Struct({ inner: RealProof })],
-      async method(_unrelated, { inner }: { inner: RealProof }) {
+      privateInputs: [Field, Nested],
+      async method(_unrelated, { inner }) {
+        inner satisfies Proof<undefined, void>;
         inner.verify();
       },
     },


### PR DESCRIPTION
closes #1039 

Removes restriction that proof parameters can't be nested.

Instead, (private) inputs are deeply searched for any proofs they possibly contain, and those proofs are all declared to Pickles

**Caveat**: `SelfProof` can't be nested yet