### PR TITLE
Cleanup runner's Nix store after the o1js bindings build procedure.

### DIFF
--- a/.github/workflows/build-bindings.yml
+++ b/.github/workflows/build-bindings.yml
@@ -12,7 +12,7 @@ jobs:
     name: build-bindings-ubuntu
     runs-on: [sdk-self-hosted-linux-amd64-build-system]
     steps:
-      - name: Set up Nix in PATH
+      - name: Set up Nix
         run: echo "PATH=$PATH:/nix/var/nix/profiles/default/bin" >> $GITHUB_ENV
       - name: Disable smudging
         run: echo "GIT_LFS_SKIP_SMUDGE=1" >> $GITHUB_ENV
@@ -22,8 +22,6 @@ jobs:
       - name: Build the o1js bindings
         run: |
           set -Eeu
-          # Until we restart the runner and the PATH gets updated from /etc/bash.bashrc
-          export PATH="$PATH":/nix/var/nix/profiles/default/bin
           ./pin.sh
           nix develop o1js --command bash -c "npm run build:update-bindings"
       - name: Cleanup the Nix store

--- a/.github/workflows/build-bindings.yml
+++ b/.github/workflows/build-bindings.yml
@@ -1,4 +1,4 @@
-# Purpose: We want to build the o1js bindings in CI so that people in the 
+# Purpose: We want to build the o1js bindings in CI so that people in the
 # community can change them without being scared of breaking things, or
 # needing to do the complicated (without nix) build setup.
 
@@ -7,7 +7,7 @@ name: Build o1js bindings
 on:
   pull_request:
 
-jobs:  
+jobs:
   nix-build:
     name: build-bindings-ubuntu
     runs-on: [sdk-self-hosted-linux-amd64-build-system]
@@ -17,9 +17,16 @@ jobs:
       - uses: actions/checkout@v4
         with:
           submodules: recursive
-      - run: |
+      - name: Build the o1js bindings
+        run: |
           set -Eeu
           # Until we restart the runner and the PATH gets updated from /etc/bash.bashrc
           export PATH="$PATH":/nix/var/nix/profiles/default/bin
           ./pin.sh
           nix develop o1js --command bash -c "npm run build:update-bindings"
+      - name: Cleanup the Nix store
+        run: |
+          nix-env --delete-generations old
+          nix-collect-garbage -d --quiet
+          nix-store --gc --print-dead
+          nix-store --optimise

--- a/.github/workflows/build-bindings.yml
+++ b/.github/workflows/build-bindings.yml
@@ -12,6 +12,8 @@ jobs:
     name: build-bindings-ubuntu
     runs-on: [sdk-self-hosted-linux-amd64-build-system]
     steps:
+      - name: Set up Nix in PATH
+        run: echo "PATH=$PATH:/nix/var/nix/profiles/default/bin" >> $GITHUB_ENV
       - name: Disable smudging
         run: echo "GIT_LFS_SKIP_SMUDGE=1" >> $GITHUB_ENV
       - uses: actions/checkout@v4


### PR DESCRIPTION
Nix store consumes quite a lot of runner's disk space if used without cache and/or without the cleaning up procedures. This PR attempts to fix that.