### PR TITLE
[easy] Add assertNone method for options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,10 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 - Compiling stuck in the browser for recursive zkprograms https://github.com/o1-labs/o1js/pull/1906
 
+### Added
+
+- Method for optional types to assert none https://github.com/o1-labs/o1js/pull/1922
+
 ## [2.1.0](https://github.com/o1-labs/o1js/compare/b04520d...e1bac02) - 2024-11-13
 
 ### Added

--- a/src/lib/provable/option.ts
+++ b/src/lib/provable/option.ts
@@ -9,7 +9,7 @@ export { Option, OptionOrValue };
 
 type Option<T, V = any> = { isSome: Bool; value: T } & {
   assertSome(message?: string): T;
-  assertNone(): void;
+  assertNone(message?: string): void;
   orElse(defaultValue: T | V): T;
 };
 
@@ -105,8 +105,8 @@ function Option<A extends ProvableType>(
       return this.value;
     }
 
-    assertNone(): void {
-      this.isSome.assertFalse();
+    assertNone(message?: string): void {
+      this.isSome.assertFalse(message);
     }
 
     static from(value?: V | T) {

--- a/src/lib/provable/option.ts
+++ b/src/lib/provable/option.ts
@@ -9,6 +9,7 @@ export { Option, OptionOrValue };
 
 type Option<T, V = any> = { isSome: Bool; value: T } & {
   assertSome(message?: string): T;
+  assertNone(): void;
   orElse(defaultValue: T | V): T;
 };
 
@@ -102,6 +103,10 @@ function Option<A extends ProvableType>(
     assertSome(message?: string): T {
       this.isSome.assertTrue(message);
       return this.value;
+    }
+
+    assertNone(): void {
+      this.isSome.assertFalse();
     }
 
     static from(value?: V | T) {


### PR DESCRIPTION
Added in https://github.com/o1-labs/o1js/pull/1848, creating a separate PR to facilitate the change earlier