### PR TITLE
Unlimited account update support 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,11 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased](https://github.com/o1-labs/o1js/compare/e1bac02...HEAD)
 
+
+### Added
+
+- Add `enforceTransactionLimits` parameter on Network https://github.com/o1-labs/o1js/issues/1910
+
 ### Fixed
 
 - Compiling stuck in the browser for recursive zkprograms https://github.com/o1-labs/o1js/pull/1906

--- a/src/lib/mina/mina.network.unit-test.ts
+++ b/src/lib/mina/mina.network.unit-test.ts
@@ -17,6 +17,8 @@ import {
   AccountUpdateForest,
   PrivateKey,
 } from 'o1js';
+import { test, describe, it, before } from 'node:test';
+import { expect } from 'expect';
 
 
 
@@ -30,21 +32,21 @@ const enforcedNetwork = Mina.Network({
   networkId: "testnet",
   mina: "https://example.com/graphql",
   archive: "https://example.com//graphql",
-  enforceTransactionLimits: true
+  bypassTransactionLimits: false
 });
 
 const unlimitedNetwork = Mina.Network({
   networkId: "testnet",
   mina: "https://unlimited.com/graphql",
   archive: "https://unlimited.com//graphql",
-  enforceTransactionLimits: false
+  bypassTransactionLimits: true
 });
 
 describe('Test default network', () => {
   let bobAccount: PublicKey,
     bobKey: PrivateKey;
 
-  beforeAll(async () => {
+  before(async () => {
 
     Mina.setActiveInstance(defaultNetwork);
     bobKey = PrivateKey.random();
@@ -88,7 +90,7 @@ describe('Test default network', () => {
       }
     });
     await txn.prove();
-    // failure with default enforceTransactionLimits
+    // failure with default bypassTransactionLimits value
     await expect(txn.sign([bobKey]).safeSend()).rejects.toThrow();
   });
 });
@@ -97,7 +99,7 @@ describe('Test enforced network', () => {
   let bobAccount: PublicKey,
     bobKey: PrivateKey;
 
-  beforeAll(async () => {
+  before(async () => {
 
     Mina.setActiveInstance(enforcedNetwork);
     bobKey = PrivateKey.random();
@@ -141,7 +143,7 @@ describe('Test enforced network', () => {
       }
     });
     await txn.prove();
-    // failure with enforceTransactionLimits = true
+    // failure with bypassTransactionLimits = false
     await expect(txn.sign([bobKey]).safeSend()).rejects.toThrow();
   });
 });
@@ -150,7 +152,7 @@ describe('Test unlimited network', () => {
   let bobAccount: PublicKey,
     bobKey: PrivateKey;
 
-  beforeAll(async () => {
+  before(async () => {
 
     Mina.setActiveInstance(unlimitedNetwork);
     bobKey = PrivateKey.random();
@@ -194,7 +196,7 @@ describe('Test unlimited network', () => {
       }
     });
     await txn.prove();
-    // success with enforceTransactionLimits = false
+    // success with bypassTransactionLimits = true
     await txn.sign([bobKey]).safeSend();
   });
 });

--- a/src/lib/mina/mina.ts
+++ b/src/lib/mina/mina.ts
@@ -162,7 +162,8 @@ function Network(
       Fetch.setLightnetAccountManagerEndpoint(lightnetAccountManagerEndpoint);
     }
 
-    if (options.enforceTransactionLimits) {
+    if (options.enforceTransactionLimits !== undefined &&
+      typeof options.enforceTransactionLimits === 'boolean') {
       enforceTransactionLimits = options.enforceTransactionLimits;
     }
   } else {

--- a/src/lib/mina/mina.ts
+++ b/src/lib/mina/mina.ts
@@ -104,7 +104,7 @@ function Network(options: {
   mina: string | string[];
   archive?: string | string[];
   lightnetAccountManager?: string;
-  enforceTransactionLimits?: boolean;
+  bypassTransactionLimits?: boolean;
 }): Mina;
 function Network(
   options:
@@ -113,7 +113,7 @@ function Network(
       mina: string | string[];
       archive?: string | string[];
       lightnetAccountManager?: string;
-      enforceTransactionLimits?: boolean;
+      bypassTransactionLimits?: boolean;
     }
     | string
 ): Mina {
@@ -162,9 +162,9 @@ function Network(
       Fetch.setLightnetAccountManagerEndpoint(lightnetAccountManagerEndpoint);
     }
 
-    if (options.enforceTransactionLimits !== undefined &&
-      typeof options.enforceTransactionLimits === 'boolean') {
-      enforceTransactionLimits = options.enforceTransactionLimits;
+    if (options.bypassTransactionLimits !== undefined &&
+      typeof options.bypassTransactionLimits === 'boolean') {
+      enforceTransactionLimits = !options.bypassTransactionLimits;
     }
   } else {
     throw new Error(

--- a/src/lib/mina/mina.ts
+++ b/src/lib/mina/mina.ts
@@ -104,21 +104,24 @@ function Network(options: {
   mina: string | string[];
   archive?: string | string[];
   lightnetAccountManager?: string;
+  enforceTransactionLimits?: boolean;
 }): Mina;
 function Network(
   options:
     | {
-        networkId?: NetworkId;
-        mina: string | string[];
-        archive?: string | string[];
-        lightnetAccountManager?: string;
-      }
+      networkId?: NetworkId;
+      mina: string | string[];
+      archive?: string | string[];
+      lightnetAccountManager?: string;
+      enforceTransactionLimits?: boolean;
+    }
     | string
 ): Mina {
   let minaNetworkId: NetworkId = 'testnet';
   let minaGraphqlEndpoint: string;
   let archiveEndpoint: string;
   let lightnetAccountManagerEndpoint: string;
+  let enforceTransactionLimits: boolean = true;
 
   if (options && typeof options === 'string') {
     minaGraphqlEndpoint = options;
@@ -157,6 +160,10 @@ function Network(
     ) {
       lightnetAccountManagerEndpoint = options.lightnetAccountManager;
       Fetch.setLightnetAccountManagerEndpoint(lightnetAccountManagerEndpoint);
+    }
+
+    if (options.enforceTransactionLimits) {
+      enforceTransactionLimits = options.enforceTransactionLimits;
     }
   } else {
     throw new Error(
@@ -251,7 +258,7 @@ function Network(
     },
     sendTransaction(txn) {
       return toPendingTransactionPromise(async () => {
-        verifyTransactionLimits(txn.transaction);
+        if (enforceTransactionLimits) verifyTransactionLimits(txn.transaction);
 
         let [response, error] = await Fetch.sendZkapp(txn.toJSON());
         let errors: string[] = [];

--- a/src/lib/mina/transaction.test.ts
+++ b/src/lib/mina/transaction.test.ts
@@ -59,8 +59,6 @@ describe('Test default network', () => {
       accountUpdateBob.account.balance.requireEquals(UInt64.zero);
       accountUpdateBob.balance.addInPlace(UInt64.one);
     });
-    console.log("Simple account update", txn.toPretty());
-    console.log("Simple account update", txn.transaction.accountUpdates.length);
     await txn.prove();
     await txn.sign([bobKey]).safeSend();
 
@@ -75,8 +73,6 @@ describe('Test default network', () => {
         accountUpdateBob.balance.addInPlace(UInt64.one);
       }
     });
-    console.log("Multiple account update", txn.toPretty());
-    console.log("Multiple account update", txn.transaction.accountUpdates.length);
     await txn.prove();
     await txn.sign([bobKey]).safeSend();
 
@@ -91,9 +87,8 @@ describe('Test default network', () => {
         accountUpdateBob.balance.addInPlace(UInt64.one);
       }
     });
-    console.log("More than limit account update", txn.toPretty());
-    console.log("More than limit account update", txn.transaction.accountUpdates.length);
     await txn.prove();
+    // failure with default enforceTransactionLimits
     await expect(txn.sign([bobKey]).safeSend()).rejects.toThrow();
   });
 });
@@ -117,8 +112,6 @@ describe('Test enforced network', () => {
       accountUpdateBob.account.balance.requireEquals(UInt64.zero);
       accountUpdateBob.balance.addInPlace(UInt64.one);
     });
-    console.log("Simple account update", txn.toPretty());
-    console.log("Simple account update", txn.transaction.accountUpdates.length);
     await txn.prove();
     await txn.sign([bobKey]).safeSend();
 
@@ -133,8 +126,6 @@ describe('Test enforced network', () => {
         accountUpdateBob.balance.addInPlace(UInt64.one);
       }
     });
-    console.log("Multiple account update", txn.toPretty());
-    console.log("Multiple account update", txn.transaction.accountUpdates.length);
     await txn.prove();
     await txn.sign([bobKey]).safeSend();
 
@@ -149,9 +140,8 @@ describe('Test enforced network', () => {
         accountUpdateBob.balance.addInPlace(UInt64.one);
       }
     });
-    console.log("More than limit account update", txn.toPretty());
-    console.log("More than limit account update", txn.transaction.accountUpdates.length);
     await txn.prove();
+    // failure with enforceTransactionLimits = true
     await expect(txn.sign([bobKey]).safeSend()).rejects.toThrow();
   });
 });
@@ -175,8 +165,6 @@ describe('Test unlimited network', () => {
       accountUpdateBob.account.balance.requireEquals(UInt64.zero);
       accountUpdateBob.balance.addInPlace(UInt64.one);
     });
-    console.log("Simple account update", txn.toPretty());
-    console.log("Simple account update", txn.transaction.accountUpdates.length);
     await txn.prove();
     await txn.sign([bobKey]).safeSend();
 
@@ -191,8 +179,6 @@ describe('Test unlimited network', () => {
         accountUpdateBob.balance.addInPlace(UInt64.one);
       }
     });
-    console.log("Multiple account update", txn.toPretty());
-    console.log("Multiple account update", txn.transaction.accountUpdates.length);
     await txn.prove();
     await txn.sign([bobKey]).safeSend();
 
@@ -207,9 +193,8 @@ describe('Test unlimited network', () => {
         accountUpdateBob.balance.addInPlace(UInt64.one);
       }
     });
-    console.log("More than limit account update", txn.toPretty());
-    console.log("More than limit account update", txn.transaction.accountUpdates.length);
     await txn.prove();
+    // success with enforceTransactionLimits = false
     await txn.sign([bobKey]).safeSend();
   });
 });

--- a/src/lib/mina/transaction.test.ts
+++ b/src/lib/mina/transaction.test.ts
@@ -1,0 +1,215 @@
+import {
+  State,
+  state,
+  UInt64,
+  Bool,
+  SmartContract,
+  Mina,
+  AccountUpdate,
+  method,
+  PublicKey,
+  Permissions,
+  VerificationKey,
+  Field,
+  Int64,
+  TokenId,
+  TokenContract as TokenContractBase,
+  AccountUpdateForest,
+  PrivateKey,
+} from 'o1js';
+
+
+
+const defaultNetwork = Mina.Network({
+  networkId: "testnet",
+  mina: "https://example.com/graphql",
+  archive: "https://example.com//graphql"
+});
+
+const enforcedNetwork = Mina.Network({
+  networkId: "testnet",
+  mina: "https://example.com/graphql",
+  archive: "https://example.com//graphql",
+  enforceTransactionLimits: true
+});
+
+const unlimitedNetwork = Mina.Network({
+  networkId: "testnet",
+  mina: "https://unlimited.com/graphql",
+  archive: "https://unlimited.com//graphql",
+  enforceTransactionLimits: false
+});
+
+describe('Test default network', () => {
+  let bobAccount: PublicKey,
+    bobKey: PrivateKey;
+
+  beforeAll(async () => {
+
+    Mina.setActiveInstance(defaultNetwork);
+    bobKey = PrivateKey.random();
+    bobAccount = bobKey.toPublicKey();
+  });
+
+
+  it('Simple account update', async () => {
+
+    let txn = await Mina.transaction(async () => {
+      const accountUpdateBob = AccountUpdate.create(bobAccount, Field.from(1));
+      accountUpdateBob.account.balance.requireEquals(UInt64.zero);
+      accountUpdateBob.balance.addInPlace(UInt64.one);
+    });
+    console.log("Simple account update", txn.toPretty());
+    console.log("Simple account update", txn.transaction.accountUpdates.length);
+    await txn.prove();
+    await txn.sign([bobKey]).safeSend();
+
+  });
+
+  it('Multiple account update', async () => {
+
+    let txn = await Mina.transaction(async () => {
+      for (let index = 0; index < 2; index++) {
+        const accountUpdateBob = AccountUpdate.create(bobAccount, Field.from(index));
+        accountUpdateBob.account.balance.requireEquals(UInt64.zero);
+        accountUpdateBob.balance.addInPlace(UInt64.one);
+      }
+    });
+    console.log("Multiple account update", txn.toPretty());
+    console.log("Multiple account update", txn.transaction.accountUpdates.length);
+    await txn.prove();
+    await txn.sign([bobKey]).safeSend();
+
+  });
+
+  it('More than limit account update', async () => {
+
+    let txn = await Mina.transaction(async () => {
+      for (let index = 0; index < 12; index++) {
+        const accountUpdateBob = AccountUpdate.create(bobAccount, Field.from(index));
+        accountUpdateBob.account.balance.requireEquals(UInt64.zero);
+        accountUpdateBob.balance.addInPlace(UInt64.one);
+      }
+    });
+    console.log("More than limit account update", txn.toPretty());
+    console.log("More than limit account update", txn.transaction.accountUpdates.length);
+    await txn.prove();
+    await expect(txn.sign([bobKey]).safeSend()).rejects.toThrow();
+  });
+});
+
+describe('Test enforced network', () => {
+  let bobAccount: PublicKey,
+    bobKey: PrivateKey;
+
+  beforeAll(async () => {
+
+    Mina.setActiveInstance(enforcedNetwork);
+    bobKey = PrivateKey.random();
+    bobAccount = bobKey.toPublicKey();
+  });
+
+
+  it('Simple account update', async () => {
+
+    let txn = await Mina.transaction(async () => {
+      const accountUpdateBob = AccountUpdate.create(bobAccount, Field.from(1));
+      accountUpdateBob.account.balance.requireEquals(UInt64.zero);
+      accountUpdateBob.balance.addInPlace(UInt64.one);
+    });
+    console.log("Simple account update", txn.toPretty());
+    console.log("Simple account update", txn.transaction.accountUpdates.length);
+    await txn.prove();
+    await txn.sign([bobKey]).safeSend();
+
+  });
+
+  it('Multiple account update', async () => {
+
+    let txn = await Mina.transaction(async () => {
+      for (let index = 0; index < 2; index++) {
+        const accountUpdateBob = AccountUpdate.create(bobAccount, Field.from(index));
+        accountUpdateBob.account.balance.requireEquals(UInt64.zero);
+        accountUpdateBob.balance.addInPlace(UInt64.one);
+      }
+    });
+    console.log("Multiple account update", txn.toPretty());
+    console.log("Multiple account update", txn.transaction.accountUpdates.length);
+    await txn.prove();
+    await txn.sign([bobKey]).safeSend();
+
+  });
+
+  it('More than limit account update', async () => {
+
+    let txn = await Mina.transaction(async () => {
+      for (let index = 0; index < 12; index++) {
+        const accountUpdateBob = AccountUpdate.create(bobAccount, Field.from(index));
+        accountUpdateBob.account.balance.requireEquals(UInt64.zero);
+        accountUpdateBob.balance.addInPlace(UInt64.one);
+      }
+    });
+    console.log("More than limit account update", txn.toPretty());
+    console.log("More than limit account update", txn.transaction.accountUpdates.length);
+    await txn.prove();
+    await expect(txn.sign([bobKey]).safeSend()).rejects.toThrow();
+  });
+});
+
+describe('Test unlimited network', () => {
+  let bobAccount: PublicKey,
+    bobKey: PrivateKey;
+
+  beforeAll(async () => {
+
+    Mina.setActiveInstance(unlimitedNetwork);
+    bobKey = PrivateKey.random();
+    bobAccount = bobKey.toPublicKey();
+  });
+
+
+  it('Simple account update', async () => {
+
+    let txn = await Mina.transaction(async () => {
+      const accountUpdateBob = AccountUpdate.create(bobAccount, Field.from(1));
+      accountUpdateBob.account.balance.requireEquals(UInt64.zero);
+      accountUpdateBob.balance.addInPlace(UInt64.one);
+    });
+    console.log("Simple account update", txn.toPretty());
+    console.log("Simple account update", txn.transaction.accountUpdates.length);
+    await txn.prove();
+    await txn.sign([bobKey]).safeSend();
+
+  });
+
+  it('Multiple account update', async () => {
+
+    let txn = await Mina.transaction(async () => {
+      for (let index = 0; index < 2; index++) {
+        const accountUpdateBob = AccountUpdate.create(bobAccount, Field.from(index));
+        accountUpdateBob.account.balance.requireEquals(UInt64.zero);
+        accountUpdateBob.balance.addInPlace(UInt64.one);
+      }
+    });
+    console.log("Multiple account update", txn.toPretty());
+    console.log("Multiple account update", txn.transaction.accountUpdates.length);
+    await txn.prove();
+    await txn.sign([bobKey]).safeSend();
+
+  });
+
+  it('More than limit account update', async () => {
+
+    let txn = await Mina.transaction(async () => {
+      for (let index = 0; index < 12; index++) {
+        const accountUpdateBob = AccountUpdate.create(bobAccount, Field.from(index));
+        accountUpdateBob.account.balance.requireEquals(UInt64.zero);
+        accountUpdateBob.balance.addInPlace(UInt64.one);
+      }
+    });
+    console.log("More than limit account update", txn.toPretty());
+    console.log("More than limit account update", txn.transaction.accountUpdates.length);
+    await txn.prove();
+    await txn.sign([bobKey]).safeSend();
+  });
+});


### PR DESCRIPTION
Some blockchain like zeko are not limited by account update, to enable transaction creation for these blockchains, I've added a new parameter to the network property `enforceTransactionLimits` as for local blockchain.

Resolve #1910
