### PR TITLE
Setup codeowners file with new team structure

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -5,9 +5,3 @@
 # We are relying on good faith to wait for admin approval on these PRs
 # Dangerous PRs that could release a new version, new consensus rules, or anything like that will necessarily touch more than `/src/lib`, so this is minimally risky
 /src/lib @o1-labs/o1js-admins @o1-labs/exploration-team @o1-labs/future-zkapps
-
-# Changes to the following paths can be safely owned by the current and future zkapps teams (correct use of codeowners)
-/src/examples @o1-labs/exploration-team @o1-labs/future-zkapps
-/src/lib/util @o1-labs/exploration-team @o1-labs/future-zkapps
-
-

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,6 +1,13 @@
-# All files require a review from @o1-labs/o1js-admins
+# By default, review is required by o1js-admins
 * @o1-labs/o1js-admins
 
-# Changes to source code should be reviewed by exploration team and future zkapps team 
-/src/examples @o1-labs/o1js-admins @o1-labs/exploration-team @o1-labs/future-zkapps
+# Changes to the following paths should be reviewed by o1js-admins, but we will tag current and future zkapps teams as well (incorrect use of codeowners)
+# We are relying on good faith to wait for admin approval on these PRs
+# Dangerous PRs that could release a new version, new consensus rules, or anything like that will necessarily touch more than `/src/lib`, so this is minimally risky
 /src/lib @o1-labs/o1js-admins @o1-labs/exploration-team @o1-labs/future-zkapps
+
+# Changes to the following paths can be safely owned by the current and future zkapps teams (correct use of codeowners)
+/src/examples @o1-labs/exploration-team @o1-labs/future-zkapps
+/src/lib/util @o1-labs/exploration-team @o1-labs/future-zkapps
+
+

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -2,8 +2,5 @@
 * @o1-labs/o1js-admins
 
 # Changes to source code should be reviewed by exploration team and future zkapps team 
-/src/examples @o1-labs/exploration-team @o1-labs/future-zkapps
-/src/lib @o1-labs/exploration-team @o1-labs/future-zkapps
-
-# Provable code should be reviewed by the crypto team
-/src/lib/provable @o1-labs/crypto-eng-reviewers
+/src/examples @o1-labs/o1js-admins @o1-labs/exploration-team @o1-labs/future-zkapps
+/src/lib @o1-labs/o1js-admins @o1-labs/exploration-team @o1-labs/future-zkapps

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,9 @@
-/src/lib/gadgets @o1-labs/crypto-eng-reviewers @mitschabaude
+# All files require a review from @o1-labs/o1js-admins
+* @o1-labs/o1js-admins
+
+# Changes to source code should be reviewed by exploration team and future zkapps team 
+/src/examples @o1-labs/exploration-team @o1-labs/future-zkapps
+/src/lib @o1-labs/exploration-team @o1-labs/future-zkapps
+
+# Provable code should be reviewed by the crypto team
+/src/lib/provable @o1-labs/crypto-eng-reviewers


### PR DESCRIPTION
This PR cleans up the `CODEOWNERS` file and lays the groundwork for a new round-robin code review process that will give the exploration team and future zkapps team exposure to o1js PR reviews.

Ultimately, it is the `o1js-admins` job to manage what code gets into o1js.  This process aims to get more people to the level that they can be added to the list of admins.