### PR TITLE
fix: typos in documentation files

### DIFF
--- a/src/examples/crypto/foreign-field.ts
+++ b/src/examples/crypto/foreign-field.ts
@@ -33,7 +33,7 @@ assert(z instanceof SmallField.Unreduced);
 // note: "unreduced" doesn't usually mean that the underlying witness is larger than the modulus.
 // it just means we haven't _proved_ so.. which means a malicious prover _could_ have managed to make it larger.
 
-// unreduced fields can be added and subtracted, but not be used in multiplcation:
+// unreduced fields can be added and subtracted, but not be used in multiplication:
 
 z.add(1).sub(x).assertEquals(0); // works
 

--- a/src/lib/mina/account-update.ts
+++ b/src/lib/mina/account-update.ts
@@ -1205,7 +1205,7 @@ class AccountUpdate implements Types.AccountUpdate {
    * This function acts as the `check()` method on an `AccountUpdate` that is sent to the Mina node as part of a transaction.
    *
    * Background: the Mina node performs most necessary validity checks on account updates, both in- and outside of circuits.
-   * To save constraints, we don't repeat these checks in zkApps in places where we can be sure the checked account udpates
+   * To save constraints, we don't repeat these checks in zkApps in places where we can be sure the checked account updates
    * will be part of a transaction.
    *
    * However, there are a few checks skipped by the Mina node, that could cause vulnerabilities in zkApps if


### PR DESCRIPTION
This pull request contains changes to improve clarity, correctness and structure.

**Description correction:**
Corrected `multiplcation` to `multiplication`
Corrected `udpates` to `updates`

Please review the changes and let me know if any additional changes are needed.