### PR TITLE
Do not mutate the ciphertext in decryption

### DIFF
--- a/src/lib/provable/crypto/encryption.ts
+++ b/src/lib/provable/crypto/encryption.ts
@@ -33,7 +33,7 @@ function decrypt(
   const sharedSecret = publicKey.scale(privateKey.s);
   const sponge = new Poseidon.Sponge();
   sponge.absorb(sharedSecret.x);
-  const authenticationTag = cipherText.pop();
+  const authenticationTag = cipherText[cipherText.length - 1];
 
   // decryption
   const message = [];


### PR DESCRIPTION
Fix #1980

Just a one line change to avoid mutating the input ciphertext.