### PR TITLE
add action to upload a patch when bindings differ

### DIFF
--- a/.github/workflows/build-bindings.yml
+++ b/.github/workflows/build-bindings.yml
@@ -30,6 +30,8 @@ jobs:
           nix run o1js#update-bindings --max-jobs 4
           #fail if this changes any files
           cd src/bindings
+          echo If this check fails you can download a patch from the patch-upload job
+          echo "https://github.com/o1-labs/o1js/blob/main/README-dev.md#build-scripts"
           git diff --exit-code
       - name: add build to gc-root if on main
         if: github.ref == 'refs/heads/main'

--- a/.github/workflows/build-bindings.yml
+++ b/.github/workflows/build-bindings.yml
@@ -31,7 +31,7 @@ jobs:
           #fail if this changes any files
           cd src/bindings
           echo If this check fails you can download a patch from the patch-upload job
-          echo "https://github.com/o1-labs/o1js/blob/main/README-dev.md#build-scripts"
+          echo "https://github.com/o1-labs/o1js/blob/main/README-dev.md#bindings-check-in-ci"
           git diff --exit-code
       - name: add build to gc-root if on main
         if: github.ref == 'refs/heads/main'

--- a/.github/workflows/build-bindings.yml
+++ b/.github/workflows/build-bindings.yml
@@ -39,3 +39,18 @@ jobs:
         run: |
           nix-store --gc --print-dead
           nix-store --optimise
+  patch-upload:
+    needs: nix-build
+    if: ${{ failure() }}
+    runs-on: [sdk-self-hosted-linux-amd64-build-system]
+    steps:
+      - name: generate patch
+        run: |
+          cd src/bindings
+          git add .
+          git diff HEAD > bindings.patch
+      - name: Upload patch
+        uses: actions/upload-artifact@v4
+        with:
+          name: bindings.patch
+          path: src/bindings/bindings.patch

--- a/.github/workflows/build-bindings.yml
+++ b/.github/workflows/build-bindings.yml
@@ -48,9 +48,9 @@ jobs:
         run: |
           cd src/bindings
           git add .
-          git diff HEAD > bindings.patch
+          git diff HEAD > ../../bindings.patch
       - name: Upload patch
         uses: actions/upload-artifact@v4
         with:
           name: bindings.patch
-          path: src/bindings/bindings.patch
+          path: bindings.patch

--- a/README-dev.md
+++ b/README-dev.md
@@ -86,6 +86,20 @@ In addition to building the OCaml and Rust code, the build script also generates
 
 o1js uses these types to ensure that the constants used in the protocol are consistent with the OCaml source files.
 
+### Bindings check in ci
+
+If the bindings check fails in CI it will upload a patch you can use to update the bindings without having to rebuild locally.
+This can also be helpful when the bindings don't build identically, as unfortunately often happens.
+
+To use this patch:
+- Click details on the `Build o1js bindings / build-bindings-ubunutu` job
+- Go to the `patch-upload` job and expand the logs for `Upload patch`
+- Download the file linked in the last line of the logs ie.
+`Artifact download URL: https://github.com/o1-labs/o1js/actions/runs/12401083741/artifacts/2339952965`
+- unzip it
+- navigate to `src/bindings`
+- run `git apply path/to/bindings.patch`
+
 ## Development
 
 ### Branching Policy


### PR DESCRIPTION
I noticed there are a couple PRs failing the bindings check right now, and I know the exact way the bindings generate can be weird and flaky, so I added a workflow to upload the diff from ci, so you can easily download it and apply it.
Ideally it would comment it as a suggestion, but AFAIK that can't really work for submodules so I think this is the next best thing.

Sorry to make such a small pr, this should've been part of #1800 