### PR TITLE
fix git diff to include .wasm files

### DIFF
--- a/.github/workflows/build-bindings.yml
+++ b/.github/workflows/build-bindings.yml
@@ -50,7 +50,7 @@ jobs:
         run: |
           cd src/bindings
           git add .
-          git diff HEAD > ../../bindings.patch
+          git diff HEAD --textconv --text > ../../bindings.patch
       - name: Upload patch
         uses: actions/upload-artifact@v4
         with:

--- a/flake.lock
+++ b/flake.lock
@@ -265,8 +265,8 @@
         "utils": "utils"
       },
       "locked": {
-        "lastModified": 1733429866,
-        "narHash": "sha256-/ZEGYdZ2hLjBwdEzG/BIjlDehOjuGWmBqzD55nXfZoY=",
+        "lastModified": 1734626051,
+        "narHash": "sha256-4LLy5VMM5TK4LpQXEBiA8ziwYyqGx2ZAuunXGCDpraQ=",
         "path": "src/mina",
         "type": "path"
       },


### PR DESCRIPTION
Fixes issue with  #1958 where wasm files get summarized in the diff to
`Binary files a/compiled/node_bindings/plonk_wasm_bg.wasm and b/compiled/node_bindings/plonk_wasm_bg.wasm differ`
and then git apply doesn't work like you'd want.

o1js-bindings changes: https://github.com/o1-labs/o1js-bindings/pull/322