### PR TITLE
Fix Lagrange bases caching on the web

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,10 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased](https://github.com/o1-labs/o1js/compare/e1bac02...HEAD)
 
+### Fixed
+
+- Compiling stuck in the browser for recursive zkprograms https://github.com/o1-labs/o1js/pull/1906
+
 ## [2.1.0](https://github.com/o1-labs/o1js/compare/b04520d...e1bac02) - 2024-11-13
 
 ### Added


### PR DESCRIPTION
fixes https://github.com/o1-labs/o1js/issues/1891

changes are in the bindings PR: https://github.com/o1-labs/o1js-bindings/pull/313

EDIT:
a frustrating aspect of this fix is that the problem with compiling recursive programs in the browser must have been present for at least a year, if I'm not mistaken -- ever since Lagrange basis caching was introduced.

Ideally, following up this PR we would add a test that catches such a regression. We do currently have web tests but they don't use recursion.