### PR TITLE
Export IndexedMerkleMapBase

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,10 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ### Added
 
+- `IndexedMerkleMapBase` type is now exported to make serialization of `IndexedMerkleMap` easier.
+
+### Added
+
 - Added `VerificationKey.dummy()` method to get the dummy value of a verification key https://github.com/o1-labs/o1js/pull/1852 [@rpanic](https://github.com/rpanic)
 
 ### Changed

--- a/src/index.ts
+++ b/src/index.ts
@@ -156,6 +156,8 @@ const Experimental_ = {
   IndexedMerkleMap,
 };
 
+type ExperimentalIndexedMerkleMapBase = IndexedMerkleMapBase;
+
 /**
  * This module exposes APIs that are unstable, in the sense that the API surface is expected to change.
  * (Not unstable in the sense that they are less functional or tested than other parts.)
@@ -166,6 +168,7 @@ namespace Experimental {
   // indexed merkle map
   export let IndexedMerkleMap = Experimental_.IndexedMerkleMap;
   export type IndexedMerkleMap = IndexedMerkleMapBase;
+  export type IndexedMerkleMapBase = ExperimentalIndexedMerkleMapBase;
 
   // offchain state
   export let OffchainState = OffchainState_.OffchainState;


### PR DESCRIPTION
Closes https://github.com/o1-labs/o1js/issues/1855

Exports IndexedMerkleMapBase that is useful for the serialization of IndexedMerkleMap of any height.