### PR TITLE
Increase max branches in a circuit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,10 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased](https://github.com/o1-labs/o1js/compare/e1bac02...HEAD)
 
+### Added
+
+- Increased maximum supported amount of methods in a `SmartContract` or `ZkProgram` to 30. https://github.com/o1-labs/o1js/pull/1918
+
 ### Fixed
 
 - Compiling stuck in the browser for recursive zkprograms https://github.com/o1-labs/o1js/pull/1906

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,8 +22,8 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 -`ZkProgram` to support non-pure provable types as inputs and outputs https://github.com/o1-labs/o1js/pull/1828
 
 - Add `enforceTransactionLimits` parameter on Network https://github.com/o1-labs/o1js/issues/1910
-
 - Method for optional types to assert none https://github.com/o1-labs/o1js/pull/1922
+- Increased maximum supported amount of methods in a `SmartContract` or `ZkProgram` to 30. https://github.com/o1-labs/o1js/pull/1918
 
 ### Fixed
 

--- a/src/lib/proof-system/zkprogram.unit-test.ts
+++ b/src/lib/proof-system/zkprogram.unit-test.ts
@@ -1,0 +1,33 @@
+import { Field } from '../provable/wrapped.js';
+import { ZkProgram } from './zkprogram.js';
+
+const methodCount = 30;
+
+let MyProgram = ZkProgram({
+  name: 'large-program',
+  publicOutput: Field,
+  methods: nMethods(methodCount),
+});
+
+function nMethods(i: number) {
+  let methods: Record<string, any> = {};
+  for (let j = 0; j < i; j++) {
+    methods['method' + j] = {
+      privateInputs: [Field],
+      async method(a: Field) {
+        return {
+          publicOutput: a.mul(1),
+        };
+      },
+    };
+  }
+  return methods;
+}
+
+try {
+  await MyProgram.compile();
+} catch (error) {
+  throw Error(
+    `Could not compile zkProgram with ${methodCount} branches: ${error}`
+  );
+}


### PR DESCRIPTION
lifts the previous maximum of 21 methods per circuit and increases it to 30, for now at least 

bindings: https://github.com/o1-labs/o1js-bindings/pull/315

closes https://github.com/o1-labs/o1js/issues/1892