### PR TITLE
Expose method to fetch internal state on an `OffchainStateInstance`

### DIFF
--- a/src/lib/mina/actions/offchain-state.ts
+++ b/src/lib/mina/actions/offchain-state.ts
@@ -104,6 +104,11 @@ type OffchainStateInstance<
    * Commitments to the offchain state, to use in your onchain state.
    */
   commitments(): State<OffchainStateCommitments>;
+
+  /**
+   * Rebuilds the internal state map by fetching actions up to the current actionState in offchainStateCommitments
+   * */
+  fetchInternalState(): void;
 };
 
 type OffchainState<Config extends { [key: string]: OffchainStateKind }> = {
@@ -468,6 +473,17 @@ function OffchainState<
         internal.valueMap = newValueMap;
 
         return result.proof;
+      },
+
+      async fetchInternalState() {
+        let actionState = await onchainActionState();
+        let { merkleMap, valueMap } = await fetchMerkleMap(
+          height,
+          internal.contract,
+          actionState
+        );
+        internal.merkleMap = merkleMap;
+        internal.valueMap = valueMap;
       },
 
       async settle(


### PR DESCRIPTION
Created to address [1935](https://github.com/o1-labs/o1js/issues/1935).

Exposes a method on `OffchainStateInstance` `fetchInternalState` which fetches settled actions from the archive node and rebuilds the internal state trees.
