### PR TITLE
Make sure bindings are initialized before accessing snarky

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,10 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - Sort order for actions now includes the transaction sequence number and the exact account id sequence https://github.com/o1-labs/o1js/pull/1917
 - Updated typedoc version for generating docs https://github.com/o1-labs/o1js/pull/1973
 
+### Fixed
+
+- Fix behavior of `initializeBindings()` when called concurrently, to improve error messages in frequent problem scenarios https://github.com/o1-labs/o1js/pull/1996
+
 ## [2.2.0](https://github.com/o1-labs/o1js/compare/e1bac02...b857516) - 2024-12-10
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,7 +27,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ### Fixed
 
-- Fix behavior of `initializeBindings()` when called concurrently, to improve error messages in frequent problem scenarios https://github.com/o1-labs/o1js/pull/1996
+- Fix behavior of `initializeBindings()` when called concurrently, to improve error messages in common failure scenarios https://github.com/o1-labs/o1js/pull/1996
 
 ## [2.2.0](https://github.com/o1-labs/o1js/compare/e1bac02...b857516) - 2024-12-10
 

--- a/src/snarky.js
+++ b/src/snarky.js
@@ -3,11 +3,17 @@ import { wasm, withThreadPool } from './bindings/js/node/node-backend.js';
 
 let Snarky, Ledger, Pickles, Test_;
 let isInitialized = false;
+let initializingPromise;
 
 async function initializeBindings() {
   if (isInitialized) return;
-  isInitialized = true;
+  if (initializingPromise) {
+    await initializingPromise;
+    return;
+  }
   let snarky;
+  let resolve;
+  initializingPromise = new Promise((r) => (resolve = r));
 
   // this dynamic import makes jest respect the import order
   // otherwise the cjs file gets imported before its implicit esm dependencies and fails
@@ -18,6 +24,9 @@ async function initializeBindings() {
     await import('./bindings/compiled/_node_bindings/o1js_node.bc.cjs')
   ).default;
   ({ Snarky, Ledger, Pickles, Test: Test_ } = snarky);
+  resolve();
+  initializingPromise = undefined;
+  isInitialized = true;
 }
 
 async function Test() {


### PR DESCRIPTION
The code in `snarky.js` > `initializeBindings()` used to be somewhat buggy in that it returned immediately when called a second time, even if bindings were not initialized. This PR fixes that, and leads to much less confusing error messages in frequent situations.

Contrived example:
```ts
import { Provable, Field } from 'o1js';

Provable.constraintSystem(() => {
  let x = Provable.witness(Field, () => 0);
  x.assertBool();
});

await Provable.constraintSystem(() => {
  let x = Provable.witness(Field, () => 0);
  x.assertBool();
});
```

Before this PR this would result in:
```
TypeError: Cannot read properties of undefined (reading 'run')
    at Object.constraintSystem (o1js/src/lib/provable/core/provable-context.ts:106:25)
    at async file:///home/gregor/o1/o1js/dist/node/lib/provable/test/initialize.js:7:1
```
That's because in the second call we are trying to access `snarky` while it's undefined, which arguably should never happen.

With this PR, we get a proper error message that tells you how to fix the problem:
```
Error: The global context managed by o1js reached an inconsistent state. This could be caused by one of the following reasons:

- You are missing an 'await' somewhere, which causes a new global context to be entered before we finished the last one.

- You are importing two different instances of o1js, which leads to inconsistent tracking of the global context in one of those instances.
  - This is a common problem in projects that use o1js as part of a UI!

- You are running multiple async operations concurrently, which conflict in using the global context.
  - Running async o1js operations (like proving) in parallel is not supported! Try running everything serially.
  
Investigate the stack traces below for more hints about the problem.
    at leave (/home/gregor/o1/o1js/src/lib/util/global-context.ts:106:11)
    at Function.leave (/home/gregor/o1/o1js/src/lib/util/global-context.ts:71:34)
    at Object.constraintSystem (/home/gregor/o1/o1js/src/lib/provable/core/provable-context.ts:113:18)
    at async file:///home/gregor/o1/o1js/dist/node/lib/provable/test/initialize.js:7:1
```

I encountered the confusing error when o1js was loaded twice, and making this change helped me confirm that problem.