### PR TITLE
Expose some types and gadgets

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -37,7 +37,12 @@ export type {
   FlexibleProvablePure,
   InferProvable,
 } from './lib/provable/types/struct.js';
-export { From } from './bindings/lib/provable-generic.js';
+export {
+  From,
+  InferValue,
+  InferJson,
+  IsPure,
+} from './bindings/lib/provable-generic.js';
 export { ProvableType } from './lib/provable/types/provable-intf.js';
 export {
   provable,

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,4 @@
+export { TupleN } from './lib/util/types.js';
 export type { ProvablePure } from './lib/provable/types/provable-intf.js';
 export { Ledger, initializeBindings } from './snarky.js';
 export { Field, Bool, Group, Scalar } from './lib/provable/wrapped.js';

--- a/src/lib/proof-system/zkprogram.ts
+++ b/src/lib/proof-system/zkprogram.ts
@@ -1,9 +1,8 @@
 import { EmptyUndefined, EmptyVoid } from '../../bindings/lib/generic.js';
 import { Snarky, initializeBindings, withThreadPool } from '../../snarky.js';
 import { Pickles, Gate } from '../../snarky.js';
-import { Field, Bool } from '../provable/wrapped.js';
+import { Field } from '../provable/wrapped.js';
 import {
-  FlexibleProvable,
   FlexibleProvablePure,
   InferProvable,
   ProvablePureExtended,
@@ -12,7 +11,6 @@ import {
 import {
   InferProvableType,
   provable,
-  provablePure,
 } from '../provable/types/provable-derivers.js';
 import { Provable } from '../provable/provable.js';
 import { assert, prettifyStacktracePromise } from '../util/errors.js';
@@ -525,15 +523,6 @@ function isProvable(type: unknown): type is ProvableType<unknown> {
     ['toFields', 'fromFields', 'sizeInFields', 'toAuxiliary'].every(
       (s) => s in type_
     )
-  );
-}
-
-function isProofType(type: unknown): type is typeof ProofBase {
-  // the third case covers subclasses
-  return (
-    type === Proof ||
-    type === DynamicProof ||
-    (typeof type === 'function' && type.prototype instanceof ProofBase)
   );
 }
 

--- a/src/lib/provable/gadgets/basic.ts
+++ b/src/lib/provable/gadgets/basic.ts
@@ -74,9 +74,14 @@ function assertMul(
  *
  * Assumes that index is in [0, n), returns an unconstrained result otherwise.
  *
- * Note: This saves 0.5*n constraints compared to equals() + switch()
+ * Note: This saves 0.5*n constraints compared to equals() + switch() even if equals() were implemented optimally.
  */
 function arrayGet(array: Field[], index: Field) {
+  // if index is constant, we can return the value directly
+  if (index.isConstant()) {
+    return array[Number(index.toBigInt())];
+  }
+
   let i = toVar(index);
 
   // witness result

--- a/src/lib/provable/gadgets/basic.ts
+++ b/src/lib/provable/gadgets/basic.ts
@@ -79,13 +79,13 @@ function assertMul(
 function arrayGet(array: Field[], index: Field) {
   // if index is constant, we can return the value directly
   if (index.isConstant()) {
-    return array[Number(index.toBigInt())];
+    return array[Number(index.toBigInt())] ?? createField(0n);
   }
 
   let i = toVar(index);
 
   // witness result
-  let a = existsOne(() => array[Number(i.toBigInt())].toBigInt());
+  let a = existsOne(() => array[Number(i.toBigInt())].toBigInt() ?? 0n);
 
   // we prove a === array[j] + z[j]*(i - j) for some z[j], for all j.
   // setting j = i, this implies a === array[i]

--- a/src/lib/provable/gadgets/gadgets.ts
+++ b/src/lib/provable/gadgets/gadgets.ts
@@ -30,10 +30,29 @@ import {
 import { divMod32, addMod32 } from './arithmetic.js';
 import { SHA256 } from './sha256.js';
 import { rangeCheck3x12 } from './lookup.js';
+import { arrayGet } from './basic.js';
 
 export { Gadgets, Field3, ForeignFieldSum };
 
 const Gadgets = {
+  /**
+   * Get value from array at a Field element index, in O(n) constraints, where n is the array length.
+   *
+   * **Warning**: This gadget assumes that the index is within the array bounds `[0, n)`,
+   * and returns an unconstrained result otherwise.
+   * To use it with an index that is not already guaranteed to be within the array bounds, you should add a suitable range check.
+   *
+   * ```ts
+   * let array = Provable.witnessFields(3, () => [1n, 2n, 3n]);
+   * let index = Provable.witness(Field, () => 1n);
+   *
+   * let value = Gadgets.arrayGet(array, index);
+   * ```
+   *
+   * **Note**: This saves n constraints compared to `Provable.switch(array.map((_, i) => index.equals(i)), type, array)`.
+   */
+  arrayGet,
+
   /**
    * Asserts that the input value is in the range [0, 2^64).
    *

--- a/src/lib/provable/gadgets/sha256.ts
+++ b/src/lib/provable/gadgets/sha256.ts
@@ -102,6 +102,7 @@ const SHA256 = {
   },
   compression: sha256Compression,
   createMessageSchedule,
+  padding,
   get initialState() {
     return SHA256Constants.H.map((x) => UInt32.from(x));
   },
@@ -239,7 +240,7 @@ function sigma(u: UInt32, bits: TupleN<number, 3>, firstShifted = false) {
  *
  * @returns The updated intermediate hash values after compression.
  */
-function sha256Compression(H: UInt32[], W: UInt32[]) {
+function sha256Compression([...H]: UInt32[], W: UInt32[]) {
   // initialize working variables
   let a = H[0];
   let b = H[1];

--- a/src/lib/provable/gadgets/sha256.ts
+++ b/src/lib/provable/gadgets/sha256.ts
@@ -8,7 +8,6 @@ import { Bytes } from '../wrapped-classes.js';
 import { chunk } from '../../util/arrays.js';
 import { TupleN } from '../../util/types.js';
 import { divMod32 } from './arithmetic.js';
-import { bytesToWord, wordToBytes } from './bit-slices.js';
 import { bitSlice } from './common.js';
 import { rangeCheck16 } from './range-check.js';
 
@@ -70,11 +69,7 @@ function padding(data: FlexibleBytes): UInt32[][] {
   for (let i = 0; i < paddedMessage.length; i += 4) {
     // chunk 4 bytes into one UInt32, as expected by SHA256
     // bytesToWord expects little endian, so we reverse the bytes
-    chunks.push(
-      UInt32.Unsafe.fromField(
-        bytesToWord(paddedMessage.slice(i, i + 4).reverse())
-      )
-    );
+    chunks.push(UInt32.fromBytesBE(paddedMessage.slice(i, i + 4)));
   }
 
   // split message into 16 element sized message blocks
@@ -97,8 +92,7 @@ const SHA256 = {
     }
 
     // the working variables H[i] are 32bit, however we want to decompose them into bytes to be more compatible
-    // wordToBytes expects little endian, so we reverse the bytes
-    return Bytes.from(H.map((x) => wordToBytes(x.value, 4).reverse()).flat());
+    return Bytes.from(H.map((x) => x.toBytesBE()).flat());
   },
   compression: sha256Compression,
   createMessageSchedule,

--- a/src/lib/provable/packed.ts
+++ b/src/lib/provable/packed.ts
@@ -1,4 +1,4 @@
-import { provableFromClass } from './types/provable-derivers.js';
+import { mapValue, provableFromClass } from './types/provable-derivers.js';
 import { HashInput, ProvableExtended } from './types/struct.js';
 import { Unconstrained } from './types/unconstrained.js';
 import { Field } from './field.js';
@@ -50,10 +50,10 @@ class Packed<T> {
   /**
    * Create a packed representation of `type`. You can then use `PackedType.pack(x)` to pack a value.
    */
-  static create<T>(
-    type: WithProvable<ProvableHashable<T>>
+  static create<T, V>(
+    type: WithProvable<ProvableHashable<T, V>>
   ): typeof Packed<T> & {
-    provable: ProvableHashable<Packed<T>>;
+    provable: ProvableHashable<Packed<T>, V>;
 
     /**
      * Pack a value.
@@ -64,13 +64,28 @@ class Packed<T> {
     // compute size of packed representation
     let input = provable.toInput(provable.empty());
     let packedSize = countFields(input);
+    let packedFields = fields(packedSize);
 
     return class Packed_ extends Packed<T> {
       static _innerProvable = provable;
-      static _provable = provableFromClass(Packed_, {
-        packed: fields(packedSize),
-        value: Unconstrained,
-      }) satisfies ProvableHashable<Packed<T>> as ProvableHashable<Packed<T>>;
+      static _provable = mapValue(
+        provableFromClass(Packed_, {
+          packed: packedFields,
+          value: Unconstrained,
+        }),
+        ({ value }: { value: Unconstrained<T> }) =>
+          provable.toValue(value.get()),
+        (x: V) => {
+          let { packed, value } = Packed_.pack(provable.fromValue(x));
+          return {
+            packed: packedFields.toValue(packed),
+            value: Unconstrained.from(value),
+          };
+        }
+      ) satisfies ProvableHashable<Packed<T>, V> as ProvableHashable<
+        Packed<T>,
+        V
+      >;
 
       static pack(x: T): Packed<T> {
         let input = provable.toInput(x);

--- a/src/lib/provable/packed.ts
+++ b/src/lib/provable/packed.ts
@@ -75,7 +75,8 @@ class Packed<T> {
         }),
         ({ value }: { value: Unconstrained<T> }) =>
           provable.toValue(value.get()),
-        (x: V) => {
+        (x) => {
+          if (x instanceof Packed) return x;
           let { packed, value } = Packed_.pack(provable.fromValue(x));
           return {
             packed: packedFields.toValue(packed),

--- a/src/lib/provable/types/provable-derivers.ts
+++ b/src/lib/provable/types/provable-derivers.ts
@@ -171,11 +171,16 @@ function provableExtends<
   } satisfies ProvableHashable<S, InferValue<A>>;
 }
 
-function mapValue<A extends ProvableHashable<any>, V extends InferValue<A>, W>(
+function mapValue<
+  A extends ProvableHashable<any>,
+  V extends InferValue<A>,
+  W,
+  T extends InferProvable<A>
+>(
   provable: A,
   there: (x: V) => W,
-  back: (x: W) => V
-): ProvableHashable<InferProvable<A>, W> {
+  back: (x: W | T) => V | T
+): ProvableHashable<T, W> {
   return {
     sizeInFields() {
       return provable.sizeInFields();

--- a/src/lib/provable/types/provable-derivers.ts
+++ b/src/lib/provable/types/provable-derivers.ts
@@ -45,6 +45,7 @@ export {
   InferredProvable,
   IsPure,
   NestedProvable,
+  mapValue,
 };
 
 type ProvableExtension<T, TJson = any> = {
@@ -168,4 +169,40 @@ function provableExtends<
       return base.toInput(value);
     },
   } satisfies ProvableHashable<S, InferValue<A>>;
+}
+
+function mapValue<A extends ProvableHashable<any>, V extends InferValue<A>, W>(
+  provable: A,
+  there: (x: V) => W,
+  back: (x: W) => V
+): ProvableHashable<InferProvable<A>, W> {
+  return {
+    sizeInFields() {
+      return provable.sizeInFields();
+    },
+    toFields(value) {
+      return provable.toFields(value);
+    },
+    toAuxiliary(value) {
+      return provable.toAuxiliary(value);
+    },
+    fromFields(fields, aux) {
+      return provable.fromFields(fields, aux);
+    },
+    check(value) {
+      provable.check(value);
+    },
+    toValue(value) {
+      return there(provable.toValue(value));
+    },
+    fromValue(value) {
+      return provable.fromValue(back(value));
+    },
+    empty() {
+      return provable.empty();
+    },
+    toInput(value) {
+      return provable.toInput(value);
+    },
+  };
 }

--- a/src/lib/provable/wrapped-classes.ts
+++ b/src/lib/provable/wrapped-classes.ts
@@ -19,3 +19,6 @@ function Bytes(size: number) {
 Bytes.from = InternalBytes.from;
 Bytes.fromHex = InternalBytes.fromHex;
 Bytes.fromString = InternalBytes.fromString;
+
+// expore base class so that we can detect Bytes with `instanceof`
+Bytes.Base = InternalBytes;


### PR DESCRIPTION
Several additions that were handy when implementing dynamic-length SHA2 and general-purpose array types in https://github.com/zksecurity/mina-attestations/pull/25

* Exposes a few utility types like `InferValue`, `From`, `TupleN`
* Exposes a few gadgets like `arrayGet()` and UInt32 to/from bytes
* make the `Packed` class much better typed

CI run here: https://github.com/zksecurity/o1js/pull/2