### PR TITLE
Build bindings in a nix derivation

### DIFF
--- a/.github/workflows/build-bindings.yml
+++ b/.github/workflows/build-bindings.yml
@@ -32,7 +32,6 @@ jobs:
           cd src/bindings
           git diff --exit-code
       - name: add build to gc-root if on main
-        # enabeling on this branch for 1 commit to test it
         if: github.ref == 'refs/heads/main'
         run: |
           nix build o1js#o1js-bindings --out-link /home/app/actions-runner/nix-cache/main-bindings-gcroot

--- a/.github/workflows/build-bindings.yml
+++ b/.github/workflows/build-bindings.yml
@@ -32,9 +32,10 @@ jobs:
           cd src/bindings
           git diff --exit-code
       - name: add build to gc-root if on main
-        if: github.ref == 'refs/heads/main'
+        # enabeling on this branch for 1 commit to test it
+        #if: github.ref == 'refs/heads/main'
         run: |
-          nix build o1js#o1js-bindings --out-link /var/o1js-bindings-gcroot
+          nix build o1js#o1js-bindings --out-link /home/app/actions-runner/nix-cache/main-bindings-gcroot
       - name: Cleanup the Nix store
         run: |
           nix-store --gc --print-dead

--- a/.github/workflows/build-bindings.yml
+++ b/.github/workflows/build-bindings.yml
@@ -33,7 +33,7 @@ jobs:
           git diff --exit-code
       - name: add build to gc-root if on main
         # enabeling on this branch for 1 commit to test it
-        #if: github.ref == 'refs/heads/main'
+        if: github.ref == 'refs/heads/main'
         run: |
           nix build o1js#o1js-bindings --out-link /home/app/actions-runner/nix-cache/main-bindings-gcroot
       - name: Cleanup the Nix store

--- a/.github/workflows/build-bindings.yml
+++ b/.github/workflows/build-bindings.yml
@@ -27,7 +27,7 @@ jobs:
         run: |
           set -Eeu
           ./pin.sh
-          nix run o1js#update-bindings
+          nix run o1js#update-bindings --max-jobs 4
           #fail if this changes any files
           cd src/bindings
           git diff-index --exit-code HEAD || (git submodule foreach git diff && exit 1)

--- a/.github/workflows/build-bindings.yml
+++ b/.github/workflows/build-bindings.yml
@@ -28,6 +28,8 @@ jobs:
           set -Eeu
           ./pin.sh
           nix run o1js#update-bindings
+          #fail if this changes any files
+          git -C src/bindings diff-index --exit-code HEAD
       - name: Cleanup the Nix store
         run: |
           nix-env --delete-generations old

--- a/.github/workflows/build-bindings.yml
+++ b/.github/workflows/build-bindings.yml
@@ -29,7 +29,8 @@ jobs:
           ./pin.sh
           nix run o1js#update-bindings
           #fail if this changes any files
-          git -C src/bindings diff-index --exit-code HEAD
+          cd src/bindings
+          git diff-index --exit-code HEAD || (git submodule foreach git diff && exit 1)
       - name: Cleanup the Nix store
         run: |
           nix-env --delete-generations old

--- a/.github/workflows/build-bindings.yml
+++ b/.github/workflows/build-bindings.yml
@@ -30,7 +30,7 @@ jobs:
           nix run o1js#update-bindings --max-jobs 4
           #fail if this changes any files
           cd src/bindings
-          git diff-index --exit-code HEAD || (git submodule foreach git diff && exit 1)
+          git diff --exit-code
       - name: Cleanup the Nix store
         run: |
           nix-env --delete-generations old

--- a/.github/workflows/build-bindings.yml
+++ b/.github/workflows/build-bindings.yml
@@ -1,4 +1,4 @@
-# Purpose: We want to build the o1js bindings in CI so that people in the 
+# Purpose: We want to build the o1js bindings in CI so that people in the
 # community can change them without being scared of breaking things, or
 # needing to do the complicated (without nix) build setup.
 
@@ -7,7 +7,7 @@ name: Build o1js bindings
 on:
   pull_request:
 
-jobs:  
+jobs:
   nix-build:
     name: build-bindings-ubuntu
     runs-on: [sdk-self-hosted-linux-amd64-build-system]
@@ -22,4 +22,4 @@ jobs:
           # Until we restart the runner and the PATH gets updated from /etc/bash.bashrc
           export PATH="$PATH":/nix/var/nix/profiles/default/bin
           ./pin.sh
-          nix develop o1js --command bash -c "npm run build:update-bindings"
+          nix run o1js#update-bindings

--- a/.github/workflows/build-bindings.yml
+++ b/.github/workflows/build-bindings.yml
@@ -31,9 +31,11 @@ jobs:
           #fail if this changes any files
           cd src/bindings
           git diff --exit-code
+      - name: add build to gc-root if on main
+        if: github.ref == 'refs/heads/main'
+        run: |
+          nix build o1js#o1js-bindings --out-link /var/o1js-bindings-gcroot
       - name: Cleanup the Nix store
         run: |
-          nix-env --delete-generations old
-          nix-collect-garbage -d --quiet
           nix-store --gc --print-dead
           nix-store --optimise

--- a/flake.lock
+++ b/flake.lock
@@ -265,8 +265,8 @@
         "utils": "utils"
       },
       "locked": {
-        "lastModified": 1733261591,
-        "narHash": "sha256-1gbcNmug8xmcWM6QEUA3BkgSVWIpjAiT8SouiEu6gQg=",
+        "lastModified": 1733421256,
+        "narHash": "sha256-X7sT6cQ7X2V5A/Q8FOnc0pDP24gca/FOMszeWRiC2mM=",
         "path": "src/mina",
         "type": "path"
       },

--- a/flake.lock
+++ b/flake.lock
@@ -265,8 +265,8 @@
         "utils": "utils"
       },
       "locked": {
-        "lastModified": 1733427826,
-        "narHash": "sha256-geJjdLW0yIjrYdgTECVWx4yDuFA6/4YDqncVQQ5e1ac=",
+        "lastModified": 1733429866,
+        "narHash": "sha256-/ZEGYdZ2hLjBwdEzG/BIjlDehOjuGWmBqzD55nXfZoY=",
         "path": "src/mina",
         "type": "path"
       },

--- a/flake.lock
+++ b/flake.lock
@@ -265,8 +265,8 @@
         "utils": "utils"
       },
       "locked": {
-        "lastModified": 1732222139,
-        "narHash": "sha256-4LLy5VMM5TK4LpQXEBiA8ziwYyqGx2ZAuunXGCDpraQ=",
+        "lastModified": 1733261591,
+        "narHash": "sha256-1gbcNmug8xmcWM6QEUA3BkgSVWIpjAiT8SouiEu6gQg=",
         "path": "src/mina",
         "type": "path"
       },

--- a/flake.lock
+++ b/flake.lock
@@ -265,8 +265,8 @@
         "utils": "utils"
       },
       "locked": {
-        "lastModified": 1733421256,
-        "narHash": "sha256-X7sT6cQ7X2V5A/Q8FOnc0pDP24gca/FOMszeWRiC2mM=",
+        "lastModified": 1733427826,
+        "narHash": "sha256-geJjdLW0yIjrYdgTECVWx4yDuFA6/4YDqncVQQ5e1ac=",
         "path": "src/mina",
         "type": "path"
       },

--- a/flake.lock
+++ b/flake.lock
@@ -48,6 +48,31 @@
         "type": "github"
       }
     },
+    "describe-dune_3": {
+      "inputs": {
+        "flake-utils": [
+          "mina-rev",
+          "utils"
+        ],
+        "nixpkgs": [
+          "mina-rev",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1724407960,
+        "narHash": "sha256-pUKTVMYEtsD1AGlHFTdPourowt+tJ3htKhRu7VALFzc=",
+        "owner": "o1-labs",
+        "repo": "describe-dune",
+        "rev": "be828239c05671209e979f9d5c2e3094e3be7a46",
+        "type": "github"
+      },
+      "original": {
+        "owner": "o1-labs",
+        "repo": "describe-dune",
+        "type": "github"
+      }
+    },
     "dune-nix": {
       "inputs": {
         "flake-utils": [
@@ -96,9 +121,52 @@
         "type": "github"
       }
     },
+    "dune-nix_3": {
+      "inputs": {
+        "flake-utils": [
+          "mina-rev",
+          "utils"
+        ],
+        "nixpkgs": [
+          "mina-rev",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1724418497,
+        "narHash": "sha256-HjTh7o02QhGXmbxmpE5HRWei3H/pyh/NKCMCnucDaYs=",
+        "owner": "o1-labs",
+        "repo": "dune-nix",
+        "rev": "26dc164a4c3976888e13eabd73a210b78505820f",
+        "type": "github"
+      },
+      "original": {
+        "owner": "o1-labs",
+        "repo": "dune-nix",
+        "type": "github"
+      }
+    },
     "flake-buildkite-pipeline": {
       "inputs": {
         "nixpkgs-lib": "nixpkgs-lib"
+      },
+      "locked": {
+        "lastModified": 1665561509,
+        "narHash": "sha256-+9KQw0ftpNjezYwbUIcLAvDWekuGSBAs8I2XulcUkT4=",
+        "owner": "tweag",
+        "repo": "flake-buildkite-pipeline",
+        "rev": "c836a5a449973dd04a80f6741863ceb43ec414c9",
+        "type": "github"
+      },
+      "original": {
+        "owner": "tweag",
+        "repo": "flake-buildkite-pipeline",
+        "type": "github"
+      }
+    },
+    "flake-buildkite-pipeline_2": {
+      "inputs": {
+        "nixpkgs-lib": "nixpkgs-lib_2"
       },
       "locked": {
         "lastModified": 1665561509,
@@ -131,6 +199,38 @@
       }
     },
     "flake-compat_2": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1627913399,
+        "narHash": "sha256-hY8g6H2KFL8ownSiFeMOjwPC8P0ueXpCVEbxgda3pko=",
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "rev": "12c64ca55c1014cdc1b16ed5a804aa8576601ff2",
+        "type": "github"
+      },
+      "original": {
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "type": "github"
+      }
+    },
+    "flake-compat_3": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1668681692,
+        "narHash": "sha256-Ht91NGdewz8IQLtWZ9LCeNXMSXHUss+9COoqu6JLmXU=",
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "rev": "009399224d5e398d03b22badca40a37ac85412a1",
+        "type": "github"
+      },
+      "original": {
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "type": "github"
+      }
+    },
+    "flake-compat_4": {
       "flake": false,
       "locked": {
         "lastModified": 1627913399,
@@ -209,7 +309,67 @@
         "type": "github"
       }
     },
+    "flake-utils_5": {
+      "locked": {
+        "lastModified": 1623875721,
+        "narHash": "sha256-A8BU7bjS5GirpAUv4QA+QnJ4CceLHkcXdRp4xITDB0s=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "f7e004a55b120c02ecb6219596820fcd32ca8772",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "flake-utils_6": {
+      "locked": {
+        "lastModified": 1638122382,
+        "narHash": "sha256-sQzZzAbvKEqN9s0bzWuYmRaA03v40gaJ4+iL1LXjaeI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "74f7e4319258e287b0f9cb95426c9853b282730b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "flake-utils_7": {
+      "locked": {
+        "lastModified": 1644229661,
+        "narHash": "sha256-1YdnJAsNy69bpcjuoKdOYQX0YxZBiCYZo4Twxerqv7k=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "3cecb5b042f7f209c56ffd8371b2711a290ec797",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
     "flockenzeit": {
+      "locked": {
+        "lastModified": 1671184471,
+        "narHash": "sha256-oTsIo40BxHG8ZcMNwJybV68F8CLNdfY9HKFzEBzeJ6A=",
+        "owner": "balsoft",
+        "repo": "Flockenzeit",
+        "rev": "0409dcd0cc87feebd211c529171d61b89f10d9b3",
+        "type": "github"
+      },
+      "original": {
+        "owner": "balsoft",
+        "repo": "Flockenzeit",
+        "type": "github"
+      }
+    },
+    "flockenzeit_2": {
       "locked": {
         "lastModified": 1671184471,
         "narHash": "sha256-oTsIo40BxHG8ZcMNwJybV68F8CLNdfY9HKFzEBzeJ6A=",
@@ -228,6 +388,27 @@
       "inputs": {
         "nixpkgs": [
           "mina",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1660459072,
+        "narHash": "sha256-8DFJjXG8zqoONA1vXtgeKXy68KdJL5UaXR8NtVMUbx8=",
+        "owner": "hercules-ci",
+        "repo": "gitignore.nix",
+        "rev": "a20de23b925fd8264fd7fad6454652e142fd7f73",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hercules-ci",
+        "repo": "gitignore.nix",
+        "type": "github"
+      }
+    },
+    "gitignore-nix_2": {
+      "inputs": {
+        "nixpkgs": [
+          "mina-rev",
           "nixpkgs"
         ]
       },
@@ -265,8 +446,8 @@
         "utils": "utils"
       },
       "locked": {
-        "lastModified": 1731611028,
-        "narHash": "sha256-sehBPO+H9mtShGb3KNhdDVHj0pogt/tmiL9tc2ICkaU=",
+        "lastModified": 1732222139,
+        "narHash": "sha256-4LLy5VMM5TK4LpQXEBiA8ziwYyqGx2ZAuunXGCDpraQ=",
         "path": "src/mina",
         "type": "path"
       },
@@ -275,7 +456,55 @@
         "type": "path"
       }
     },
+    "mina-rev": {
+      "inputs": {
+        "describe-dune": "describe-dune_3",
+        "dune-nix": "dune-nix_3",
+        "flake-buildkite-pipeline": "flake-buildkite-pipeline_2",
+        "flake-compat": "flake-compat_3",
+        "flockenzeit": "flockenzeit_2",
+        "gitignore-nix": "gitignore-nix_2",
+        "mix-to-nix": "mix-to-nix_2",
+        "nix-filter": "nix-filter_2",
+        "nix-npm-buildPackage": "nix-npm-buildPackage_2",
+        "nix-utils": "nix-utils_2",
+        "nixpkgs": "nixpkgs_4",
+        "nixpkgs-mozilla": "nixpkgs-mozilla_2",
+        "o1-opam-repository": "o1-opam-repository_2",
+        "opam-nix": "opam-nix_2",
+        "opam-repository": "opam-repository_2",
+        "utils": "utils_2"
+      },
+      "locked": {
+        "lastModified": 1729507624,
+        "narHash": "sha256-DudL1W06R1K0HYyetAVZSzao5B5fjS/rS6cMfCBhiqE=",
+        "rev": "6899054b745c1323b9d5bcaa62c00bed2ad1ead3",
+        "revCount": 32900,
+        "type": "git",
+        "url": "file:src/mina"
+      },
+      "original": {
+        "type": "git",
+        "url": "file:src/mina"
+      }
+    },
     "mirage-opam-overlays": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1661959605,
+        "narHash": "sha256-CPTuhYML3F4J58flfp3ZbMNhkRkVFKmBEYBZY5tnQwA=",
+        "owner": "dune-universe",
+        "repo": "mirage-opam-overlays",
+        "rev": "05f1c1823d891ce4d8adab91f5db3ac51d86dc0b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "dune-universe",
+        "repo": "mirage-opam-overlays",
+        "type": "github"
+      }
+    },
+    "mirage-opam-overlays_2": {
       "flake": false,
       "locked": {
         "lastModified": 1661959605,
@@ -306,7 +535,37 @@
         "type": "github"
       }
     },
+    "mix-to-nix_2": {
+      "locked": {
+        "lastModified": 1643291492,
+        "narHash": "sha256-B+VIFF8qDJhF5hVMc8PbY/WPzUtbGgjsV1eAxTt5GuQ=",
+        "owner": "serokell",
+        "repo": "mix-to-nix",
+        "rev": "f6f0172b3ac4d32c0e6050a7d805734de0b7adef",
+        "type": "github"
+      },
+      "original": {
+        "owner": "serokell",
+        "repo": "mix-to-nix",
+        "type": "github"
+      }
+    },
     "nix-filter": {
+      "locked": {
+        "lastModified": 1666547822,
+        "narHash": "sha256-razwnAybPHyoAyhkKCwXdxihIqJi1G6e1XP4FQOJTEs=",
+        "owner": "numtide",
+        "repo": "nix-filter",
+        "rev": "1a3b735e13e90a8d2fd5629f2f8363bd7ffbbec7",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "nix-filter",
+        "type": "github"
+      }
+    },
+    "nix-filter_2": {
       "locked": {
         "lastModified": 1666547822,
         "narHash": "sha256-razwnAybPHyoAyhkKCwXdxihIqJi1G6e1XP4FQOJTEs=",
@@ -325,6 +584,27 @@
       "inputs": {
         "nixpkgs": [
           "mina",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1670813451,
+        "narHash": "sha256-v0IvQ35CMKtPreGlxWb1FvFUraJNZd144+MbiDwGoAA=",
+        "owner": "serokell",
+        "repo": "nix-npm-buildpackage",
+        "rev": "ec0365cd14a3359a23b80a9e2531a09afc3488fc",
+        "type": "github"
+      },
+      "original": {
+        "owner": "serokell",
+        "repo": "nix-npm-buildpackage",
+        "type": "github"
+      }
+    },
+    "nix-npm-buildPackage_2": {
+      "inputs": {
+        "nixpkgs": [
+          "mina-rev",
           "nixpkgs"
         ]
       },
@@ -361,6 +641,25 @@
         "type": "github"
       }
     },
+    "nix-utils_2": {
+      "inputs": {
+        "flake-utils": "flake-utils_5",
+        "nixpkgs": "nixpkgs_3"
+      },
+      "locked": {
+        "lastModified": 1632973430,
+        "narHash": "sha256-9G8zo+0nfYAALV5umCyQR/2hVUFNH10JropBkyxZGGw=",
+        "owner": "juliosueiras-nix",
+        "repo": "nix-utils",
+        "rev": "b44e1ffd726aa03056db9df469efb497d8b9871b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "juliosueiras-nix",
+        "repo": "nix-utils",
+        "type": "github"
+      }
+    },
     "nixpkgs": {
       "locked": {
         "lastModified": 1629252929,
@@ -377,6 +676,21 @@
       }
     },
     "nixpkgs-lib": {
+      "locked": {
+        "lastModified": 1649551420,
+        "narHash": "sha256-J/Pn38rBZTszdtTHhhxroQaHADhd5TgbJ53F9j1WTIE=",
+        "owner": "nix-community",
+        "repo": "nixpkgs.lib",
+        "rev": "3a16841c57b0d3025b21b869cc921a119ce73033",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "nixpkgs.lib",
+        "type": "github"
+      }
+    },
+    "nixpkgs-lib_2": {
       "locked": {
         "lastModified": 1649551420,
         "narHash": "sha256-J/Pn38rBZTszdtTHhhxroQaHADhd5TgbJ53F9j1WTIE=",
@@ -423,6 +737,22 @@
         "type": "github"
       }
     },
+    "nixpkgs-mozilla_3": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1704373101,
+        "narHash": "sha256-+gi59LRWRQmwROrmE1E2b3mtocwueCQqZ60CwLG+gbg=",
+        "owner": "mozilla",
+        "repo": "nixpkgs-mozilla",
+        "rev": "9b11a87c0cc54e308fa83aac5b4ee1816d5418a2",
+        "type": "github"
+      },
+      "original": {
+        "owner": "mozilla",
+        "repo": "nixpkgs-mozilla",
+        "type": "github"
+      }
+    },
     "nixpkgs_2": {
       "locked": {
         "lastModified": 1713180868,
@@ -441,6 +771,37 @@
     },
     "nixpkgs_3": {
       "locked": {
+        "lastModified": 1629252929,
+        "narHash": "sha256-Aj20gmGBs8TG7pyaQqgbsqAQ6cB+TVuL18Pk3DPBxcQ=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "3788c68def67ca7949e0864c27638d484389363d",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_4": {
+      "locked": {
+        "lastModified": 1713180868,
+        "narHash": "sha256-5CSnPSCEWeUmrFiLuYIQIPQzPrpCB8x3VhE+oXLRO3k=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "140546acf30a8212a03a88ded8506413fa3b5d21",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "nixos-23.11-small",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_5": {
+      "locked": {
         "lastModified": 1720535198,
         "narHash": "sha256-zwVvxrdIzralnSbcpghA92tWu2DV2lwv89xZc8MTrbg=",
         "owner": "nixos",
@@ -456,6 +817,22 @@
       }
     },
     "o1-opam-repository": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1715294616,
+        "narHash": "sha256-W2p9Vs8PqpKGvMByxVqpxAljjpEMqNcuNnjMBAAKicI=",
+        "owner": "o1-labs",
+        "repo": "opam-repository",
+        "rev": "38d6995e307c82b3c0b3bc86a867213db724d1c5",
+        "type": "github"
+      },
+      "original": {
+        "owner": "o1-labs",
+        "repo": "opam-repository",
+        "type": "github"
+      }
+    },
+    "o1-opam-repository_2": {
       "flake": false,
       "locked": {
         "lastModified": 1715294616,
@@ -501,6 +878,36 @@
         "type": "github"
       }
     },
+    "opam-nix_2": {
+      "inputs": {
+        "flake-compat": "flake-compat_4",
+        "flake-utils": "flake-utils_6",
+        "mirage-opam-overlays": "mirage-opam-overlays_2",
+        "nixpkgs": [
+          "mina-rev",
+          "nixpkgs"
+        ],
+        "opam-overlays": "opam-overlays_2",
+        "opam-repository": [
+          "mina-rev",
+          "opam-repository"
+        ],
+        "opam2json": "opam2json_2"
+      },
+      "locked": {
+        "lastModified": 1712645768,
+        "narHash": "sha256-9dUh8nElGtC74Q4gIDV6DM0FKgF1oXh0PUkCxdbp+sg=",
+        "owner": "tweag",
+        "repo": "opam-nix",
+        "rev": "464863fba44c7ecc50bd1a2967274482a2c33daf",
+        "type": "github"
+      },
+      "original": {
+        "owner": "tweag",
+        "repo": "opam-nix",
+        "type": "github"
+      }
+    },
     "opam-overlays": {
       "flake": false,
       "locked": {
@@ -517,7 +924,39 @@
         "type": "github"
       }
     },
+    "opam-overlays_2": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1654162756,
+        "narHash": "sha256-RV68fUK+O3zTx61iiHIoS0LvIk0E4voMp+0SwRg6G6c=",
+        "owner": "dune-universe",
+        "repo": "opam-overlays",
+        "rev": "c8f6ef0fc5272f254df4a971a47de7848cc1c8a4",
+        "type": "github"
+      },
+      "original": {
+        "owner": "dune-universe",
+        "repo": "opam-overlays",
+        "type": "github"
+      }
+    },
     "opam-repository": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1708601497,
+        "narHash": "sha256-mDYINTjOiYLN4wT5fGlWTvHFQdWkzY46XUuZWKgmJxY=",
+        "owner": "ocaml",
+        "repo": "opam-repository",
+        "rev": "90d8c520a4f0b035ac51e267a8b33739c5a78b5a",
+        "type": "github"
+      },
+      "original": {
+        "owner": "ocaml",
+        "repo": "opam-repository",
+        "type": "github"
+      }
+    },
+    "opam-repository_2": {
       "flake": false,
       "locked": {
         "lastModified": 1708601497,
@@ -555,14 +994,37 @@
         "type": "github"
       }
     },
+    "opam2json_2": {
+      "inputs": {
+        "nixpkgs": [
+          "mina-rev",
+          "opam-nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1671540003,
+        "narHash": "sha256-5pXfbUfpVABtKbii6aaI2EdAZTjHJ2QntEf0QD2O5AM=",
+        "owner": "tweag",
+        "repo": "opam2json",
+        "rev": "819d291ea95e271b0e6027679de6abb4d4f7f680",
+        "type": "github"
+      },
+      "original": {
+        "owner": "tweag",
+        "repo": "opam2json",
+        "type": "github"
+      }
+    },
     "root": {
       "inputs": {
         "describe-dune": "describe-dune",
         "dune-nix": "dune-nix",
         "flake-utils": "flake-utils",
         "mina": "mina",
-        "nixpkgs": "nixpkgs_3",
-        "nixpkgs-mozilla": "nixpkgs-mozilla_2"
+        "mina-rev": "mina-rev",
+        "nixpkgs": "nixpkgs_5",
+        "nixpkgs-mozilla": "nixpkgs-mozilla_3"
       }
     },
     "systems": {
@@ -583,6 +1045,24 @@
     "utils": {
       "inputs": {
         "flake-utils": "flake-utils_4"
+      },
+      "locked": {
+        "lastModified": 1657226504,
+        "narHash": "sha256-GIYNjuq4mJlFgqKsZ+YrgzWm0IpA4axA3MCrdKYj7gs=",
+        "owner": "gytis-ivaskevicius",
+        "repo": "flake-utils-plus",
+        "rev": "2bf0f91643c2e5ae38c1b26893ac2927ac9bd82a",
+        "type": "github"
+      },
+      "original": {
+        "owner": "gytis-ivaskevicius",
+        "repo": "flake-utils-plus",
+        "type": "github"
+      }
+    },
+    "utils_2": {
+      "inputs": {
+        "flake-utils": "flake-utils_7"
       },
       "locked": {
         "lastModified": 1657226504,

--- a/flake.lock
+++ b/flake.lock
@@ -48,31 +48,6 @@
         "type": "github"
       }
     },
-    "describe-dune_3": {
-      "inputs": {
-        "flake-utils": [
-          "mina-rev",
-          "utils"
-        ],
-        "nixpkgs": [
-          "mina-rev",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1724407960,
-        "narHash": "sha256-pUKTVMYEtsD1AGlHFTdPourowt+tJ3htKhRu7VALFzc=",
-        "owner": "o1-labs",
-        "repo": "describe-dune",
-        "rev": "be828239c05671209e979f9d5c2e3094e3be7a46",
-        "type": "github"
-      },
-      "original": {
-        "owner": "o1-labs",
-        "repo": "describe-dune",
-        "type": "github"
-      }
-    },
     "dune-nix": {
       "inputs": {
         "flake-utils": [
@@ -121,52 +96,9 @@
         "type": "github"
       }
     },
-    "dune-nix_3": {
-      "inputs": {
-        "flake-utils": [
-          "mina-rev",
-          "utils"
-        ],
-        "nixpkgs": [
-          "mina-rev",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1724418497,
-        "narHash": "sha256-HjTh7o02QhGXmbxmpE5HRWei3H/pyh/NKCMCnucDaYs=",
-        "owner": "o1-labs",
-        "repo": "dune-nix",
-        "rev": "26dc164a4c3976888e13eabd73a210b78505820f",
-        "type": "github"
-      },
-      "original": {
-        "owner": "o1-labs",
-        "repo": "dune-nix",
-        "type": "github"
-      }
-    },
     "flake-buildkite-pipeline": {
       "inputs": {
         "nixpkgs-lib": "nixpkgs-lib"
-      },
-      "locked": {
-        "lastModified": 1665561509,
-        "narHash": "sha256-+9KQw0ftpNjezYwbUIcLAvDWekuGSBAs8I2XulcUkT4=",
-        "owner": "tweag",
-        "repo": "flake-buildkite-pipeline",
-        "rev": "c836a5a449973dd04a80f6741863ceb43ec414c9",
-        "type": "github"
-      },
-      "original": {
-        "owner": "tweag",
-        "repo": "flake-buildkite-pipeline",
-        "type": "github"
-      }
-    },
-    "flake-buildkite-pipeline_2": {
-      "inputs": {
-        "nixpkgs-lib": "nixpkgs-lib_2"
       },
       "locked": {
         "lastModified": 1665561509,
@@ -199,38 +131,6 @@
       }
     },
     "flake-compat_2": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1627913399,
-        "narHash": "sha256-hY8g6H2KFL8ownSiFeMOjwPC8P0ueXpCVEbxgda3pko=",
-        "owner": "edolstra",
-        "repo": "flake-compat",
-        "rev": "12c64ca55c1014cdc1b16ed5a804aa8576601ff2",
-        "type": "github"
-      },
-      "original": {
-        "owner": "edolstra",
-        "repo": "flake-compat",
-        "type": "github"
-      }
-    },
-    "flake-compat_3": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1668681692,
-        "narHash": "sha256-Ht91NGdewz8IQLtWZ9LCeNXMSXHUss+9COoqu6JLmXU=",
-        "owner": "edolstra",
-        "repo": "flake-compat",
-        "rev": "009399224d5e398d03b22badca40a37ac85412a1",
-        "type": "github"
-      },
-      "original": {
-        "owner": "edolstra",
-        "repo": "flake-compat",
-        "type": "github"
-      }
-    },
-    "flake-compat_4": {
       "flake": false,
       "locked": {
         "lastModified": 1627913399,
@@ -309,67 +209,7 @@
         "type": "github"
       }
     },
-    "flake-utils_5": {
-      "locked": {
-        "lastModified": 1623875721,
-        "narHash": "sha256-A8BU7bjS5GirpAUv4QA+QnJ4CceLHkcXdRp4xITDB0s=",
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "rev": "f7e004a55b120c02ecb6219596820fcd32ca8772",
-        "type": "github"
-      },
-      "original": {
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "type": "github"
-      }
-    },
-    "flake-utils_6": {
-      "locked": {
-        "lastModified": 1638122382,
-        "narHash": "sha256-sQzZzAbvKEqN9s0bzWuYmRaA03v40gaJ4+iL1LXjaeI=",
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "rev": "74f7e4319258e287b0f9cb95426c9853b282730b",
-        "type": "github"
-      },
-      "original": {
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "type": "github"
-      }
-    },
-    "flake-utils_7": {
-      "locked": {
-        "lastModified": 1644229661,
-        "narHash": "sha256-1YdnJAsNy69bpcjuoKdOYQX0YxZBiCYZo4Twxerqv7k=",
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "rev": "3cecb5b042f7f209c56ffd8371b2711a290ec797",
-        "type": "github"
-      },
-      "original": {
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "type": "github"
-      }
-    },
     "flockenzeit": {
-      "locked": {
-        "lastModified": 1671184471,
-        "narHash": "sha256-oTsIo40BxHG8ZcMNwJybV68F8CLNdfY9HKFzEBzeJ6A=",
-        "owner": "balsoft",
-        "repo": "Flockenzeit",
-        "rev": "0409dcd0cc87feebd211c529171d61b89f10d9b3",
-        "type": "github"
-      },
-      "original": {
-        "owner": "balsoft",
-        "repo": "Flockenzeit",
-        "type": "github"
-      }
-    },
-    "flockenzeit_2": {
       "locked": {
         "lastModified": 1671184471,
         "narHash": "sha256-oTsIo40BxHG8ZcMNwJybV68F8CLNdfY9HKFzEBzeJ6A=",
@@ -388,27 +228,6 @@
       "inputs": {
         "nixpkgs": [
           "mina",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1660459072,
-        "narHash": "sha256-8DFJjXG8zqoONA1vXtgeKXy68KdJL5UaXR8NtVMUbx8=",
-        "owner": "hercules-ci",
-        "repo": "gitignore.nix",
-        "rev": "a20de23b925fd8264fd7fad6454652e142fd7f73",
-        "type": "github"
-      },
-      "original": {
-        "owner": "hercules-ci",
-        "repo": "gitignore.nix",
-        "type": "github"
-      }
-    },
-    "gitignore-nix_2": {
-      "inputs": {
-        "nixpkgs": [
-          "mina-rev",
           "nixpkgs"
         ]
       },
@@ -456,55 +275,7 @@
         "type": "path"
       }
     },
-    "mina-rev": {
-      "inputs": {
-        "describe-dune": "describe-dune_3",
-        "dune-nix": "dune-nix_3",
-        "flake-buildkite-pipeline": "flake-buildkite-pipeline_2",
-        "flake-compat": "flake-compat_3",
-        "flockenzeit": "flockenzeit_2",
-        "gitignore-nix": "gitignore-nix_2",
-        "mix-to-nix": "mix-to-nix_2",
-        "nix-filter": "nix-filter_2",
-        "nix-npm-buildPackage": "nix-npm-buildPackage_2",
-        "nix-utils": "nix-utils_2",
-        "nixpkgs": "nixpkgs_4",
-        "nixpkgs-mozilla": "nixpkgs-mozilla_2",
-        "o1-opam-repository": "o1-opam-repository_2",
-        "opam-nix": "opam-nix_2",
-        "opam-repository": "opam-repository_2",
-        "utils": "utils_2"
-      },
-      "locked": {
-        "lastModified": 1729507624,
-        "narHash": "sha256-DudL1W06R1K0HYyetAVZSzao5B5fjS/rS6cMfCBhiqE=",
-        "rev": "6899054b745c1323b9d5bcaa62c00bed2ad1ead3",
-        "revCount": 32900,
-        "type": "git",
-        "url": "file:src/mina"
-      },
-      "original": {
-        "type": "git",
-        "url": "file:src/mina"
-      }
-    },
     "mirage-opam-overlays": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1661959605,
-        "narHash": "sha256-CPTuhYML3F4J58flfp3ZbMNhkRkVFKmBEYBZY5tnQwA=",
-        "owner": "dune-universe",
-        "repo": "mirage-opam-overlays",
-        "rev": "05f1c1823d891ce4d8adab91f5db3ac51d86dc0b",
-        "type": "github"
-      },
-      "original": {
-        "owner": "dune-universe",
-        "repo": "mirage-opam-overlays",
-        "type": "github"
-      }
-    },
-    "mirage-opam-overlays_2": {
       "flake": false,
       "locked": {
         "lastModified": 1661959605,
@@ -535,37 +306,7 @@
         "type": "github"
       }
     },
-    "mix-to-nix_2": {
-      "locked": {
-        "lastModified": 1643291492,
-        "narHash": "sha256-B+VIFF8qDJhF5hVMc8PbY/WPzUtbGgjsV1eAxTt5GuQ=",
-        "owner": "serokell",
-        "repo": "mix-to-nix",
-        "rev": "f6f0172b3ac4d32c0e6050a7d805734de0b7adef",
-        "type": "github"
-      },
-      "original": {
-        "owner": "serokell",
-        "repo": "mix-to-nix",
-        "type": "github"
-      }
-    },
     "nix-filter": {
-      "locked": {
-        "lastModified": 1666547822,
-        "narHash": "sha256-razwnAybPHyoAyhkKCwXdxihIqJi1G6e1XP4FQOJTEs=",
-        "owner": "numtide",
-        "repo": "nix-filter",
-        "rev": "1a3b735e13e90a8d2fd5629f2f8363bd7ffbbec7",
-        "type": "github"
-      },
-      "original": {
-        "owner": "numtide",
-        "repo": "nix-filter",
-        "type": "github"
-      }
-    },
-    "nix-filter_2": {
       "locked": {
         "lastModified": 1666547822,
         "narHash": "sha256-razwnAybPHyoAyhkKCwXdxihIqJi1G6e1XP4FQOJTEs=",
@@ -584,27 +325,6 @@
       "inputs": {
         "nixpkgs": [
           "mina",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1670813451,
-        "narHash": "sha256-v0IvQ35CMKtPreGlxWb1FvFUraJNZd144+MbiDwGoAA=",
-        "owner": "serokell",
-        "repo": "nix-npm-buildpackage",
-        "rev": "ec0365cd14a3359a23b80a9e2531a09afc3488fc",
-        "type": "github"
-      },
-      "original": {
-        "owner": "serokell",
-        "repo": "nix-npm-buildpackage",
-        "type": "github"
-      }
-    },
-    "nix-npm-buildPackage_2": {
-      "inputs": {
-        "nixpkgs": [
-          "mina-rev",
           "nixpkgs"
         ]
       },
@@ -641,25 +361,6 @@
         "type": "github"
       }
     },
-    "nix-utils_2": {
-      "inputs": {
-        "flake-utils": "flake-utils_5",
-        "nixpkgs": "nixpkgs_3"
-      },
-      "locked": {
-        "lastModified": 1632973430,
-        "narHash": "sha256-9G8zo+0nfYAALV5umCyQR/2hVUFNH10JropBkyxZGGw=",
-        "owner": "juliosueiras-nix",
-        "repo": "nix-utils",
-        "rev": "b44e1ffd726aa03056db9df469efb497d8b9871b",
-        "type": "github"
-      },
-      "original": {
-        "owner": "juliosueiras-nix",
-        "repo": "nix-utils",
-        "type": "github"
-      }
-    },
     "nixpkgs": {
       "locked": {
         "lastModified": 1629252929,
@@ -676,21 +377,6 @@
       }
     },
     "nixpkgs-lib": {
-      "locked": {
-        "lastModified": 1649551420,
-        "narHash": "sha256-J/Pn38rBZTszdtTHhhxroQaHADhd5TgbJ53F9j1WTIE=",
-        "owner": "nix-community",
-        "repo": "nixpkgs.lib",
-        "rev": "3a16841c57b0d3025b21b869cc921a119ce73033",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nix-community",
-        "repo": "nixpkgs.lib",
-        "type": "github"
-      }
-    },
-    "nixpkgs-lib_2": {
       "locked": {
         "lastModified": 1649551420,
         "narHash": "sha256-J/Pn38rBZTszdtTHhhxroQaHADhd5TgbJ53F9j1WTIE=",
@@ -737,22 +423,6 @@
         "type": "github"
       }
     },
-    "nixpkgs-mozilla_3": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1704373101,
-        "narHash": "sha256-+gi59LRWRQmwROrmE1E2b3mtocwueCQqZ60CwLG+gbg=",
-        "owner": "mozilla",
-        "repo": "nixpkgs-mozilla",
-        "rev": "9b11a87c0cc54e308fa83aac5b4ee1816d5418a2",
-        "type": "github"
-      },
-      "original": {
-        "owner": "mozilla",
-        "repo": "nixpkgs-mozilla",
-        "type": "github"
-      }
-    },
     "nixpkgs_2": {
       "locked": {
         "lastModified": 1713180868,
@@ -771,37 +441,6 @@
     },
     "nixpkgs_3": {
       "locked": {
-        "lastModified": 1629252929,
-        "narHash": "sha256-Aj20gmGBs8TG7pyaQqgbsqAQ6cB+TVuL18Pk3DPBxcQ=",
-        "owner": "nixos",
-        "repo": "nixpkgs",
-        "rev": "3788c68def67ca7949e0864c27638d484389363d",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nixos",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
-    "nixpkgs_4": {
-      "locked": {
-        "lastModified": 1713180868,
-        "narHash": "sha256-5CSnPSCEWeUmrFiLuYIQIPQzPrpCB8x3VhE+oXLRO3k=",
-        "owner": "nixos",
-        "repo": "nixpkgs",
-        "rev": "140546acf30a8212a03a88ded8506413fa3b5d21",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nixos",
-        "ref": "nixos-23.11-small",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
-    "nixpkgs_5": {
-      "locked": {
         "lastModified": 1720535198,
         "narHash": "sha256-zwVvxrdIzralnSbcpghA92tWu2DV2lwv89xZc8MTrbg=",
         "owner": "nixos",
@@ -817,22 +456,6 @@
       }
     },
     "o1-opam-repository": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1715294616,
-        "narHash": "sha256-W2p9Vs8PqpKGvMByxVqpxAljjpEMqNcuNnjMBAAKicI=",
-        "owner": "o1-labs",
-        "repo": "opam-repository",
-        "rev": "38d6995e307c82b3c0b3bc86a867213db724d1c5",
-        "type": "github"
-      },
-      "original": {
-        "owner": "o1-labs",
-        "repo": "opam-repository",
-        "type": "github"
-      }
-    },
-    "o1-opam-repository_2": {
       "flake": false,
       "locked": {
         "lastModified": 1715294616,
@@ -878,36 +501,6 @@
         "type": "github"
       }
     },
-    "opam-nix_2": {
-      "inputs": {
-        "flake-compat": "flake-compat_4",
-        "flake-utils": "flake-utils_6",
-        "mirage-opam-overlays": "mirage-opam-overlays_2",
-        "nixpkgs": [
-          "mina-rev",
-          "nixpkgs"
-        ],
-        "opam-overlays": "opam-overlays_2",
-        "opam-repository": [
-          "mina-rev",
-          "opam-repository"
-        ],
-        "opam2json": "opam2json_2"
-      },
-      "locked": {
-        "lastModified": 1712645768,
-        "narHash": "sha256-9dUh8nElGtC74Q4gIDV6DM0FKgF1oXh0PUkCxdbp+sg=",
-        "owner": "tweag",
-        "repo": "opam-nix",
-        "rev": "464863fba44c7ecc50bd1a2967274482a2c33daf",
-        "type": "github"
-      },
-      "original": {
-        "owner": "tweag",
-        "repo": "opam-nix",
-        "type": "github"
-      }
-    },
     "opam-overlays": {
       "flake": false,
       "locked": {
@@ -924,39 +517,7 @@
         "type": "github"
       }
     },
-    "opam-overlays_2": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1654162756,
-        "narHash": "sha256-RV68fUK+O3zTx61iiHIoS0LvIk0E4voMp+0SwRg6G6c=",
-        "owner": "dune-universe",
-        "repo": "opam-overlays",
-        "rev": "c8f6ef0fc5272f254df4a971a47de7848cc1c8a4",
-        "type": "github"
-      },
-      "original": {
-        "owner": "dune-universe",
-        "repo": "opam-overlays",
-        "type": "github"
-      }
-    },
     "opam-repository": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1708601497,
-        "narHash": "sha256-mDYINTjOiYLN4wT5fGlWTvHFQdWkzY46XUuZWKgmJxY=",
-        "owner": "ocaml",
-        "repo": "opam-repository",
-        "rev": "90d8c520a4f0b035ac51e267a8b33739c5a78b5a",
-        "type": "github"
-      },
-      "original": {
-        "owner": "ocaml",
-        "repo": "opam-repository",
-        "type": "github"
-      }
-    },
-    "opam-repository_2": {
       "flake": false,
       "locked": {
         "lastModified": 1708601497,
@@ -994,37 +555,14 @@
         "type": "github"
       }
     },
-    "opam2json_2": {
-      "inputs": {
-        "nixpkgs": [
-          "mina-rev",
-          "opam-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1671540003,
-        "narHash": "sha256-5pXfbUfpVABtKbii6aaI2EdAZTjHJ2QntEf0QD2O5AM=",
-        "owner": "tweag",
-        "repo": "opam2json",
-        "rev": "819d291ea95e271b0e6027679de6abb4d4f7f680",
-        "type": "github"
-      },
-      "original": {
-        "owner": "tweag",
-        "repo": "opam2json",
-        "type": "github"
-      }
-    },
     "root": {
       "inputs": {
         "describe-dune": "describe-dune",
         "dune-nix": "dune-nix",
         "flake-utils": "flake-utils",
         "mina": "mina",
-        "mina-rev": "mina-rev",
-        "nixpkgs": "nixpkgs_5",
-        "nixpkgs-mozilla": "nixpkgs-mozilla_3"
+        "nixpkgs": "nixpkgs_3",
+        "nixpkgs-mozilla": "nixpkgs-mozilla_2"
       }
     },
     "systems": {
@@ -1045,24 +583,6 @@
     "utils": {
       "inputs": {
         "flake-utils": "flake-utils_4"
-      },
-      "locked": {
-        "lastModified": 1657226504,
-        "narHash": "sha256-GIYNjuq4mJlFgqKsZ+YrgzWm0IpA4axA3MCrdKYj7gs=",
-        "owner": "gytis-ivaskevicius",
-        "repo": "flake-utils-plus",
-        "rev": "2bf0f91643c2e5ae38c1b26893ac2927ac9bd82a",
-        "type": "github"
-      },
-      "original": {
-        "owner": "gytis-ivaskevicius",
-        "repo": "flake-utils-plus",
-        "type": "github"
-      }
-    },
-    "utils_2": {
-      "inputs": {
-        "flake-utils": "flake-utils_7"
       },
       "locked": {
         "lastModified": 1657226504,

--- a/flake.nix
+++ b/flake.nix
@@ -3,6 +3,10 @@
   inputs = {
     nixpkgs.url = "github:nixos/nixpkgs/nixos-23.11-small";
     mina.url = "path:src/mina";
+    # Nix doesn't seem to handle recursive submodules well
+    # so we import mina once not as a git repo so the submodules work
+    # but also as a git repo so the git rev is visible
+    mina-rev.url = "git+file:src/mina";
     nixpkgs-mozilla.url = "github:mozilla/nixpkgs-mozilla";
     nixpkgs-mozilla.flake = false;
     describe-dune.url = "github:o1-labs/describe-dune";
@@ -84,6 +88,42 @@
           { targets = ["wasm32-unknown-unknown" "x86_64-unknown-linux-gnu" ];
             extensions = [ "rust-src" ];
           });
+        rust-platform = pkgs.makeRustPlatform
+            { cargo = rust-channel;
+              rustc = rust-channel;
+            };
+
+        bindings-pkgs = with pkgs;
+            [ nodejs
+              nodePackages.npm
+              typescript
+              nodePackages.typescript-language-server
+
+              #Rustup doesn't allow local toolchains to contain 'nightly' in the name
+              #so the toolchain is linked with the name nix and rustup is wrapped in a shellscript
+              #which calls the nix toolchain instead of the nightly one
+              (writeShellApplication
+                { name = "rustup";
+                  text =
+                  ''
+                  if [ "$1" = run ] && { [ "$2" = nightly-2023-09-01 ] || [ "$2" = 1.72-x86_64-unknowl-linux-gnu ]; }
+                  then
+                    echo USING NIX TOOLCHAIN
+                    ${rustup}/bin/rustup run nix "''${@:3}"
+                  else
+                    echo escape rustup "$@"
+                    ${rustup}/bin/rustup "$@"
+                  fi
+                  '';
+                }
+              )
+              rustup
+              wasm-pack
+              binaryen # provides wasm-opt
+
+              dune_3
+            ] ++ commonOverrides.buildInputs ;
+
         inherit (nixpkgs) lib;
         # All the submodules required by .gitmodules
         submodules = map builtins.head (builtins.filter lib.isList
@@ -111,6 +151,47 @@
                 command "nix-shell"
               }.
             '';
+
+          o1js-npm-deps = pkgs.buildNpmPackage
+            { name = "o1js";
+              src = with pkgs.lib.fileset;
+                  (toSource {
+                    root = ./.;
+                    fileset = unions [
+                      ./package.json
+                      ./package-lock.json
+                    ];
+                  });
+              npmDepsHash = "sha256-UdzSaZJmr5k4voyKPA+9Odb6a2Ia9+3C5YQol9dSIDE=";
+              # The prepack script runs the build script, which we'd rather do in the build phase.
+              npmPackFlags = [ "--ignore-scripts" ];
+              dontNpmBuild = true;
+              installPhase = ''
+                runHook preInstall
+
+                mkdir -p $out/lib
+                cp -r node_modules $out/lib
+
+                runHook postInstall
+              '';
+            };
+          test-vectors = rust-platform.buildRustPackage {
+            src = pkgs.lib.sourceByRegex ./src/mina/src
+              [
+                "^lib(/crypto(/kimchi_bindings(/stubs(/.*)?)?)?)?$"
+                "^lib(/crypto(/proof-systems(/.*)?)?)?$"
+              ];
+            sourceRoot = "source/lib/crypto/proof-systems/poseidon/export_test_vectors";
+            patchPhase =
+            ''
+            cp ${./src/mina/src/lib/crypto/proof-systems/Cargo.lock} .
+            '';
+            name = "export_test_vectors";
+            version = "0.1.0";
+            cargoSha256 = "";
+            CARGO_TARGET_DIR = "./target";
+            cargoLock = { lockFile = ./src/mina/src/lib/crypto/proof-systems/Cargo.lock ; };
+          };
       in {
         formatter = pkgs.nixfmt;
         inherit mina;
@@ -124,48 +205,62 @@
             export RUSTUP_HOME
             rustup toolchain link nix ${rust-channel}
             '';
-            packages = with pkgs;
-              [ nodejs
-                nodePackages.npm
-                typescript
-                nodePackages.typescript-language-server
-
-                #Rustup doesn't allow local toolchains to contain 'nightly' in the name
-                #so the toolchain is linked with the name nix and rustup is wrapped in a shellscript
-                #which calls the nix toolchain instead of the nightly one
-                (writeShellApplication
-                  { name = "rustup";
-                    text =
-                    ''
-                    if [ "$1" = run ] && [ "$2" = nightly-2023-09-01 ]
-                    then
-                      ${rustup}/bin/rustup run nix "''${@:3}"
-                    else
-                      ${rustup}/bin/rustup "$@"
-                    fi
-                    '';
-                  }
-                )
-                rustup
-                wasm-pack
-                binaryen # provides wasm-opt
-
-                dune_3
-              ] ++ commonOverrides.buildInputs ;
+            packages = bindings-pkgs;
           });
+
+
         };
         # TODO build from ./ocaml root, not ./. (after fixing a bug in dune-nix)
         packages = {
-          kim = pkgs.kimchi-rust-wasm;
           inherit dune-description;
-          bindings = prj.pkgs.o1js_bindings;
+          o1js-bindings = pkgs.stdenv.mkDerivation {
+            name = "o1js_bindings";
+            src = ./.;
+            inherit (inputs.mina.devShells."${system}".default)
+              PLONK_WASM_NODEJS
+              PLONK_WASM_WEB
+              MARLIN_PLONK_STUBS
+              ;
+            PREBUILT_KIMCHI_BINDINGS_JS_WEB =
+              "${mina.files.src-lib-crypto-kimchi_bindings-js-web}/src/lib/crypto/kimchi_bindings/js/web";
+            PREBUILT_KIMCHI_BINDINGS_JS_NODE_JS =
+              "${mina.files.src-lib-crypto-kimchi_bindings-js-node_js}/src/lib/crypto/kimchi_bindings/js/node_js";
+            EXPORT_TEST_VECTORS = "${test-vectors}/bin/export_test_vectors";
+            buildInputs = bindings-pkgs ++ [ pkgs.bash ];
+            MINA_COMMIT = inputs.mina-rev.rev;
+            patchPhase = ''
+            patchShebangs ./src/bindings/scripts/
+            patchShebangs ./src/bindings/crypto/test-vectors/
+            '';
+            buildPhase =
+            ''
+            RUSTUP_HOME=$(pwd)/.rustup
+            export RUSTUP_HOME
+            rustup toolchain link nix ${rust-channel}
+            cp -r ${o1js-npm-deps}/lib/node_modules/ .
+
+            npm run build:update-bindings
+            mkdir $out
+            pushd ./src/bindings
+              cp -Lr ./compiled ./mina-transaction ./ocaml MINA_COMMIT $out
+            popd
+            '';
+          };
+          kimchi = pkgs.kimchi-rust-wasm;
           ocaml-js = prj.pkgs.__ocaml-js__;
-          default = pkgs.buildNpmPackage
-            { name = "o1js";
-              src = ./.;
-              npmDepsHash = "sha256-++MTGDUVBccYN8LA2Xb0FkbrZ14ZyVCrDPESXa52AwQ=";
-              # TODO ideally re-build bindings here
-            };
+        };
+        apps = {
+
+          update-bindings = {
+            type = "app";
+            program = "${pkgs.writeShellApplication
+              { name = "update-bindings";
+                text =
+                ''
+                cp -r ${self.packages."${system}".o1js-bindings}/* ./src/bindings
+                '';
+              }}/bin/update-bindings";
+          };
         };
       });
 }

--- a/flake.nix
+++ b/flake.nix
@@ -284,6 +284,7 @@
                 text =
                 ''
                 cp -r ${self.packages."${system}".o1js-bindings}/* ./src/bindings
+                chmod +w -R src/bindings/compiled
                 MINA_COMMIT=$(git -C src/mina rev-parse HEAD)
                 echo "The mina commit used to generate the backends for node and web is" "$MINA_COMMIT" \
                   > src/bindings/MINA_COMMIT

--- a/flake.nix
+++ b/flake.nix
@@ -3,10 +3,6 @@
   inputs = {
     nixpkgs.url = "github:nixos/nixpkgs/nixos-23.11-small";
     mina.url = "path:src/mina";
-    # Nix doesn't seem to handle recursive submodules well
-    # so we import mina once not as a git repo so the submodules work
-    # but also as a git repo so the git rev is visible
-    mina-rev.url = "git+file:src/mina";
     nixpkgs-mozilla.url = "github:mozilla/nixpkgs-mozilla";
     nixpkgs-mozilla.flake = false;
     describe-dune.url = "github:o1-labs/describe-dune";
@@ -227,7 +223,7 @@
               "${mina.files.src-lib-crypto-kimchi_bindings-js-node_js}/src/lib/crypto/kimchi_bindings/js/node_js";
             EXPORT_TEST_VECTORS = "${test-vectors}/bin/export_test_vectors";
             buildInputs = bindings-pkgs ++ [ pkgs.bash ];
-            MINA_COMMIT = inputs.mina-rev.rev;
+            SKIP_MINA_COMMIT = true;
             patchPhase = ''
             patchShebangs ./src/bindings/scripts/
             patchShebangs ./src/bindings/crypto/test-vectors/
@@ -243,7 +239,7 @@
             mkdir $out
             pushd ./src/bindings
               rm -rf ./compiled/_node_bindings
-              cp -Lr ./compiled ./mina-transaction ./ocaml ./MINA_COMMIT $out
+              cp -Lr ./compiled ./mina-transaction ./ocaml $out
             popd
             '';
           };
@@ -258,6 +254,9 @@
                 text =
                 ''
                 cp -r ${self.packages."${system}".o1js-bindings}/* ./src/bindings
+                MINA_COMMIT=$(git -C src/mina rev-parse HEAD)
+                echo "The mina commit used to generate the backends for node and web is" "$MINA_COMMIT" \
+                  > src/bindings/MINA_COMMIT
                 '';
               }}/bin/update-bindings";
           };

--- a/flake.nix
+++ b/flake.nix
@@ -159,15 +159,16 @@
                     ];
                   });
               # If you see 'ERROR: npmDepsHash is out of date' in ci
-              # set this to blank run ``nix build o1js#o1js-bindings` You should get an output like this:
+              # set this to blank run ``nix build o1js#o1js-bindings`
               # If you don't want to install nix you can also set it to "" and run ci to get the new hash
+              # You should get an output like this:
 
               # error: hash mismatch in fixed-output derivation '/nix/store/a03cg2az0b2cvjsp1wnr89clf31i79c1-o1js-npm-deps.drv':
               # specified: sha256-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=
               #    got:    sha256-8EPvXpOgn0nvm/pFKN3h6EMjabOeBqfy5optIfe8E8Q=
               # replace npmDepsHash bellow with the new hash
 
-              npmDepsHash = "sha256-8EPvXpOgn0nvm/pFKN3h6EMjabOeBqfy5optIfe8E8Q=";
+              npmDepsHash = "sha256-QLnSfX6JwYQXyHGNSxXdzqbhkbFl67sDrmlW/F6D/pw=";
               # The prepack script runs the build script, which we'd rather do in the build phase.
               npmPackFlags = [ "--ignore-scripts" ];
               dontNpmBuild = true;

--- a/flake.nix
+++ b/flake.nix
@@ -162,7 +162,7 @@
                       ./package-lock.json
                     ];
                   });
-              npmDepsHash = "sha256-UdzSaZJmr5k4voyKPA+9Odb6a2Ia9+3C5YQol9dSIDE=";
+              npmDepsHash = "sha256-8EPvXpOgn0nvm/pFKN3h6EMjabOeBqfy5optIfe8E8Q=";
               # The prepack script runs the build script, which we'd rather do in the build phase.
               npmPackFlags = [ "--ignore-scripts" ];
               dontNpmBuild = true;

--- a/flake.nix
+++ b/flake.nix
@@ -104,10 +104,10 @@
                   ''
                   if [ "$1" = run ] && { [ "$2" = nightly-2023-09-01 ] || [ "$2" = 1.72-x86_64-unknowl-linux-gnu ]; }
                   then
-                    echo USING NIX TOOLCHAIN
+                    echo using nix toolchain
                     ${rustup}/bin/rustup run nix "''${@:3}"
                   else
-                    echo escape rustup "$@"
+                    echo using plain rustup "$@"
                     ${rustup}/bin/rustup "$@"
                   fi
                   '';
@@ -184,7 +184,6 @@
           test-vectors = rust-platform.buildRustPackage {
             src = pkgs.lib.sourceByRegex ./src/mina/src
               [
-                "^lib(/crypto(/kimchi_bindings(/stubs(/.*)?)?)?)?$"
                 "^lib(/crypto(/proof-systems(/.*)?)?)?$"
               ];
             sourceRoot = "source/lib/crypto/proof-systems/poseidon/export_test_vectors";

--- a/flake.nix
+++ b/flake.nix
@@ -251,7 +251,6 @@
           ocaml-js = prj.pkgs.__ocaml-js__;
         };
         apps = {
-
           update-bindings = {
             type = "app";
             program = "${pkgs.writeShellApplication

--- a/flake.nix
+++ b/flake.nix
@@ -242,7 +242,8 @@
             npm run build:update-bindings
             mkdir $out
             pushd ./src/bindings
-              cp -Lr ./compiled ./mina-transaction ./ocaml MINA_COMMIT $out
+              rm -rf ./compiled/_node_bindings
+              cp -Lr ./compiled ./mina-transaction ./ocaml ./MINA_COMMIT $out
             popd
             '';
           };

--- a/flake.nix
+++ b/flake.nix
@@ -158,6 +158,15 @@
                       ./package-lock.json
                     ];
                   });
+              # If you see 'ERROR: npmDepsHash is out of date' in ci
+              # set this to blank run ``nix build o1js#o1js-bindings` You should get an output like this:
+              # If you don't want to install nix you can also set it to "" and run ci to get the new hash
+
+              # error: hash mismatch in fixed-output derivation '/nix/store/a03cg2az0b2cvjsp1wnr89clf31i79c1-o1js-npm-deps.drv':
+              # specified: sha256-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=
+              #    got:    sha256-8EPvXpOgn0nvm/pFKN3h6EMjabOeBqfy5optIfe8E8Q=
+              # replace npmDepsHash bellow with the new hash
+
               npmDepsHash = "sha256-8EPvXpOgn0nvm/pFKN3h6EMjabOeBqfy5optIfe8E8Q=";
               # The prepack script runs the build script, which we'd rather do in the build phase.
               npmPackFlags = [ "--ignore-scripts" ];

--- a/pin.sh
+++ b/pin.sh
@@ -11,5 +11,4 @@ nix registry add o1js "git+file://$ROOT?submodules=1"
 # update mina input to local submodule
 # --override-input seems redundant but fixes a cacheing issue with local paths
 nix flake update mina --override-input mina 'path:src/mina' --flake '.?submodules=1'
-nix flake update mina-rev --override-input mina-rev 'git+file:src/mina' --flake '.?submodules=1'
 popd

--- a/pin.sh
+++ b/pin.sh
@@ -10,4 +10,5 @@ git submodule sync && git submodule update --init --recursive
 nix registry add o1js "git+file://$ROOT?submodules=1"
 # update mina input to local submodule
 nix flake update mina --override-input mina 'path:src/mina' --flake '.?submodules=1'
+nix flake update mina-rev --flake '.?submodules=1'
 popd

--- a/pin.sh
+++ b/pin.sh
@@ -11,5 +11,5 @@ nix registry add o1js "git+file://$ROOT?submodules=1"
 # update mina input to local submodule
 # --override-input seems redundant but fixes a cacheing issue with local paths
 nix flake update mina --override-input mina 'path:src/mina' --flake '.?submodules=1'
-nix flake update mina-rev --flake --override-input mina-rev 'git+file:src/mina' '.?submodules=1'
+nix flake update mina-rev --override-input mina-rev 'git+file:src/mina' --flake '.?submodules=1'
 popd

--- a/pin.sh
+++ b/pin.sh
@@ -9,6 +9,7 @@ git submodule sync && git submodule update --init --recursive
 # Add the flake registry entry
 nix registry add o1js "git+file://$ROOT?submodules=1"
 # update mina input to local submodule
+# --override-input seems redundant but fixes a cacheing issue with local paths
 nix flake update mina --override-input mina 'path:src/mina' --flake '.?submodules=1'
-nix flake update mina-rev --flake '.?submodules=1'
+nix flake update mina-rev --flake --override-input mina-rev 'git+file:src/mina' '.?submodules=1'
 popd

--- a/pin.sh
+++ b/pin.sh
@@ -9,6 +9,6 @@ git submodule sync && git submodule update --init --recursive
 # Add the flake registry entry
 nix registry add o1js "git+file://$ROOT?submodules=1"
 # update mina input to local submodule
-# --override-input seems redundant but fixes a cacheing issue with local paths
+# --override-input seems redundant but fixes a caching issue with local paths
 nix flake update mina --override-input mina 'path:src/mina' --flake '.?submodules=1'
 popd


### PR DESCRIPTION
Adds support for building bindings as a nix derivation
They can be built with `nix build o1js#o1js-bindings` or updated with `nix run o1js#update-bindings`
should be more reproducible than the devshell approach
should improve rebuild performance in CI

also adds a check that the bindings are the same (currently we just check that they can be built without error)

Bindings part: https://github.com/o1-labs/o1js-bindings/pull/316