### PR TITLE
Add recursive ZkProgram to e2e testing

### DIFF
--- a/src/build/e2e-tests-build-helper.js
+++ b/src/build/e2e-tests-build-helper.js
@@ -1,14 +1,32 @@
 import replace from 'replace-in-file';
 
-const options = {
-  files: './dist/web/examples/zkapps/**/*.js',
-  from: /from 'o1js'/g,
-  to: "from '../../../index.js'",
-};
+const replaceOptions = [
+  {
+    files: './dist/web/examples/zkapps/**/*.js',
+    from: /from 'o1js'/g,
+    to: "from '../../../index.js'",
+  },
+  {
+    files: './dist/web/examples/zkprogram/*.js',
+    from: /from 'o1js'/g,
+    to: "from '../../index.js'",
+  },
+];
 
-try {
-  const results = await replace(options);
-  console.log('Replacement results:', results);
-} catch (error) {
-  console.error('Error occurred:', error);
+async function performReplacement(options) {
+  try {
+    const results = await replace(options);
+    console.log(`Replacement results for ${options.files}:`, results);
+  } catch (error) {
+    console.error(`Error occurred while replacing in ${options.files}:`, error);
+  }
 }
+
+async function main() {
+  for (const options of replaceOptions) {
+    await performReplacement(options);
+  }
+}
+
+main();
+

--- a/src/build/e2e-tests-build-helper.js
+++ b/src/build/e2e-tests-build-helper.js
@@ -29,4 +29,3 @@ async function main() {
 }
 
 main();
-

--- a/src/examples/zkprogram/program-with-input.ts
+++ b/src/examples/zkprogram/program-with-input.ts
@@ -8,7 +8,7 @@ import {
   Provable,
 } from 'o1js';
 
-export let MyProgram = ZkProgram({
+let MyProgram = ZkProgram({
   name: 'example-with-input',
   publicInput: Field,
 

--- a/src/examples/zkprogram/program-with-input.ts
+++ b/src/examples/zkprogram/program-with-input.ts
@@ -8,7 +8,7 @@ import {
   Provable,
 } from 'o1js';
 
-let MyProgram = ZkProgram({
+export let MyProgram = ZkProgram({
   name: 'example-with-input',
   publicInput: Field,
 

--- a/src/examples/zkprogram/recursive-program.ts
+++ b/src/examples/zkprogram/recursive-program.ts
@@ -1,0 +1,23 @@
+import { SelfProof, Field, ZkProgram } from 'o1js';
+
+export const RecusiveProgram = ZkProgram({
+  name: 'recursive-program',
+  publicInput: Field,
+
+  methods: {
+    baseCase: {
+      privateInputs: [],
+      async method(input: Field) {
+        input.assertEquals(Field(0));
+      },
+    },
+
+    inductiveCase: {
+      privateInputs: [SelfProof],
+      async method(input: Field, earlierProof: SelfProof<Field, void>) {
+        earlierProof.verify();
+        earlierProof.publicInput.add(1).assertEquals(input);
+      },
+    },
+  },
+});

--- a/src/examples/zkprogram/recursive-program.ts
+++ b/src/examples/zkprogram/recursive-program.ts
@@ -1,6 +1,6 @@
 import { SelfProof, Field, ZkProgram } from 'o1js';
 
-export const RecusiveProgram = ZkProgram({
+export const RecursiveProgram = ZkProgram({
   name: 'recursive-program',
   publicInput: Field,
 

--- a/tests/artifacts/html/on-chain-state-mgmt-zkapp-ui.html
+++ b/tests/artifacts/html/on-chain-state-mgmt-zkapp-ui.html
@@ -25,6 +25,10 @@
     </div>
     <hr />
     <div>
+      <h4>zkProgram Management</h4>
+      <div>
+        <button type="button" id="compileButton">Compile ZkProgram</button>
+      </div>
       <h4>zkApp Management</h4>
       <div>
         <button type="button" id="deployButton">Deploy zkApp</button>

--- a/tests/artifacts/javascript/on-chain-state-mgmt-zkapp-ui.js
+++ b/tests/artifacts/javascript/on-chain-state-mgmt-zkapp-ui.js
@@ -3,10 +3,7 @@ import {
   adminPrivateKey,
   HelloWorld,
 } from './examples/zkapps/hello-world/hello-world.js';
-// MyProgram to serve as a test case for recursive ZkProgram compilation.
-// This helps to catch any regressions that might occur in the future.
-// For more details, refer to: https://github.com/o1-labs/o1js/pull/1906
-import { MyProgram } from './examples/zkprogram/program-with-input.js';
+import { RecursiveProgram } from './examples/zkprogram/recursive-program.js';
 import { AccountUpdate, Field, Mina, verify } from './index.js';
 
 const compileButton = document.querySelector('#compileButton');
@@ -36,7 +33,7 @@ compileButton.addEventListener('click', async () => {
   logEvents('Compiling ZkProgram', eventsContainer);
 
   try {
-    await MyProgram.compile();
+    await RecursiveProgram.compile();
     logEvents('ZkProgram compiled successfully!', eventsContainer);
   } catch (exception) {
     logEvents(`Compilation failure: ${exception.message}`, eventsContainer);

--- a/tests/artifacts/javascript/on-chain-state-mgmt-zkapp-ui.js
+++ b/tests/artifacts/javascript/on-chain-state-mgmt-zkapp-ui.js
@@ -3,8 +3,10 @@ import {
   adminPrivateKey,
   HelloWorld,
 } from './examples/zkapps/hello-world/hello-world.js';
+import { MyProgram } from './examples/zkprogram/program-with-input.js'
 import { AccountUpdate, Field, Mina, verify } from './index.js';
 
+const compileButton = document.querySelector('#compileButton');
 const deployButton = document.querySelector('#deployButton');
 const updateButton = document.querySelector('#updateButton');
 const clearEventsButton = document.querySelector('#clearEventsButton');
@@ -24,6 +26,22 @@ const [feePayer] = Local.testAccounts;
 const contractAddress = Mina.TestPublicKey.random();
 const contract = new HelloWorld(contractAddress);
 let verificationKey = null;
+
+compileButton.addEventListener('click', async () => {
+  compileButton.disabled = true;
+
+  logEvents('Compiling ZkProgram', eventsContainer);
+
+  try {
+    await MyProgram.compile();
+    logEvents('ZkProgram compiled successfully!', eventsContainer);
+  } catch (exception) {
+    logEvents(`Compilation failure: ${exception.message}`, eventsContainer);
+    console.log(exception);
+  }
+
+  compileButton.disabled = false;
+});
 
 deployButton.addEventListener('click', async () => {
   deployButton.disabled = true;

--- a/tests/artifacts/javascript/on-chain-state-mgmt-zkapp-ui.js
+++ b/tests/artifacts/javascript/on-chain-state-mgmt-zkapp-ui.js
@@ -3,7 +3,10 @@ import {
   adminPrivateKey,
   HelloWorld,
 } from './examples/zkapps/hello-world/hello-world.js';
-import { MyProgram } from './examples/zkprogram/program-with-input.js'
+// MyProgram to serve as a test case for recursive ZkProgram compilation.
+// This helps to catch any regressions that might occur in the future.
+// For more details, refer to: https://github.com/o1-labs/o1js/pull/1906
+import { MyProgram } from './examples/zkprogram/program-with-input.js';
 import { AccountUpdate, Field, Mina, verify } from './index.js';
 
 const compileButton = document.querySelector('#compileButton');

--- a/tests/on-chain-state-mgmt-zkapp-ui.spec.ts
+++ b/tests/on-chain-state-mgmt-zkapp-ui.spec.ts
@@ -8,6 +8,16 @@ test.describe('On-Chain State Management zkApp UI', () => {
     await onChainStateMgmtZkAppPage.checkO1jsInitialization();
   });
 
+  test('should compile zkProgram', async ({
+    onChainStateMgmtZkAppPage,
+  }) => {
+    await onChainStateMgmtZkAppPage.goto();
+    await onChainStateMgmtZkAppPage.checkO1jsInitialization();
+    await onChainStateMgmtZkAppPage.compileZkProgram();
+    await onChainStateMgmtZkAppPage.checkZkProgramCompilation();
+  });
+
+
   test('should fail to update account state since zkApp was not yet deployed', async ({
     onChainStateMgmtZkAppPage,
   }) => {

--- a/tests/pages/on-chain-state-mgmt-zkapp.ts
+++ b/tests/pages/on-chain-state-mgmt-zkapp.ts
@@ -2,6 +2,7 @@ import { expect, type Locator, type Page } from '@playwright/test';
 
 export class OnChainStateMgmtZkAppPage {
   readonly page: Page;
+  readonly compileButton: Locator;
   readonly deployButton: Locator;
   readonly updateButton: Locator;
   readonly clearEventsButton: Locator;
@@ -11,6 +12,7 @@ export class OnChainStateMgmtZkAppPage {
 
   constructor(page: Page) {
     this.page = page;
+    this.compileButton = page.locator('button[id="compileButton"]');
     this.deployButton = page.locator('button[id="deployButton"]');
     this.updateButton = page.locator('button[id="updateButton"]');
     this.clearEventsButton = page.locator('button[id="clearEventsButton"]');
@@ -21,6 +23,10 @@ export class OnChainStateMgmtZkAppPage {
 
   async goto() {
     await this.page.goto('/on-chain-state-mgmt-zkapp-ui.html');
+  }
+
+  async compileZkProgram() {
+    await this.compileButton.click();
   }
 
   async compileAndDeployZkApp() {
@@ -38,6 +44,11 @@ export class OnChainStateMgmtZkAppPage {
 
   async checkO1jsInitialization() {
     await expect(this.eventsContainer).toContainText('o1js initialized after');
+  }
+
+  async checkZkProgramCompilation() {
+    await expect(this.eventsContainer).toContainText('Compiling ZkProgram');
+    await expect(this.eventsContainer).toContainText('ZkProgram compiled successfully!');
   }
 
   async checkDeployedZkApp() {

--- a/tests/pages/on-chain-state-mgmt-zkapp.ts
+++ b/tests/pages/on-chain-state-mgmt-zkapp.ts
@@ -48,7 +48,9 @@ export class OnChainStateMgmtZkAppPage {
 
   async checkZkProgramCompilation() {
     await expect(this.eventsContainer).toContainText('Compiling ZkProgram');
-    await expect(this.eventsContainer).toContainText('ZkProgram compiled successfully!');
+    await expect(this.eventsContainer).toContainText(
+      'ZkProgram compiled successfully!'
+    );
   }
 
   async checkDeployedZkApp() {


### PR DESCRIPTION
This PR adds a recursive zkProgram to e2e testing to catch future regressions in zkProgram compilation on the web, as mentioned in #1906.