### PR TITLE
Introduce recursive proofs from within ZkPrograms

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,10 +17,15 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased](https://github.com/o1-labs/o1js/compare/e1bac02...HEAD)
 
+### Added
+
+- API for recursively proving a ZkProgram method from within another https://github.com/o1-labs/o1js/pull/1931
+  - `program.proveRecursively.<methodName>(...args): Promise<PublicOutput>`
+  - This also works within the same program, as long as the return value is type-annotated
+
 ### Fixed
 
 - Compiling stuck in the browser for recursive zkprograms https://github.com/o1-labs/o1js/pull/1906
-
 - Error message in `rangeCheck16` gadget https://github.com/o1-labs/o1js/pull/1920
 
 ## [2.1.0](https://github.com/o1-labs/o1js/compare/b04520d...e1bac02) - 2024-11-13

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 - `ZkProgram` to support non-pure provable types as inputs and outputs https://github.com/o1-labs/o1js/pull/1828
 - API for recursively proving a ZkProgram method from within another https://github.com/o1-labs/o1js/pull/1931
-  - `program.proveRecursively.<methodName>(...args): Promise<PublicOutput>`
+  - `let recursive = Experimental.Recursive(program); recursive.<methodName>(...args): Promise<PublicOutput>`
   - This also works within the same program, as long as the return value is type-annotated
 - Add `enforceTransactionLimits` parameter on Network https://github.com/o1-labs/o1js/issues/1910
 - Method for optional types to assert none https://github.com/o1-labs/o1js/pull/1922

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,8 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 - `ZkProgram` to support non-pure provable types as inputs and outputs https://github.com/o1-labs/o1js/pull/1828
 - API for recursively proving a ZkProgram method from within another https://github.com/o1-labs/o1js/pull/1931
-  - `let recursive = Experimental.Recursive(program); recursive.<methodName>(...args): Promise<PublicOutput>`
+  - `let recursive = Experimental.Recursive(program);`
+  - `recursive.<methodName>(...args): Promise<PublicOutput>`
   - This also works within the same program, as long as the return value is type-annotated
 - Add `enforceTransactionLimits` parameter on Network https://github.com/o1-labs/o1js/issues/1910
 - Method for optional types to assert none https://github.com/o1-labs/o1js/pull/1922

--- a/run-ci-tests.sh
+++ b/run-ci-tests.sh
@@ -9,6 +9,7 @@ case $TEST_TYPE in
   ./run src/examples/zkapps/reducer/reducer-composite.ts --bundle
   ./run src/examples/zkapps/composability.ts --bundle
   ./run src/tests/fake-proof.ts
+  ./run src/tests/inductive-proofs-internal.ts --bundle
   ./run tests/vk-regression/diverse-zk-program-run.ts --bundle
   ;;
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -148,6 +148,7 @@ import * as OffchainState_ from './lib/mina/actions/offchain-state.js';
 import * as BatchReducer_ from './lib/mina/actions/batch-reducer.js';
 import { Actionable } from './lib/mina/actions/offchain-state-serialization.js';
 import { InferProvable } from './lib/provable/types/struct.js';
+import { Recursive as Recursive_ } from './lib/proof-system/recursive.js';
 export { Experimental };
 
 const Experimental_ = {
@@ -161,6 +162,8 @@ const Experimental_ = {
  */
 namespace Experimental {
   export let memoizeWitness = Experimental_.memoizeWitness;
+
+  export let Recursive = Recursive_;
 
   // indexed merkle map
   export let IndexedMerkleMap = Experimental_.IndexedMerkleMap;

--- a/src/lib/mina/account-update.ts
+++ b/src/lib/mina/account-update.ts
@@ -2151,7 +2151,7 @@ async function createZkappProof(
     }
   );
 
-  let maxProofsVerified = ZkappClass._maxProofsVerified!;
+  let maxProofsVerified = await ZkappClass.getMaxProofsVerified();
   const Proof = ZkappClass.Proof();
   return new Proof({
     publicInput,

--- a/src/lib/mina/account-update.ts
+++ b/src/lib/mina/account-update.ts
@@ -655,7 +655,6 @@ type LazyProof = {
   kind: 'lazy-proof';
   methodName: string;
   args: any[];
-  previousProofs: Pickles.Proof[];
   ZkappClass: typeof SmartContract;
   memoized: { fields: Field[]; aux: any[] }[];
   blindingValue: Field;
@@ -2116,14 +2115,7 @@ async function addProof(
 
 async function createZkappProof(
   prover: Pickles.Prover,
-  {
-    methodName,
-    args,
-    previousProofs,
-    ZkappClass,
-    memoized,
-    blindingValue,
-  }: LazyProof,
+  { methodName, args, ZkappClass, memoized, blindingValue }: LazyProof,
   { transaction, accountUpdate, index }: ZkappProverData
 ): Promise<Proof<ZkappPublicInput, Empty>> {
   let publicInput = accountUpdate.toPublicInput(transaction);
@@ -2141,7 +2133,7 @@ async function createZkappProof(
         blindingValue,
       });
       try {
-        return await prover(publicInputFields, MlArray.to(previousProofs));
+        return await prover(publicInputFields);
       } catch (err) {
         console.error(`Error when proving ${ZkappClass.name}.${methodName}()`);
         throw err;

--- a/src/lib/mina/zkapp.ts
+++ b/src/lib/mina/zkapp.ts
@@ -46,7 +46,6 @@ import {
   compileProgram,
   computeMaxProofsVerified,
   Empty,
-  getPreviousProofsForProver,
   MethodInterface,
   sortMethodArguments,
   VerificationKey,
@@ -337,8 +336,6 @@ function wrapMethod(
               {
                 methodName: methodIntf.methodName,
                 args: clonedArgs,
-                // proofs actually don't have to be cloned
-                previousProofs: getPreviousProofsForProver(actualArgs),
                 ZkappClass,
                 memoized,
                 blindingValue,
@@ -429,7 +426,6 @@ function wrapMethod(
             {
               methodName: methodIntf.methodName,
               args: constantArgs,
-              previousProofs: getPreviousProofsForProver(constantArgs),
               ZkappClass,
               memoized,
               blindingValue: constantBlindingValue,

--- a/src/lib/mina/zkapp.ts
+++ b/src/lib/mina/zkapp.ts
@@ -44,13 +44,14 @@ import {
 import {
   analyzeMethod,
   compileProgram,
+  computeMaxProofsVerified,
   Empty,
   getPreviousProofsForProver,
   MethodInterface,
   sortMethodArguments,
   VerificationKey,
 } from '../proof-system/zkprogram.js';
-import { Proof } from '../proof-system/proof.js';
+import { Proof, ProofClass } from '../proof-system/proof.js';
 import { PublicKey } from '../provable/crypto/signature.js';
 import {
   InternalStateType,
@@ -154,11 +155,6 @@ function method<K extends string, T extends SmartContract>(
   // FIXME: overriding a method implies pushing a separate method entry here, yielding two entries with the same name
   // this should only be changed once we no longer share the _methods array with the parent class (otherwise a subclass declaration messes up the parent class)
   ZkappClass._methods.push(methodEntry);
-  ZkappClass._maxProofsVerified ??= 0;
-  ZkappClass._maxProofsVerified = Math.max(
-    ZkappClass._maxProofsVerified,
-    methodEntry.numberOfProofs
-  ) as 0 | 1 | 2;
   let func = descriptor.value as AsyncFunction;
   descriptor.value = wrapMethod(func, ZkappClass, internalMethodEntry);
 }
@@ -593,10 +589,10 @@ class SmartContract extends SmartContractBase {
       rows: number;
       digest: string;
       gates: Gate[];
+      proofs: ProofClass[];
     }
   >; // keyed by method name
   static _provers?: Pickles.Prover[];
-  static _maxProofsVerified?: 0 | 1 | 2;
   static _verificationKey?: { data: string; hash: Field };
 
   /**
@@ -644,6 +640,7 @@ class SmartContract extends SmartContractBase {
     forceRecompile = false,
   } = {}) {
     let methodIntfs = this._methods ?? [];
+    let methodKeys = methodIntfs.map(({ methodName }) => methodName);
     let methods = methodIntfs.map(({ methodName }) => {
       return async (
         publicInput: unknown,
@@ -657,13 +654,15 @@ class SmartContract extends SmartContractBase {
     });
     // run methods once to get information that we need already at compile time
     let methodsMeta = await this.analyzeMethods();
-    let gates = methodIntfs.map((intf) => methodsMeta[intf.methodName].gates);
+    let gates = methodKeys.map((k) => methodsMeta[k].gates);
+    let proofs = methodKeys.map((k) => methodsMeta[k].proofs);
     let { verificationKey, provers, verify } = await compileProgram({
       publicInputType: ZkappPublicInput,
       publicOutputType: Empty,
       methodIntfs,
       methods,
       gates,
+      proofs,
       proofSystemTag: this,
       cache,
       forceRecompile,
@@ -687,6 +686,17 @@ class SmartContract extends SmartContractBase {
       Object.values(methodData).map((d) => Field(BigInt('0x' + d.digest)))
     );
     return hash.toBigInt().toString(16);
+  }
+
+  /**
+   * The maximum number of proofs that are verified by any of the zkApp methods.
+   * This is an internal parameter needed by the proof system.
+   */
+  static async getMaxProofsVerified() {
+    let methodData = await this.analyzeMethods();
+    return computeMaxProofsVerified(
+      Object.values(methodData).map((d) => d.proofs.length)
+    );
   }
 
   /**
@@ -1189,7 +1199,7 @@ super.init();
       try {
         for (let methodIntf of methodIntfs) {
           let accountUpdate: AccountUpdate;
-          let { rows, digest, gates, summary } = await analyzeMethod(
+          let { rows, digest, gates, summary, proofs } = await analyzeMethod(
             ZkappPublicInput,
             methodIntf,
             async (publicInput, publicKey, tokenId, ...args) => {
@@ -1207,6 +1217,7 @@ super.init();
             rows,
             digest,
             gates,
+            proofs,
           };
           if (printSummary) console.log(methodIntf.methodName, summary());
         }

--- a/src/lib/proof-system/proof-system.unit-test.ts
+++ b/src/lib/proof-system/proof-system.unit-test.ts
@@ -67,7 +67,7 @@ it('pickles rule creation', async () => {
     { name: 'mock' },
     methodIntf,
     [],
-    []
+    [EmptyProof]
   );
 
   await equivalentAsync(
@@ -133,7 +133,6 @@ it('pickles rule creation: nested proof', async () => {
   expect(methodIntf).toEqual({
     methodName: 'main',
     args: [NestedProof2],
-    numberOfProofs: 2,
   });
 
   // store compiled tag
@@ -147,7 +146,7 @@ it('pickles rule creation: nested proof', async () => {
     { name: 'mock' },
     methodIntf,
     [],
-    []
+    [EmptyProof, EmptyProof]
   );
 
   let dummy = await EmptyProof.dummy(Field(0), undefined, 0);

--- a/src/lib/proof-system/proof-system.unit-test.ts
+++ b/src/lib/proof-system/proof-system.unit-test.ts
@@ -54,7 +54,6 @@ it('pickles rule creation', async () => {
   expect(methodIntf).toEqual({
     methodName: 'main',
     args: [EmptyProof, Bool],
-    numberOfProofs: 1,
   });
 
   // store compiled tag
@@ -67,6 +66,7 @@ it('pickles rule creation', async () => {
     main as AnyFunction,
     { name: 'mock' },
     methodIntf,
+    [],
     []
   );
 
@@ -146,6 +146,7 @@ it('pickles rule creation: nested proof', async () => {
     main as AnyFunction,
     { name: 'mock' },
     methodIntf,
+    [],
     []
   );
 

--- a/src/lib/proof-system/proof.ts
+++ b/src/lib/proof-system/proof.ts
@@ -55,8 +55,8 @@ class ProofBase<Input = any, Output = any> {
    */
   declare() {
     if (!ZkProgramContext.has()) return false;
-    const Proof = this.constructor as Subclass<typeof ProofBase>;
-    ZkProgramContext.declareProof({ Proof, proof: this });
+    const ProofClass = this.constructor as Subclass<typeof ProofBase>;
+    ZkProgramContext.declareProof({ ProofClass, proofInstance: this });
     return true;
   }
 

--- a/src/lib/proof-system/proof.ts
+++ b/src/lib/proof-system/proof.ts
@@ -15,12 +15,14 @@ import { ProvableType } from '../provable/types/provable-intf.js';
 import { ZkProgramContext } from './zkprogram-context.js';
 
 // public API
-export { ProofBase, Proof, DynamicProof };
+export { ProofBase, Proof, DynamicProof, ProofClass };
 
 // internal API
 export { dummyProof, extractProofs, extractProofTypes, type ProofValue };
 
 type MaxProofs = 0 | 1 | 2;
+
+type ProofClass = Subclass<typeof ProofBase>;
 
 class ProofBase<Input = any, Output = any> {
   static publicInputType: FlexibleProvablePure<any> = undefined as any;

--- a/src/lib/proof-system/recursive.ts
+++ b/src/lib/proof-system/recursive.ts
@@ -62,7 +62,7 @@ function Recursive<
 
   let methodKeys: MethodKey[] = Object.keys(methods);
 
-  let regularRecursiveProvers = mapObject(zkprogram, (prover, key) => {
+  let regularRecursiveProvers = mapToObject(methodKeys, (key) => {
     return async function proveRecursively_(
       publicInput: PublicInput,
       ...args: TupleToInstances<PrivateInputs[MethodKey]>
@@ -77,6 +77,9 @@ function Recursive<
         let constArgs = zip(args, privateInputs[key]).map(([arg, type]) =>
           Provable.toConstant(type, arg)
         );
+
+        let prover = zkprogram[key];
+
         if (hasPublicInput) {
           let { proof } = await prover(constInput, ...constArgs);
           return proof;

--- a/src/lib/proof-system/recursive.ts
+++ b/src/lib/proof-system/recursive.ts
@@ -1,0 +1,132 @@
+import { InferProvable } from '../provable/types/struct.js';
+import { Provable } from '../provable/provable.js';
+import { ProvableType } from '../provable/types/provable-intf.js';
+import { Tuple } from '../util/types.js';
+import { Proof } from './proof.js';
+import { mapObject, mapToObject, zip } from '../util/arrays.js';
+import { RegularProver, Undefined, Void } from './zkprogram.js';
+
+export { Recursive };
+
+function Recursive<
+  PublicInputType extends Provable<any>,
+  PublicOutputType extends Provable<any>,
+  PrivateInputs extends {
+    [Key in string]: Tuple<ProvableType>;
+  }
+>(zkprogram: {
+  name: string;
+  publicInputType: PublicInputType;
+  publicOutputType: PublicOutputType;
+  privateInputTypes: PrivateInputs;
+  rawMethods: {
+    [Key in keyof PrivateInputs]: (
+      ...args: any
+    ) => Promise<{ publicOutput: InferProvable<PublicOutputType> }>;
+  };
+  provers: {
+    [Key in keyof PrivateInputs]: RegularProver<
+      InferProvable<PublicInputType>,
+      InferProvable<PublicOutputType>,
+      any,
+      any
+    >;
+  };
+}): {
+  [Key in keyof PrivateInputs]: RecursiveProver<
+    InferProvable<PublicInputType>,
+    InferProvable<PublicOutputType>,
+    PrivateInputs[Key]
+  >;
+} {
+  type PublicInput = InferProvable<PublicInputType>;
+  type PublicOutput = InferProvable<PublicOutputType>;
+  type MethodKey = keyof PrivateInputs;
+
+  let {
+    publicInputType,
+    publicOutputType,
+    privateInputTypes: privateInputs,
+    rawMethods: methods,
+    provers,
+  } = zkprogram;
+
+  let hasPublicInput =
+    publicInputType !== Undefined && publicInputType !== Void;
+
+  class SelfProof extends Proof<PublicInput, PublicOutput> {
+    static publicInputType = publicInputType;
+    static publicOutputType = publicOutputType;
+    static tag = () => zkprogram;
+  }
+
+  let methodKeys: MethodKey[] = Object.keys(methods);
+
+  let regularRecursiveProvers = mapObject(provers, (prover, key) => {
+    return async function proveRecursively_(
+      publicInput: PublicInput,
+      ...args: TupleToInstances<PrivateInputs[MethodKey]>
+    ) {
+      // create the base proof in a witness block
+      let proof = await Provable.witnessAsync(SelfProof, async () => {
+        // move method args to constants
+        let constInput = Provable.toConstant<PublicInput>(
+          publicInputType,
+          publicInput
+        );
+        let constArgs = zip(args, privateInputs[key]).map(([arg, type]) =>
+          Provable.toConstant(type, arg)
+        );
+        let { proof } = await prover(constInput, ...(constArgs as any));
+        return proof;
+      });
+
+      // assert that the witnessed proof has the correct public input (which will be used by Pickles as part of verification)
+      if (hasPublicInput) {
+        Provable.assertEqual(publicInputType, proof.publicInput, publicInput);
+      }
+
+      // declare and verify the proof, and return its public output
+      proof.declare();
+      proof.verify();
+      return proof.publicOutput;
+    };
+  });
+
+  type RecursiveProver_<K extends MethodKey> = RecursiveProver<
+    PublicInput,
+    PublicOutput,
+    PrivateInputs[K]
+  >;
+  type RecursiveProvers = {
+    [K in MethodKey]: RecursiveProver_<K>;
+  };
+  let proveRecursively: RecursiveProvers = mapToObject(
+    methodKeys,
+    (key: MethodKey) => {
+      if (!hasPublicInput) {
+        return ((...args: any) =>
+          regularRecursiveProvers[key](undefined as any, ...args)) as any;
+      } else {
+        return regularRecursiveProvers[key] as any;
+      }
+    }
+  );
+
+  return proveRecursively;
+}
+
+type RecursiveProver<
+  PublicInput,
+  PublicOutput,
+  Args extends Tuple<ProvableType>
+> = PublicInput extends undefined
+  ? (...args: TupleToInstances<Args>) => Promise<PublicOutput>
+  : (
+      publicInput: PublicInput,
+      ...args: TupleToInstances<Args>
+    ) => Promise<PublicOutput>;
+
+type TupleToInstances<T> = {
+  [I in keyof T]: InferProvable<T[I]>;
+};

--- a/src/lib/proof-system/zkprogram-context.ts
+++ b/src/lib/proof-system/zkprogram-context.ts
@@ -5,8 +5,8 @@ import type { ProofBase } from './proof.js';
 export { ZkProgramContext, DeclaredProof };
 
 type DeclaredProof = {
-  Proof: Subclass<typeof ProofBase<any, any>>;
-  proof: ProofBase<any, any>;
+  ProofClass: Subclass<typeof ProofBase<any, any>>;
+  proofInstance: ProofBase<any, any>;
 };
 type ZkProgramContext = {
   proofs: DeclaredProof[];

--- a/src/lib/proof-system/zkprogram-context.ts
+++ b/src/lib/proof-system/zkprogram-context.ts
@@ -18,6 +18,7 @@ const ZkProgramContext = {
     return context.enter({ proofs: [] });
   },
   leave: context.leave,
+  has: context.has,
 
   declareProof(proof: DeclaredProof) {
     context.get().proofs.push(proof);

--- a/src/lib/proof-system/zkprogram-context.ts
+++ b/src/lib/proof-system/zkprogram-context.ts
@@ -1,0 +1,28 @@
+import { Context } from '../util/global-context.js';
+import type { Subclass } from '../util/types.js';
+import type { ProofBase } from './proof.js';
+
+export { ZkProgramContext, DeclaredProof };
+
+type DeclaredProof = {
+  Proof: Subclass<typeof ProofBase<any, any>>;
+  proof: ProofBase<any, any>;
+};
+type ZkProgramContext = {
+  proofs: DeclaredProof[];
+};
+let context = Context.create<ZkProgramContext>();
+
+const ZkProgramContext = {
+  enter() {
+    return context.enter({ proofs: [] });
+  },
+  leave: context.leave,
+
+  declareProof(proof: DeclaredProof) {
+    context.get().proofs.push(proof);
+  },
+  getDeclaredProofs() {
+    return context.get().proofs;
+  },
+};

--- a/src/lib/proof-system/zkprogram.ts
+++ b/src/lib/proof-system/zkprogram.ts
@@ -393,17 +393,25 @@ function ZkProgram<
   ): RegularProver<K> {
     return async function prove_(publicInput, ...args) {
       if (!doProving) {
-        let { publicOutput, auxiliaryOutput } =
-          (hasPublicInput
-            ? await (methods[key].method as any)(publicInput, ...args)
-            : await (methods[key].method as any)(...args)) ?? {};
+        // we step into a ZkProgramContext here to match the context nesting
+        // that would happen if proofs were enabled -- otherwise, proofs declared
+        // in an inner program could be counted to the outer program
+        let id = ZkProgramContext.enter();
+        try {
+          let { publicOutput, auxiliaryOutput } =
+            (hasPublicInput
+              ? await (methods[key].method as any)(publicInput, ...args)
+              : await (methods[key].method as any)(...args)) ?? {};
 
-        let proof = await SelfProof.dummy(
-          publicInput,
-          publicOutput,
-          await getMaxProofsVerified()
-        );
-        return { proof, auxiliaryOutput };
+          let proof = await SelfProof.dummy(
+            publicInput,
+            publicOutput,
+            await getMaxProofsVerified()
+          );
+          return { proof, auxiliaryOutput };
+        } finally {
+          ZkProgramContext.leave(id);
+        }
       }
 
       if (compileOutput === undefined) {

--- a/src/lib/proof-system/zkprogram.ts
+++ b/src/lib/proof-system/zkprogram.ts
@@ -796,7 +796,7 @@ function picklesRuleFromFunction(
   proofSystemTag: { name: string },
   { methodName, args, auxiliaryType }: MethodInterface,
   gates: Gate[],
-  state?: ReturnType<typeof createProgramState>
+  state: ReturnType<typeof createProgramState> = createProgramState()
 ): Pickles.Rule {
   async function main(
     publicInput: MlFieldArray
@@ -875,11 +875,7 @@ function picklesRuleFromFunction(
       ? publicOutputType.toFields(result.publicOutput)
       : [];
 
-    if (
-      state !== undefined &&
-      auxiliaryType !== undefined &&
-      auxiliaryType.sizeInFields() !== 0
-    ) {
+    if (auxiliaryType !== undefined && auxiliaryType.sizeInFields() !== 0) {
       Provable.asProver(() => {
         let { auxiliaryOutput } = result;
         assert(

--- a/src/lib/proof-system/zkprogram.ts
+++ b/src/lib/proof-system/zkprogram.ts
@@ -816,10 +816,7 @@ function picklesRuleFromFunction(
         });
         finalArgs[i] = value;
 
-        for (let proof of extractProofs(value)) {
-          let Proof = proof.constructor as Subclass<typeof ProofBase<any, any>>;
-          ZkProgramContext.declareProof({ Proof, proof });
-        }
+        extractProofs(value).forEach((proof) => proof.declare());
       } catch (e: any) {
         ZkProgramContext.leave(id);
         e.message = `Error when witnessing in ${methodName}, argument ${i}: ${e.message}`;

--- a/src/lib/proof-system/zkprogram.ts
+++ b/src/lib/proof-system/zkprogram.ts
@@ -250,14 +250,6 @@ function ZkProgram<
   rawMethods: {
     [I in keyof Config['methods']]: Methods[I]['method'];
   };
-  provers: {
-    [I in keyof Config['methods']]: RegularProver<
-      InferProvableOrUndefined<Get<Config, 'publicInput'>>,
-      InferProvableOrVoid<Get<Config, 'publicOutput'>>,
-      PrivateInputs[I],
-      InferProvableOrUndefined<AuxiliaryOutputs[I]>
-    >;
-  };
   proofsEnabled: boolean;
   setProofsEnabled(proofsEnabled: boolean): void;
 } & {
@@ -549,7 +541,6 @@ function ZkProgram<
       rawMethods: Object.fromEntries(
         methodKeys.map((key) => [key, methods[key].method])
       ) as any,
-      provers: regularProvers,
       proofsEnabled: doProving,
       setProofsEnabled(proofsEnabled: boolean) {
         doProving = proofsEnabled;

--- a/src/lib/proof-system/zkprogram.ts
+++ b/src/lib/proof-system/zkprogram.ts
@@ -376,6 +376,9 @@ function ZkProgram<
     }
   }
 
+  // for each of the methods, create a prover function.
+  // in the first step, these are "regular" in that they always expect the public input as the first argument,
+  // which is easier to use internally.
   type RegularProver<K extends MethodKey> = (
     publicInput: PublicInput,
     ...args: PrivateInputs[K]
@@ -470,6 +473,8 @@ function ZkProgram<
   }
   let regularProvers = mapToObject(methodKeys, toRegularProver);
 
+  // wrap "regular" provers to remove an `undefined` public input argument,
+  // this matches how the method itself was defined in the case of no public input
   type Prover_<K extends MethodKey = MethodKey> = Prover<
     PublicInput,
     PublicOutput,

--- a/src/lib/util/arrays.ts
+++ b/src/lib/util/arrays.ts
@@ -1,6 +1,6 @@
 import { assert } from './errors.js';
 
-export { chunk, chunkString, zip, pad };
+export { chunk, chunkString, zip, pad, mapObject, mapToObject };
 
 function chunk<T>(array: T[], size: number): T[][] {
   assert(
@@ -30,4 +30,25 @@ function pad<T>(array: T[], size: number, value: T): T[] {
     `target size ${size} should be greater or equal than the length of the array ${array.length}`
   );
   return array.concat(Array.from({ length: size - array.length }, () => value));
+}
+
+function mapObject<
+  T extends Record<string, any>,
+  F extends <K extends keyof T>(value: T[K], key: K) => any
+>(t: T, fn: F) {
+  let s = {} as { [K in keyof T]: ReturnType<F> };
+  for (let key in t) {
+    s[key] = fn(t[key], key);
+  }
+  return s;
+}
+function mapToObject<
+  Key extends string | number | symbol,
+  F extends <K extends Key>(key: K, i: number) => any
+>(keys: Key[], fn: F) {
+  let s = {} as { [K in Key]: ReturnType<F> };
+  keys.forEach((key, i) => {
+    s[key] = fn(key, i);
+  });
+  return s;
 }

--- a/src/snarky.d.ts
+++ b/src/snarky.d.ts
@@ -625,6 +625,7 @@ declare namespace Pickles {
     main: (publicInput: MlArray<FieldVar>) => Promise<{
       publicOutput: MlArray<FieldVar>;
       previousStatements: MlArray<Statement<FieldVar>>;
+      previousProofs: MlArray<Proof>;
       shouldVerify: MlArray<BoolVar>;
     }>;
     /**
@@ -652,8 +653,7 @@ declare namespace Pickles {
   ];
 
   type Prover = (
-    publicInput: MlArray<FieldConst>,
-    previousProofs: MlArray<Proof>
+    publicInput: MlArray<FieldConst>
   ) => Promise<[_: 0, publicOutput: MlArray<FieldConst>, proof: Proof]>;
 }
 

--- a/src/tests/fake-proof.ts
+++ b/src/tests/fake-proof.ts
@@ -148,17 +148,12 @@ console.log('fake proof test passed for nested proofs 🎉');
 
 // test internal proof
 
-let wasCalled = false;
-callRecursive = () => {
-  console.log('creating a proof inside another!!!');
-  wasCalled = true;
-};
+callRecursive = () => console.log('creating a proof inside another!!!');
 
 const { proof: internalProof } = await RecursiveProgram.verifyInternal();
 assert(
   await verify(internalProof, programVk),
   'recursive program accepts internal proof'
 );
-assert(wasCalled, 'other program was called');
 
 console.log('positive test passed for internal proofs 🎉');

--- a/src/tests/inductive-proofs-internal.ts
+++ b/src/tests/inductive-proofs-internal.ts
@@ -1,0 +1,62 @@
+import { Field, ZkProgram, assert, Provable } from 'o1js';
+import { tic, toc } from '../examples/utils/tic-toc.js';
+import { expect } from 'expect';
+
+let log: string[] = [];
+
+function pushLog(s: string) {
+  Provable.asProver(() => {
+    console.log(s);
+    log.push(s);
+  });
+}
+
+let MaxProofsVerifiedTwo = ZkProgram({
+  name: 'recursive-2',
+  publicOutput: Field,
+
+  methods: {
+    baseCase: {
+      privateInputs: [],
+
+      async method() {
+        pushLog('baseCase');
+        return { publicOutput: Field(7) };
+      },
+    },
+
+    mergeOne: {
+      privateInputs: [],
+
+      async method() {
+        pushLog('mergeOne');
+        let x: Field = await MaxProofsVerifiedTwo.proveRecursively.baseCase();
+        return { publicOutput: x.add(1) };
+      },
+    },
+
+    mergeTwo: {
+      privateInputs: [],
+
+      async method() {
+        pushLog('mergeTwo');
+        let x: Field = await MaxProofsVerifiedTwo.proveRecursively.baseCase();
+        let y: Field = await MaxProofsVerifiedTwo.proveRecursively.mergeOne();
+        return { publicOutput: x.add(y) };
+      },
+    },
+  },
+});
+tic('compiling');
+await MaxProofsVerifiedTwo.compile();
+toc();
+
+tic('executing 4 proofs');
+let { proof } = await MaxProofsVerifiedTwo.mergeTwo();
+toc();
+
+assert(await MaxProofsVerifiedTwo.verify(proof), 'Proof is not valid');
+
+proof.publicOutput.assertEquals(15);
+
+expect(log).toEqual(['mergeTwo', 'baseCase', 'mergeOne', 'baseCase']);

--- a/src/tests/inductive-proofs-internal.ts
+++ b/src/tests/inductive-proofs-internal.ts
@@ -1,6 +1,5 @@
 import { Field, ZkProgram, assert, Provable } from 'o1js';
 import { tic, toc } from '../examples/utils/tic-toc.js';
-import { expect } from 'expect';
 
 let log: string[] = [];
 
@@ -59,4 +58,8 @@ assert(await MaxProofsVerifiedTwo.verify(proof), 'Proof is not valid');
 
 proof.publicOutput.assertEquals(15);
 
-expect(log).toEqual(['mergeTwo', 'baseCase', 'mergeOne', 'baseCase']);
+assert(log.length === 4, 'log.length === 4');
+assert(log[0] === 'mergeTwo', 'log[0] === "mergeTwo"');
+assert(log[1] === 'baseCase', 'log[1] === "baseCase"');
+assert(log[2] === 'mergeOne', 'log[2] === "mergeOne"');
+assert(log[3] === 'baseCase', 'log[3] === "baseCase"');

--- a/src/tests/inductive-proofs-internal.ts
+++ b/src/tests/inductive-proofs-internal.ts
@@ -1,4 +1,4 @@
-import { Field, ZkProgram, assert, Provable } from 'o1js';
+import { Field, ZkProgram, assert, Provable, Proof } from 'o1js';
 import { tic, toc } from '../examples/utils/tic-toc.js';
 
 let log: string[] = [];
@@ -49,8 +49,26 @@ let MaxProofsVerifiedTwo = ZkProgram({
     },
   },
 });
+
+let Wrapper = ZkProgram({
+  name: 'wraps-recursive-2',
+
+  methods: {
+    wrap: {
+      privateInputs: [ZkProgram.Proof(MaxProofsVerifiedTwo)],
+
+      async method(proof: Proof<undefined, Field>) {
+        proof.verify();
+        let x = proof.publicOutput;
+        x.assertLessThan(30);
+      },
+    },
+  },
+});
+
 tic('compiling');
 await MaxProofsVerifiedTwo.compile();
+await Wrapper.compile();
 toc();
 
 tic('executing 4 proofs');
@@ -66,3 +84,8 @@ assert(log[0] === 'mergeTwo', 'log[0] === "mergeTwo"');
 assert(log[1] === 'baseCase', 'log[1] === "baseCase"');
 assert(log[2] === 'mergeOne', 'log[2] === "mergeOne"');
 assert(log[3] === 'baseCase', 'log[3] === "baseCase"');
+
+tic('execute wrapper proof');
+let { proof: wrapperProof } = await Wrapper.wrap(proof);
+toc();
+assert(await Wrapper.verify(wrapperProof), 'Wrapper proof is not valid');

--- a/src/tests/inductive-proofs-internal.ts
+++ b/src/tests/inductive-proofs-internal.ts
@@ -16,11 +16,12 @@ let MaxProofsVerifiedTwo = ZkProgram({
 
   methods: {
     baseCase: {
-      privateInputs: [],
+      privateInputs: [Field],
 
-      async method() {
+      async method(x: Field) {
         pushLog('baseCase');
-        return { publicOutput: Field(7) };
+        x = x.add(7);
+        return { publicOutput: x };
       },
     },
 
@@ -29,7 +30,8 @@ let MaxProofsVerifiedTwo = ZkProgram({
 
       async method() {
         pushLog('mergeOne');
-        let x: Field = await MaxProofsVerifiedTwo.proveRecursively.baseCase();
+        let z = Provable.witness(Field, () => 0);
+        let x: Field = await MaxProofsVerifiedTwo.proveRecursively.baseCase(z);
         return { publicOutput: x.add(1) };
       },
     },
@@ -39,7 +41,8 @@ let MaxProofsVerifiedTwo = ZkProgram({
 
       async method() {
         pushLog('mergeTwo');
-        let x: Field = await MaxProofsVerifiedTwo.proveRecursively.baseCase();
+        let z = Provable.witness(Field, () => 0);
+        let x: Field = await MaxProofsVerifiedTwo.proveRecursively.baseCase(z);
         let y: Field = await MaxProofsVerifiedTwo.proveRecursively.mergeOne();
         return { publicOutput: x.add(y) };
       },


### PR DESCRIPTION
This PR enables to "declare" a recursively verified proof from _within a ZkProgram method_. Thus, recursive proofs no longer need to be inputs to the method, and therefore can be abstracted away much more easily.

bindings: https://github.com/o1-labs/o1js-bindings/pull/318

The new low-level way of introducing a proof that hasn't been passed as method argument is as follows:
```ts
let proof = await Provable.witnessAsync(MyProof, async () => { /* generate and return proof */  });
proof.declare();
// ... use the proof as if it had been a method argument ...
```

## New Recursion API

_see UPDATE below for final version of this API_

On top of this, I added an even more pleasant API, which you can use in the typical case where the ZkProgram that produces the inner proof is in scope. For this, assume the proof in question is supposed to come from a method `innerProgram.run()`. Then, the entire logic above is now encapsulated inside the new property `innerProgram.proveRecursively.run()`:

```ts
// inside outer zkprogram method
let output = await innerProgram.proveRecursively.run(...inputs);
```
note: this expects the inputs (public and private) as arguments and returns the public output -- which is the natural way to think of calling a method.

Internally, we make sure that the inner proof's _public_ input matches what the outer circuit passed in.

**Caveats**: of course we can't make any statement about the private inputs, because the inner proof inherently doesn't reveal those. so the private inputs must be understood only as hints to the recursive proving. Similarly, the inner proof doesn't guarantee the _particular method_ that was called on the inner program: as usual with recursive proofs, all of the methods can produce it.

An e2e example, that I added to CI and also manually ran in the browser, is at `src/tests/inductive-proofs-internal.ts`

**UPDATE**: after discussions, the API was changed to live separately from ZkProgram:

```ts
let inner = ZkProgram({ ..., methods: { run: ... });
let innerRecursive = Experimental.Recursive(program);

// inside another -- or even the same -- program:
let output = await innerRecursive.run(...inputs);
```