### PR TITLE
Update blog link

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ o1js is automatically included when you create a project using the [zkApp CLI](h
 
 - For a list of changes between versions, see the [CHANGELOG](https://github.com/o1-labs/o1js/blob/main/CHANGELOG.md).
 
-- To stay up to date with o1js, see the [O(1) Labs Blog](https://blog.o1labs.org/tagged/o1js).
+- To stay up to date with o1js, see the [O(1) Labs Blog](https://www.o1labs.org/blog?topics=o1js).
 
 ## Contributing
 


### PR DESCRIPTION
https://blog.o1labs.org/tagged/o1js does not have our latest content

https://www.o1labs.org/blog?topics=o1js does.  We must have changed the website architecture with the rebrand and not updated this link.