### PR TITLE
Update nix build and local dev guides

### DIFF
--- a/README-dev.md
+++ b/README-dev.md
@@ -227,3 +227,19 @@ To facilitate this process, use the provided script named `run-debug`. To use th
 This script initializes a Node.js process with the `--inspect-brk` flag that starts the Node.js inspector and breaks before the user script starts (i.e., it pauses execution until a debugger is attached). The `--enable-source-maps` flag ensures that source maps are used to allow easy debugging of o1js code directly.
 
 After the Node.js process is running, open the Chrome browser and navigate to `chrome://inspect` to attach the Chrome Debugger to the Node.js process. You can set breakpoints, inspect variables, and profile the performance of your zkApp or o1js. For more information on using the Chrome Debugger, see the [DevTools documentation](https://developer.chrome.com/docs/devtools/).
+
+### Debugging within the SDK
+To debug a call into the SDK, you can link your local copy of the SDK with `npm link`. After that, you'll be able to add log statements, set breakpoints, and make code changes. Within the SDK, run:
+```sh
+npm run link
+``` 
+Then in your zkApp codebase, run:
+```sh
+npm link o1js
+```
+
+#### Logging from OCaml
+If you need to debug a call into the OCaml code, the process is a little more complicated. The OCaml is compiled into JavaScript with js_of_ocaml during `npm run build:update-bindings`, so you'll need to add your logs into the OCaml code and rebuild the bindings to see them. Logging from OCaml in a way that will reflect as JS `console.log`s in the compiled code can be done like this:
+```ocaml
+let () = print_endline "This is a log" in
+```

--- a/README-nix.md
+++ b/README-nix.md
@@ -92,21 +92,7 @@ nix develop o1js#default
 The first time you run this command, you can expect it to take hours (or even a full day) to complete. Then, you will observe that the current devshell becomes a Nix shell with the right
 configuration for `o1js` and `mina`.
 
-In order to make sure that the bindings will be regenerated in the case that you
-are modifying them, make sure to comment out the conditionals in
-`src/mina/src/lib/crypto/kimchi_bindings/js/node_js/build.sh` and `src/mina/src/lib/crypto/kimchi_bindings/js/web/build.sh` locally. That's because otherwise the
-PLONK_WASM_WEB check prevents `proof-systems` from compiling with each build.
-
-```sh
-if true; then # [[ -z "${PLONK_WASM_WEB-}" ]]; then
-    export RUSTFLAGS="-C target-feature=+atomics,+bulk-memory,+mutable-globals -C link-arg=--no-check-features -C link-arg=--max-memory=4294967296"
-    rustup run nightly-2023-09-01 wasm-pack build --target web --out-dir ../js/web ../../wasm -- -Z build-std=panic_abort,std
-else
-    cp "$PLONK_WASM_WEB"/* -R .
-fi
-```
-
-Then, you can build o1js and update the bindings.
+From within the shell, you can build o1js and update the bindings.
 
 ```console
 npm run build
@@ -305,4 +291,4 @@ Then, the error message would still contain old directories.
 
 #### Fix
 
-Create a new environment for Nix and start from scratch. In particular, run the garbage collector which will remove old dependencies. 
+Rerun `pin.sh` and `src/mina/nix/pin.sh`.


### PR DESCRIPTION
Requires a change to build scripts in Mina repo removing the check that blocks rust builds when `npm run build:update-bindings` is run.