### PR TITLE
ci/bindings: build o1js bindings in CI

### DIFF
--- a/.github/workflows/build-bindings.yml
+++ b/.github/workflows/build-bindings.yml
@@ -1,0 +1,25 @@
+# Purpose: We want to build the o1js bindings in CI so that people in the 
+# community can change them without being scared of breaking things, or
+# needing to do the complicated (without nix) build setup.
+
+name: Build o1js bindings
+
+on:
+  pull_request:
+
+jobs:  
+  nix-build:
+    name: build-bindings-ubuntu
+    runs-on: [sdk-self-hosted-linux-amd64-build-system]
+    steps:
+      - name: Disable smudging
+        run: echo "GIT_LFS_SKIP_SMUDGE=1" >> $GITHUB_ENV
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+      - run: |
+          set -Eeu
+          # Until we restart the runner and the PATH gets updated from /etc/bash.bashrc
+          export PATH="$PATH":/nix/var/nix/profiles/default/bin
+          ./pin.sh
+          nix develop o1js --command bash -c "npm run build:update-bindings"


### PR DESCRIPTION
Closes #1897.