### PR TITLE
Fix incorrect usage of articles ("a" vs "an") in code comments to improve clarity and grammatical accuracy.  

### DIFF
--- a/src/examples/crypto/rsa/utils.ts
+++ b/src/examples/crypto/rsa/utils.ts
@@ -13,7 +13,7 @@ function rsaSign(message: bigint, privateKey: bigint, modulus: bigint): bigint {
 }
 
 /**
- * Generates a SHA-256 digest of the input message and returns the hash as a native bigint.
+ * Generates an SHA-256 digest of the input message and returns the hash as a native bigint.
  * @param  message - The input message to be hashed.
  * @returns The SHA-256 hash of the input message as a native bigint.
  */

--- a/src/lib/mina/token.test.ts
+++ b/src/lib/mina/token.test.ts
@@ -30,7 +30,7 @@ class TokenContract extends TokenContractBase {
   }
 
   /**
-   * This deploy method lets a another token account deploy their contract and verification key as a child of this token contract.
+   * This deploy method lets an another token account deploy their contract and verification key as a child of this token contract.
    * This is important since we want the native token id of the deployed contract to be the token id of the token contract.
    */
   @method async deploy_(address: PublicKey, verificationKey: VerificationKey) {

--- a/src/lib/provable/crypto/nullifier.ts
+++ b/src/lib/provable/crypto/nullifier.ts
@@ -71,7 +71,7 @@ class Nullifier extends Struct({
     // h_m_pk_r =  h(m,pk)^s / nullifier^c
     let h_m_pk_s_div_nullifier_s = h_m_pk_s.sub(nullifier.scale(c));
 
-    // this is supposed to match the entries generated on "the other side" of the nullifier (mina-signer, in an wallet enclave)
+    // this is supposed to match the entries generated on "the other side" of the nullifier (mina-signer, in a wallet enclave)
     Poseidon.hash([
       ...Group.toFields(G),
       ...pk_fields,


### PR DESCRIPTION
- Corrected article usage based on whether the following word starts with a consonant or vowel sound.
 
### Checklist
- [x] Reviewed and corrected grammar issues in comments.
- [x] Ensured no functional changes were introduced.
- [x] Verified consistency across all updated files.
 
---
 
### Additional Notes
These changes are focused solely on improving documentation and code comments without affecting logic or functionality.

