### PR TITLE
Enforce changelog changes :) 

### DIFF
--- a/.github/workflows/changelog-entry.yml
+++ b/.github/workflows/changelog-entry.yml
@@ -1,0 +1,14 @@
+name: Check Changelog for changes
+on:
+  pull_request:
+    types: [assigned, opened, synchronize, reopened, labeled, unlabeled]
+    branches:
+      - main
+jobs:
+  Check-Changelog:
+    name: Check Changelog Action
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: tarides/changelog-check-action@v2
+        with:
+          changelog: CHANGELOG.md


### PR DESCRIPTION
why?
- sometimes, we forget to add things to the changelog
- we want to keep the community as informed as possible - even small things are valuable, let's not forget to add them to the changelog!
- CI blocking a PR because of this might seem too drastic, but sometimes a little strictness is needed to achieve great things