### PR TITLE
Add Provable to documentation

### DIFF
--- a/src/lib/provable/provable.ts
+++ b/src/lib/provable/provable.ts
@@ -1,8 +1,3 @@
-/**
- * {@link Provable} is
- * - a namespace with tools for writing provable code
- * - the main interface for types that can be used in provable code
- */
 import { Bool } from './bool.js';
 import { Field } from './field.js';
 import { Provable as Provable_, ProvableType } from './types/provable-intf.js';
@@ -30,7 +25,7 @@ import { InferValue } from '../../bindings/lib/provable-generic.js';
 import { ToProvable } from '../../lib/provable/types/provable-intf.js';
 
 // external API
-export { Provable };
+export { Provable, ProvableNamespace };
 
 // internal API
 export {
@@ -54,7 +49,7 @@ export {
  */
 type Provable<T, TValue = any> = Provable_<T, TValue>;
 
-const Provable = {
+type ProvableNamespace = {
   /**
    * Create a new witness. A witness, or variable, is a value that is provided as input
    * by the prover. This provides a flexible way to introduce values from outside into the circuit.
@@ -72,19 +67,19 @@ const Provable = {
    * invX.mul(x).assertEquals(1);
    * ```
    */
-  witness,
+  witness: Function;
   /**
    * Witness a tuple of field elements. This works just like {@link Provable.witness},
    * but optimized for witnessing plain field elements, which is especially common
    * in low-level provable code.
    */
-  witnessFields,
+  witnessFields: Function;
   /**
    * Create a new witness from an async callback.
    *
    * See {@link Provable.witness} for more information.
    */
-  witnessAsync,
+  witnessAsync: Function;
   /**
    * Proof-compatible if-statement.
    * This behaves like a ternary conditional statement in JS.
@@ -99,7 +94,7 @@ const Provable = {
    * const result = Provable.if(condition, Field(1), Field(2)); // returns Field(1)
    * ```
    */
-  if: if_,
+  if: Function;
   /**
    * Generalization of {@link Provable.if} for choosing between more than two different cases.
    * It takes a "mask", which is an array of `Bool`s that contains only one `true` element, a type/constructor, and an array of values of that type.
@@ -110,7 +105,7 @@ const Provable = {
    * x.assertEquals(2);
    * ```
    */
-  switch: switch_,
+  switch: Function;
   /**
    * Asserts that two values are equal.
    * @example
@@ -121,13 +116,13 @@ const Provable = {
    * Provable.assertEqual(MyStruct, a, b);
    * ```
    */
-  assertEqual,
+  assertEqual: Function;
   /**
    * Asserts that two values are equal, if an enabling condition is true.
    *
    * If the condition is false, the assertion is skipped.
    */
-  assertEqualIf,
+  assertEqualIf: Function;
   /**
    * Checks if two elements are equal.
    * @example
@@ -138,7 +133,7 @@ const Provable = {
    * const isEqual = Provable.equal(MyStruct, a, b);
    * ```
    */
-  equal,
+  equal: Function;
   /**
    * Creates a {@link Provable} for a generic array.
    * @example
@@ -146,7 +141,7 @@ const Provable = {
    * const ProvableArray = Provable.Array(Field, 5);
    * ```
    */
-  Array: provableArray,
+  Array: Function;
   /**
    * Check whether a value is constant.
    * See {@link FieldVar} for more information about constants and variables.
@@ -157,7 +152,7 @@ const Provable = {
    * Provable.isConstant(Field, x); // true
    * ```
    */
-  isConstant,
+  isConstant: Function;
   /**
    * Interface to log elements within a circuit. Similar to `console.log()`.
    * @example
@@ -166,7 +161,7 @@ const Provable = {
    * Provable.log(element);
    * ```
    */
-  log,
+  log: Function;
   /**
    * Runs code as a prover.
    * @example
@@ -176,7 +171,7 @@ const Provable = {
    * });
    * ```
    */
-  asProver,
+  asProver: Function;
   /**
    * Runs provable code quickly, without creating a proof, but still checking whether constraints are satisfied.
    * @example
@@ -186,9 +181,7 @@ const Provable = {
    * });
    * ```
    */
-  async runAndCheck(f: (() => Promise<void>) | (() => void)) {
-    await generateWitness(f, { checkConstraints: true });
-  },
+  runAndCheck: Function;
   /**
    * Runs provable code quickly, without creating a proof, and not checking whether constraints are satisfied.
    * @example
@@ -198,9 +191,7 @@ const Provable = {
    * });
    * ```
    */
-  async runUnchecked(f: (() => Promise<void>) | (() => void)) {
-    await generateWitness(f, { checkConstraints: false });
-  },
+  runUnchecked: Function;
   /**
    * Returns information about the constraints created by the callback function.
    * @example
@@ -209,7 +200,7 @@ const Provable = {
    * console.log(result);
    * ```
    */
-  constraintSystem,
+  constraintSystem: Function;
   /**
    * Checks if the code is run in prover mode.
    * @example
@@ -219,7 +210,7 @@ const Provable = {
    * }
    * ```
    */
-  inProver,
+  inProver: Function;
   /**
    * Checks if the code is run in checked computation mode.
    * @example
@@ -229,11 +220,48 @@ const Provable = {
    * }
    * ```
    */
-  inCheckedComputation,
+  inCheckedComputation: Function;
 
   /**
    * Returns a constant version of a provable type.
    */
+  toConstant: Function;
+
+  /**
+   * Return a canonical version of a value, where
+   * canonical is defined by the `type`.
+   */
+  toCanonical: Function;
+};
+
+/**
+ * {@link Provable} is
+ * - a namespace with tools for writing provable code
+ * - the main interface for types that can be used in provable code
+ * - see: {@link ProvableNamespace}
+ */
+const Provable = {
+  witness,
+  witnessFields,
+  witnessAsync,
+  if: if_,
+  switch: switch_,
+  assertEqual,
+  assertEqualIf,
+  equal,
+  Array: provableArray,
+  isConstant,
+  log,
+  asProver,
+  async runAndCheck(f: (() => Promise<void>) | (() => void)) {
+    await generateWitness(f, { checkConstraints: true });
+  },
+  async runUnchecked(f: (() => Promise<void>) | (() => void)) {
+    await generateWitness(f, { checkConstraints: false });
+  },
+  constraintSystem,
+  inProver,
+  inCheckedComputation,
   toConstant<T>(type: ProvableType<T>, value: T) {
     type = ProvableType.get(type);
     return type.fromFields(
@@ -241,11 +269,6 @@ const Provable = {
       type.toAuxiliary(value)
     );
   },
-
-  /**
-   * Return a canonical version of a value, where
-   * canonical is defined by the `type`.
-   */
   toCanonical<T>(type: Provable<T>, value: T) {
     return type.toCanonical?.(value) ?? value;
   },

--- a/src/lib/provable/provable.ts
+++ b/src/lib/provable/provable.ts
@@ -1,3 +1,9 @@
+/**
+ * {@link Provable} is
+ * - a namespace with tools for writing provable code
+ * - the main interface for types that can be used in provable code
+ */
+
 import { Bool } from './bool.js';
 import { Field } from './field.js';
 import { Provable as Provable_, ProvableType } from './types/provable-intf.js';
@@ -46,9 +52,17 @@ export {
  * All built-in provable types in o1js ({@link Field}, {@link Bool}, etc.) are instances of `Provable<T>` as well.
  *
  * Note: These methods are meant to be used by the library internally and are not directly when writing provable code.
+ *
+ * For documentation about the methods in the `Provable` namespace, see {@link ProvableNamespace}.
  */
 type Provable<T, TValue = any> = Provable_<T, TValue>;
 
+/**
+ * The `Provable` namespace contains methods for writing provable code.
+ *
+ * Access these methods by importing `Provable` from o1js.
+ *
+ */
 type ProvableNamespace = {
   /**
    * Create a new witness. A witness, or variable, is a value that is provided as input
@@ -235,10 +249,7 @@ type ProvableNamespace = {
 };
 
 /**
- * {@link Provable} is
- * - a namespace with tools for writing provable code
- * - the main interface for types that can be used in provable code
- * - see: {@link ProvableNamespace}
+ * For documentation about the methods in the `Provable` namespace, see {@link ProvableNamespace}.
  */
 const Provable = {
   witness,

--- a/typedoc.json
+++ b/typedoc.json
@@ -12,8 +12,7 @@
     "src/bindings/**/*",
     "src/examples/**/*",
     "src/lib/provable/+(core|test)/**/*",
-    "src/**/*(test|unit-test).ts",
-    "src/lib/provable/provable.ts"
+    "src/**/*(test|unit-test).ts"
   ],
   "entryPoints": [
     "src/index.ts",
@@ -25,6 +24,7 @@
     "src/lib/provable/merkle-list.ts",
     "src/lib/provable/merkle-map.ts",
     "src/lib/provable/merkle-tree.ts",
+    "src/lib/provable/provable.ts",
     "src/lib/provable/types/provable-intf.ts"
   ],
   "entryPointStrategy": "resolve",


### PR DESCRIPTION
## Summary

[Provable<T>](https://github.com/o1-labs/o1js/blob/82db28b6cb491801f42f5b3d4b89c8aa7b5d177d/src/lib/provable/provable.ts#L55) and [Provable](https://github.com/o1-labs/o1js/blob/82db28b6cb491801f42f5b3d4b89c8aa7b5d177d/src/lib/provable/provable.ts#L57) are both exported as `Provable` from the same file.  There are good documentation comments on the constant variable `Provable` that we want to expose in the [o1js-reference documentation](https://docs.minaprotocol.com/zkapps/o1js-reference), but it is tricky to disambiguate the two symbols.

### Approach

This PR creates a dummy type called `ProvableNamespace` and exports it such that documentation about the type generates under `type-aliases/ProvableNamespace`.  This isn't ideal, but it does quickly and without fuss get the documentation out there.

### Alternatives considered

#### Modifying the export

```diff

- export { Provable };

+ export type Provable<t> = ...

+ export const Provabe = ...
```

We can abandon our style of declaring module exports at the top of the file, but the result is that many of the comments are missing in the ultimate documentation.  For instance, this documentation is what we get for `witness`:

> ### witness()
> 
> ```ts
> witness: <A, T>(type: A, compute: () => T) => InferProvable<ToProvable<A>>;
> ```
> 
> #### Type parameters
> 
> • **A** *extends* [`ProvableType`](../type-aliases/ProvableType.mdx)\<`any`, `any`\>
> 
> • **T** *extends* `any` = `From`\<[`ToProvable`](../type-aliases/ToProvable.mdx)\<`A`\>\>
> 
> #### Parameters
> 
> • **type**: `A`
> 
> • **compute**
> 
> #### Returns
> 
> [`InferProvable`](../type-aliases/InferProvable.mdx)\<[`ToProvable`](../type-aliases/ToProvable.mdx)\<`A`\>\>

And this is the documentation we get using the fake type workaround:

> ### witness()
> 
> ```ts
> witness: <A, T>(type: A, compute: () => T) => InferProvable<ToProvable<A>>;
> ```
> 
> Create a new witness. A witness, or variable, is a value that is provided as input
> by the prover. This provides a flexible way to introduce values from outside into the circuit.
> However, note that nothing about how the value was created is part of the proof - `Provable.witness`
> behaves exactly like user input. So, make sure that after receiving the witness you make any assertions
> that you want to associate with it.
> 
> #### Example
> 
> Example for re-implementing `Field.inv` with the help of `witness`:
> ```ts
> let invX = Provable.witness(Field, () => {
>   // compute the inverse of `x` outside the circuit, however you like!
>   return Field.inv(x);
> }
> // prove that `invX` is really the inverse of `x`:
> invX.mul(x).assertEquals(1);
> ```
> 
> #### Type parameters
> 
> • **A** *extends* [`ProvableType`](ProvableType.mdx)\<`any`, `any`\>
> 
> • **T** *extends* `From`\<[`ToProvable`](ToProvable.mdx)\<`A`\>\> = `From`\<[`ToProvable`](ToProvable.mdx)\<`A`\>\>
> 
> #### Parameters
> 
> • **type**: `A`
> 
> • **compute**
> 
> #### Returns
> 
> [`InferProvable`](InferProvable.mdx)\<[`ToProvable`](ToProvable.mdx)\<`A`\>\>

The second version is what we want to show to developers. 

#### Changing the name of one or the other `Provable`

```diff

- export { Provable };
+ export { ProvableT, ProvableV };

- type Provable<T> = ...
+ type ProvableT<T> = ...

- const Provable = ...
+ const ProvableV = ...
```

This approach seems like the best long-term solution, but involves fixing a lot of imports across the code-base and a potential for regression that my lightweight approach does not risk.  I'd like to take this approach eventually, but first learn more about this code, why the names were chosen the way they were, and which footguns to look out for in extricating them.


