### PR TITLE
chore(all): fix typos with spellchecker

### DIFF
--- a/src/examples/crypto/foreign-field.ts
+++ b/src/examples/crypto/foreign-field.ts
@@ -33,7 +33,7 @@ assert(z instanceof SmallField.Unreduced);
 // note: "unreduced" doesn't usually mean that the underlying witness is larger than the modulus.
 // it just means we haven't _proved_ so.. which means a malicious prover _could_ have managed to make it larger.
 
-// unreduced fields can be added and subtracted, but not be used in multiplcation:
+// unreduced fields can be added and subtracted, but not be used in multiplication:
 
 z.add(1).sub(x).assertEquals(0); // works
 

--- a/src/examples/zkapps/voting/membership.ts
+++ b/src/examples/zkapps/voting/membership.ts
@@ -96,7 +96,7 @@ export class Membership_ extends SmartContract {
     // Preconditions: Restrict who can vote or who can be a candidate
 
     // since we need to keep this contract "generic", we always assert within a range
-    // even tho voters cant have a maximum balance, only candidates
+    // even tho voters can't have a maximum balance, only candidates
     // but for a voter we simply use UInt64.MAXINT() as the maximum
 
     let accountUpdate = AccountUpdate.create(member.publicKey);
@@ -133,7 +133,7 @@ export class Membership_ extends SmartContract {
     );
 
     /*
-    we cant really branch the control flow - we will always have to emit an event no matter what, 
+    we can't really branch the control flow - we will always have to emit an event no matter what, 
     so we emit an empty event if the member already exists
     it the member doesn't exist, emit the "real" member
     */

--- a/src/examples/zkapps/voting/test.ts
+++ b/src/examples/zkapps/voting/test.ts
@@ -556,7 +556,7 @@ export async function testSet(
     }
 
     // the merkle roots of both membership contract should still be the initial ones because publish hasn't been invoked
-    // therefor the state should not have changes
+    // therefore the state should not have changes
     if (
       !candidateContract.committedMembers.get().equals(initialRoot).toBoolean()
     ) {

--- a/src/lib/mina/account-update.ts
+++ b/src/lib/mina/account-update.ts
@@ -1205,7 +1205,7 @@ class AccountUpdate implements Types.AccountUpdate {
    * This function acts as the `check()` method on an `AccountUpdate` that is sent to the Mina node as part of a transaction.
    *
    * Background: the Mina node performs most necessary validity checks on account updates, both in- and outside of circuits.
-   * To save constraints, we don't repeat these checks in zkApps in places where we can be sure the checked account udpates
+   * To save constraints, we don't repeat these checks in zkApps in places where we can be sure the checked account updates
    * will be part of a transaction.
    *
    * However, there are a few checks skipped by the Mina node, that could cause vulnerabilities in zkApps if

--- a/src/lib/proof-system/proof.ts
+++ b/src/lib/proof-system/proof.ts
@@ -183,7 +183,7 @@ class Proof<Input, Output> extends ProofBase<Input, Output> {
 let sideloadedKeysCounter = 0;
 
 /**
- * The `DynamicProof` class enables circuits to verify proofs using in-ciruit verfication keys.
+ * The `DynamicProof` class enables circuits to verify proofs using in-ciruit verification keys.
  * This is opposed to the baked-in verification keys of the `Proof` class.
  *
  * In order to use this, a subclass of DynamicProof that specifies the public input and output types along with the maxProofsVerified number has to be created.

--- a/src/lib/proof-system/zkprogram.ts
+++ b/src/lib/proof-system/zkprogram.ts
@@ -534,7 +534,7 @@ function ZkProgram<
     provers
   );
 
-  // Object.assign only shallow-copies, hence we cant use this getter and have to define it explicitly
+  // Object.assign only shallow-copies, hence we can't use this getter and have to define it explicitly
   Object.defineProperty(program, 'proofsEnabled', {
     get: () => doProving,
   });

--- a/src/lib/provable/core/fieldvar.ts
+++ b/src/lib/provable/core/fieldvar.ts
@@ -31,7 +31,7 @@ enum FieldType {
 }
 
 /**
- * `FieldVar` is the core data type in snarky. It is eqivalent to `Cvar.t` in OCaml.
+ * `FieldVar` is the core data type in snarky. It is equivalent to `Cvar.t` in OCaml.
  * It represents a field element that is part of provable code - either a constant or a variable.
  *
  * **Variables** end up filling the witness columns of a constraint system.

--- a/src/lib/provable/gadgets/blake2b.ts
+++ b/src/lib/provable/gadgets/blake2b.ts
@@ -116,7 +116,7 @@ function G(
  */
 function compress(state: State, last: boolean): State {
   const { h, t, buf } = state;
-  const v = h.concat(BLAKE2B.IV); // initalize local work vector. First half from state and second half from IV.
+  const v = h.concat(BLAKE2B.IV); // initialize local work vector. First half from state and second half from IV.
 
   v[12] = v[12].xor(UInt64.from(t[0])); // low word of the offset
   v[13] = v[13].xor(UInt64.from(t[1])); // high word of the offset

--- a/src/lib/provable/group.ts
+++ b/src/lib/provable/group.ts
@@ -96,7 +96,7 @@ class Group {
    */
   add(g: Group) {
     if (isConstant(this) && isConstant(g)) {
-      // we check if either operand is zero, because adding zero to g just results in g (and vise versa)
+      // we check if either operand is zero, because adding zero to g just results in g (and vice versa)
       if (this.isZero().toBoolean()) {
         return g;
       } else if (g.isZero().toBoolean()) {

--- a/src/lib/provable/merkle-tree-indexed.ts
+++ b/src/lib/provable/merkle-tree-indexed.ts
@@ -52,7 +52,7 @@ export { Leaf };
  *
  * Initially, every `IndexedMerkleMap` is populated by a single key-value pair: `(0, 0)`. The value for key `0` can be updated like any other.
  * When keys and values are hash outputs, `(0, 0)` can serve as a convenient way to represent a dummy update to the tree, since 0 is not
- * effciently computable as a hash image, and this update doesn't affect the Merkle root.
+ * efficiently computable as a hash image, and this update doesn't affect the Merkle root.
  */
 function IndexedMerkleMap(height: number): typeof IndexedMerkleMapBase {
   assert(height > 0, 'height must be positive');

--- a/src/lib/provable/scalar-field.ts
+++ b/src/lib/provable/scalar-field.ts
@@ -20,7 +20,7 @@ class ScalarField extends createForeignField(Fq.modulus) {
   public static toScalar(field: ForeignField) {
     if (field.modulus !== Fq.modulus) {
       throw new Error(
-        'Only ForeignFields with Fq modulus are convertable into a scalar'
+        'Only ForeignFields with Fq modulus are convertible into a scalar'
       );
     }
     const field3 = field.value;


### PR DESCRIPTION
 1. fix current exist typo:`codespell  -L TE,tHi,modul,everytime,iSelf  --skip="*test,CHANGELOG.md"`
 2. consider add typo checker in workflow ref: https://github.com/codespell-project/codespell