### PR TITLE
[easy] Added `zip` and `pad` functionalities for arrays

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,8 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 - Support secp256r1 in elliptic curve and ECDSA gadgets https://github.com/o1-labs/o1js/pull/1885
 
+- Provide `zip` and `pad` for the array utility https://github.com/o1-labs/o1js/pull/1921
+
 ### Fixed
 
 - Witness generation error in `Gadgets.arrayGet()` when accessing out-of-bounds indices https://github.com/o1-labs/o1js/pull/1886

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,10 +21,6 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 - Compiling stuck in the browser for recursive zkprograms https://github.com/o1-labs/o1js/pull/1906
 
-### Added
-
-- Provide `zip` and `pad` for the array utility https://github.com/o1-labs/o1js/pull/1921
-
 ## [2.1.0](https://github.com/o1-labs/o1js/compare/b04520d...e1bac02) - 2024-11-13
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,13 +21,15 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 - Compiling stuck in the browser for recursive zkprograms https://github.com/o1-labs/o1js/pull/1906
 
+### Added
+
+- Provide `zip` and `pad` for the array utility https://github.com/o1-labs/o1js/pull/1921
+
 ## [2.1.0](https://github.com/o1-labs/o1js/compare/b04520d...e1bac02) - 2024-11-13
 
 ### Added
 
 - Support secp256r1 in elliptic curve and ECDSA gadgets https://github.com/o1-labs/o1js/pull/1885
-
-- Provide `zip` and `pad` for the array utility https://github.com/o1-labs/o1js/pull/1921
 
 ### Fixed
 

--- a/src/lib/util/arrays.ts
+++ b/src/lib/util/arrays.ts
@@ -1,9 +1,12 @@
 import { assert } from './errors.js';
 
-export { chunk, chunkString };
+export { chunk, chunkString, zip, pad };
 
 function chunk<T>(array: T[], size: number): T[][] {
-  assert(array.length % size === 0, 'invalid input length');
+  assert(
+    array.length % size === 0,
+    'chunk(): invalid input length, it must be a multiple of ${size}'
+  );
   return Array.from({ length: array.length / size }, (_, i) =>
     array.slice(size * i, size * (i + 1))
   );
@@ -11,4 +14,17 @@ function chunk<T>(array: T[], size: number): T[][] {
 
 function chunkString(str: string, size: number): string[] {
   return chunk([...str], size).map((c) => c.join(''));
+}
+
+function zip<T, S>(a: T[], b: S[]) {
+  assert(a.length === b.length, 'zip(): arrays of unequal length');
+  return a.map((a, i): [T, S] => [a, b[i]!]);
+}
+
+function pad<T>(array: T[], size: number, value: T): T[] {
+  assert(
+    array.length <= size,
+    `target size ${size} should be greater or equal than the length of the array ${array.length}`
+  );
+  return array.concat(Array.from({ length: size - array.length }, () => value));
 }

--- a/src/lib/util/arrays.ts
+++ b/src/lib/util/arrays.ts
@@ -17,7 +17,10 @@ function chunkString(str: string, size: number): string[] {
 }
 
 function zip<T, S>(a: T[], b: S[]) {
-  assert(a.length === b.length, 'zip(): arrays of unequal length');
+  assert(
+    a.length <= b.length,
+    'zip(): first array must be at least as long as the second array'
+  );
   return a.map((a, i): [T, S] => [a, b[i]!]);
 }
 

--- a/src/lib/util/arrays.ts
+++ b/src/lib/util/arrays.ts
@@ -19,7 +19,7 @@ function chunkString(str: string, size: number): string[] {
 function zip<T, S>(a: T[], b: S[]) {
   assert(
     a.length <= b.length,
-    'zip(): first array must be at least as long as the second array'
+    'zip(): second array must be at least as long as the first array'
   );
   return a.map((a, i): [T, S] => [a, b[i]!]);
 }


### PR DESCRIPTION
Introduced in https://github.com/o1-labs/o1js/pull/1848, creating a separate PR to facilitate the change earlier.