### PR TITLE
[easy] Fix typo in rangeCheck16 error message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,8 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 - Compiling stuck in the browser for recursive zkprograms https://github.com/o1-labs/o1js/pull/1906
 
+- Error message in `rangeCheck16` gadget https://github.com/o1-labs/o1js/pull/1920
+
 ## [2.1.0](https://github.com/o1-labs/o1js/compare/b04520d...e1bac02) - 2024-11-13
 
 ### Added

--- a/src/lib/provable/gadgets/range-check.ts
+++ b/src/lib/provable/gadgets/range-check.ts
@@ -332,7 +332,7 @@ function rangeCheck16(x: Field) {
   if (x.isConstant()) {
     assert(
       x.toBigInt() < 1n << 16n,
-      `rangeCheck16: expected field to fit in 8 bits, got ${x}`
+      `rangeCheck16: expected field to fit in 16 bits, got ${x}`
     );
     return;
   }


### PR DESCRIPTION
Pointed out in https://github.com/o1-labs/o1js/pull/1848, creating a separate PR for it for a faster merge of the changes.