### PR TITLE
Expose proof base64 conversion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - Add `enforceTransactionLimits` parameter on Network https://github.com/o1-labs/o1js/issues/1910
 - Method for optional types to assert none https://github.com/o1-labs/o1js/pull/1922
 - Increased maximum supported amount of methods in a `SmartContract` or `ZkProgram` to 30. https://github.com/o1-labs/o1js/pull/1918
+- Expose low-level conversion methods `Proof.{_proofToBase64,_proofFromBase64}` https://github.com/o1-labs/o1js/pull/1928
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,10 +17,13 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased](https://github.com/o1-labs/o1js/compare/e1bac02...HEAD)
 
+### Added
+
+- Expose low-level conversion methods `Proof.{_proofToBase64,_proofFromBase64}` https://github.com/o1-labs/o1js/pull/1928
+
 ### Fixed
 
 - Compiling stuck in the browser for recursive zkprograms https://github.com/o1-labs/o1js/pull/1906
-
 - Error message in `rangeCheck16` gadget https://github.com/o1-labs/o1js/pull/1920
 
 ## [2.1.0](https://github.com/o1-labs/o1js/compare/b04520d...e1bac02) - 2024-11-13

--- a/src/lib/proof-system/proof.ts
+++ b/src/lib/proof-system/proof.ts
@@ -92,6 +92,13 @@ class ProofBase<Input = any, Output = any> {
   publicFields() {
     return (this.constructor as typeof ProofBase).publicFields(this);
   }
+
+  static _proofFromBase64(proofString: string, maxProofsVerified: 0 | 1 | 2) {
+    return Pickles.proofOfBase64(proofString, maxProofsVerified)[1];
+  }
+  static _proofToBase64(proof: Pickles.Proof, maxProofsVerified: 0 | 1 | 2) {
+    return Pickles.proofToBase64([maxProofsVerified, proof]);
+  }
 }
 
 class Proof<Input, Output> extends ProofBase<Input, Output> {

--- a/src/lib/proof-system/proof.ts
+++ b/src/lib/proof-system/proof.ts
@@ -1,4 +1,8 @@
-import { initializeBindings, withThreadPool } from '../../snarky.js';
+import {
+  areBindingsInitialized,
+  initializeBindings,
+  withThreadPool,
+} from '../../snarky.js';
 import { Pickles } from '../../snarky.js';
 import { Field, Bool } from '../provable/wrapped.js';
 import type {
@@ -94,9 +98,11 @@ class ProofBase<Input = any, Output = any> {
   }
 
   static _proofFromBase64(proofString: string, maxProofsVerified: 0 | 1 | 2) {
+    assertBindingsInitialized();
     return Pickles.proofOfBase64(proofString, maxProofsVerified)[1];
   }
   static _proofToBase64(proof: Pickles.Proof, maxProofsVerified: 0 | 1 | 2) {
+    assertBindingsInitialized();
     return Pickles.proofToBase64([maxProofsVerified, proof]);
   }
 }
@@ -434,4 +440,11 @@ function extractProofTypes(type: ProvableType) {
   let value = ProvableType.synthesize(type);
   let proofValues = extractProofs(value);
   return proofValues.map((proof) => proof.constructor as typeof ProofBase);
+}
+
+function assertBindingsInitialized() {
+  assert(
+    areBindingsInitialized,
+    'Bindings are not initialized. Try calling `await initializeBindings()` first.'
+  );
 }

--- a/src/lib/proof-system/proof.unit-test.ts
+++ b/src/lib/proof-system/proof.unit-test.ts
@@ -13,7 +13,18 @@ test('Proof provable', async () => {
 
   expect(MyProof.provable.sizeInFields()).toEqual(1);
 
+  // can't call this before bindings are initialized
+  expect(() => MyProof._proofFromBase64('', 0)).toThrow(
+    'Bindings are not initialized'
+  );
+
   let proof = await MyProof.dummy(Field(1n), undefined, 0);
+
+  // now bindings are initialized and we can call this
+  let proofBase64 = MyProof._proofToBase64(proof.proof, 0);
+  let proofRecovered = MyProof._proofFromBase64(proofBase64, 0);
+  let proofBase64_2 = MyProof._proofToBase64(proofRecovered, 0);
+  expect(proofBase64).toEqual(proofBase64_2);
 
   expect(MyProof.provable.toFields(proof)).toEqual([Field(1n)]);
   expect(MyProof.provable.toAuxiliary(proof)).toEqual([

--- a/src/snarky.d.ts
+++ b/src/snarky.d.ts
@@ -47,7 +47,10 @@ export {
   MlPublicKey,
   MlPublicKeyVar,
   MlFeatureFlags,
+  areBindingsInitialized,
 };
+
+declare let areBindingsInitialized: boolean;
 
 type WasmModule = typeof wasm;
 

--- a/src/snarky.js
+++ b/src/snarky.js
@@ -33,4 +33,5 @@ export {
   withThreadPool,
   wasm,
   initializeBindings,
+  isInitialized as areBindingsInitialized,
 };

--- a/src/snarky.web.js
+++ b/src/snarky.web.js
@@ -29,4 +29,5 @@ export {
   withThreadPool,
   wasm,
   initializeBindings,
+  isInitialized as areBindingsInitialized,
 };


### PR DESCRIPTION
low-level method exposed to have more flexibility for how to serialize proofs

I need this in https://github.com/zksecurity/mina-credentials/pull/82 to get a synchronous version of `Proof.fromJSON()`