### PR TITLE
Check mina commit in ci

### DIFF
--- a/.github/workflows/build-action.yml
+++ b/.github/workflows/build-action.yml
@@ -61,6 +61,33 @@ jobs:
           path: .
           key: repo-${{ github.sha }}
 
+  Check-mina-commit:
+    needs: Prepare
+    timeout-minutes: 5
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+    steps:
+      - name: Restore repository
+        uses: actions/cache@v4
+        with:
+          path: .
+          key: repo-${{ github.sha }}
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '18'
+
+      - name: Check Commit
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.npm
+            node_modules
+            dist
+          key: npm run checkCommit
+
   Build-And-Test-Server:
     needs: Prepare
     timeout-minutes: 210

--- a/flake.lock
+++ b/flake.lock
@@ -265,8 +265,8 @@
         "utils": "utils"
       },
       "locked": {
-        "lastModified": 1726508134,
-        "narHash": "sha256-rAyggDaasWFcgoYi1aNrGZxPK/wH5+cleIV453xuUYY=",
+        "lastModified": 1731611028,
+        "narHash": "sha256-sehBPO+H9mtShGb3KNhdDVHj0pogt/tmiL9tc2ICkaU=",
         "path": "src/mina",
         "type": "path"
       },

--- a/package.json
+++ b/package.json
@@ -68,7 +68,8 @@
     "e2e:run-server": "node dist/web/server.js",
     "e2e:install": "npx playwright install --with-deps",
     "e2e:show-report": "npx playwright show-report tests/report",
-    "update-changelog": "./update-changelog.sh"
+    "update-changelog": "./update-changelog.sh",
+    "checkCommit": "./src/bindings/scripts/check-commit.sh"
   },
   "author": "O(1) Labs",
   "devDependencies": {


### PR DESCRIPTION
Adds a check in ci that the bindings were build with the same version of mina as exists in the submodule

https://github.com/o1-labs/o1js-bindings/pull/311