### PR TITLE
Typos fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,7 +45,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - Method for optional types to assert none https://github.com/o1-labs/o1js/pull/1922
 - Increased maximum supported amount of methods in a `SmartContract` or `ZkProgram` to 30. https://github.com/o1-labs/o1js/pull/1918
 - Expose low-level conversion methods `Proof.{_proofToBase64,_proofFromBase64}` https://github.com/o1-labs/o1js/pull/1928
-- Expore `maxProofsVerified()` and a `Proof` class directly on ZkPrograms https://github.com/o1-labs/o1js/pull/1933
+- Explore, Expire, Export, Exposure, Expose `maxProofsVerified()` and a `Proof` class directly on ZkPrograms https://github.com/o1-labs/o1js/pull/1933
 
 ### Changed
 

--- a/README-nix.md
+++ b/README-nix.md
@@ -99,7 +99,7 @@ npm run build:update-bindings
 ```
 
 If you need to update the underlying `mina` code, you can also do so with Nix,
-but from the corresopnding subdirectory. In particular, you should build Mina
+but from the corresponding subdirectory. In particular, you should build Mina
 from the o1js subdirectory from a Nix shell. That means,
 
 ```console


### PR DESCRIPTION
### Changes

1. **File:** `/CHANGELOG.md`
    - Fixed `Expore` to `Explore, Expire, Export, Exposure, Expose` (Line 48)
1. **File:** `/README-nix.md`
    - Fixed `corresopnding` to `corresponding` (Line 102)

### Purpose

- Improved documentation accuracy by fixing typographical errors.
- Ensured better readability and consistency.