### PR TITLE
feat: Allow fetch functions to pass headers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,11 +18,14 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 ## [Unreleased](https://github.com/o1-labs/o1js/compare/b857516...HEAD)
 
 ### Added
+
 - `setFee` and `setFeePerSnarkCost` for `Transaction` and `PendingTransaction` https://github.com/o1-labs/o1js/pull/1968
 - Doc comments for various ZkProgram methods https://github.com/o1-labs/o1js/pull/1974
 - `MerkleList.popOption()` for popping the last element and also learning if there was one https://github.com/o1-labs/o1js/pull/1997
+- Added custom header support for `Fetch` methods such as `fetchEvents`, `fetchActions` etc. and to `Mina` instance. Also added two new methods `setMinaDefaultHeaders` and `setArchiveDefaultHeaders` https://github.com/o1-labs/o1js/pull/2004
 
 ### Changed
+
 - Sort order for actions now includes the transaction sequence number and the exact account id sequence https://github.com/o1-labs/o1js/pull/1917
 - Updated typedoc version for generating docs https://github.com/o1-labs/o1js/pull/1973
 
@@ -381,7 +384,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - `Reducer.reduce()` requires the maximum number of actions per method as an explicit (optional) argument https://github.com/o1-labs/o1js/pull/1450
   - The default value is 1 and should work for most existing contracts
 - `new UInt64()` and `UInt64.from()` no longer unsafely accept a field element as input. https://github.com/o1-labs/o1js/pull/1438 [@julio4](https://github.com/julio4)
-   As a replacement, `UInt64.Unsafe.fromField()` was introduced
+  As a replacement, `UInt64.Unsafe.fromField()` was introduced
   - This prevents you from accidentally creating a `UInt64` without proving that it fits in 64 bits
   - Equivalent changes were made to `UInt32`
 - Fixed vulnerability in `Field.to/fromBits()` outlined in [#1023](https://github.com/o1-labs/o1js/issues/1023) by imposing a limit of 254 bits https://github.com/o1-labs/o1js/pull/1461

--- a/src/lib/mina/fetch.ts
+++ b/src/lib/mina/fetch.ts
@@ -565,7 +565,8 @@ async function fetchLatestBlockZkappStatus(
     await makeGraphqlRequest<LastBlockQueryFailureCheckResponse>(
       lastBlockQueryFailureCheck(blockLength),
       graphqlEndpoint,
-      networkConfig.minaFallbackEndpoints
+      networkConfig.minaFallbackEndpoints,
+      { headers: networkConfig.minaDefaultHeaders }
     );
   if (error) throw Error(`Error making GraphQL request: ${error.statusText}`);
   let bestChain = resp?.data;

--- a/src/lib/mina/fetch.unit-test.ts
+++ b/src/lib/mina/fetch.unit-test.ts
@@ -238,14 +238,18 @@ describe('Fetch', () => {
 
       setGraphqlEndpoint(minaEndpoint);
       setArchiveGraphqlEndpoint(archiveEndpoint);
+      setMinaDefaultHeaders({ Authorization: 'Bearer mina-default-token' });
+      setArchiveDefaultHeaders({
+        Authorization: 'Bearer archive-default-token',
+      });
     });
 
     afterEach(() => {
       global.fetch = originalFetch;
+      lastFetchOptions = null;
     });
 
     test('Mina default headers with per request headers', async () => {
-      setMinaDefaultHeaders({ Authorization: 'Bearer mina-default-token' });
       const perRequestHeaders = { 'X-Custom': 'custom-value' };
       await fetchAccount(
         { publicKey: PrivateKey.random().toPublicKey().toBase58() },
@@ -263,8 +267,6 @@ describe('Fetch', () => {
     });
 
     test('Per request headers overrides default headers', async () => {
-      setMinaDefaultHeaders({ Authorization: 'Bearer mina-default-token' });
-
       const perRequestHeaders = {
         Authorization: 'Bearer override-token',
         'X-Test': 'value',
@@ -285,10 +287,6 @@ describe('Fetch', () => {
     });
 
     test('Archive default headers with per request headers', async () => {
-      setArchiveDefaultHeaders({
-        Authorization: 'Bearer archive-default-token',
-      });
-
       const perRequestHeaders = { 'X-Another': 'another-value' };
       await fetchEvents(
         { publicKey: PrivateKey.random().toPublicKey().toBase58() },
@@ -324,11 +322,11 @@ describe('Fetch', () => {
 
     test('Default and per request headers are used for fetchActions', async () => {
       setMinaDefaultHeaders({
-        'X-Default': 'default-header',
+        Authorization: 'Bearer archive-default-token',
       });
 
       const perRequestHeaders = {
-        Authorization: 'Bearer archive-default-token',
+        'X-Default': 'default-header',
       };
       await fetchActions(
         {
@@ -344,8 +342,8 @@ describe('Fetch', () => {
 
       expect(lastFetchOptions.headers).toMatchObject({
         'Content-Type': 'application/json',
-        'X-Default': 'default-header',
         Authorization: 'Bearer archive-default-token',
+        'X-Default': 'default-header',
       });
     });
 

--- a/src/lib/mina/mina-instance.ts
+++ b/src/lib/mina/mina-instance.ts
@@ -89,12 +89,14 @@ type Mina = {
   fetchEvents: (
     publicKey: PublicKey,
     tokenId?: Field,
-    filterOptions?: EventActionFilterOptions
+    filterOptions?: EventActionFilterOptions,
+    headers?: HeadersInit
   ) => ReturnType<typeof Fetch.fetchEvents>;
   fetchActions: (
     publicKey: PublicKey,
     actionStates?: ActionStates,
-    tokenId?: Field
+    tokenId?: Field,
+    headers?: HeadersInit
   ) => ReturnType<typeof Fetch.fetchActions>;
   getActions: (
     publicKey: PublicKey,
@@ -186,9 +188,15 @@ function getBalance(publicKey: PublicKey, tokenId?: Field) {
 async function fetchEvents(
   publicKey: PublicKey,
   tokenId: Field,
-  filterOptions: EventActionFilterOptions = {}
+  filterOptions: EventActionFilterOptions = {},
+  headers?: HeadersInit
 ) {
-  return await activeInstance.fetchEvents(publicKey, tokenId, filterOptions);
+  return await activeInstance.fetchEvents(
+    publicKey,
+    tokenId,
+    filterOptions,
+    headers
+  );
 }
 
 /**
@@ -197,9 +205,15 @@ async function fetchEvents(
 async function fetchActions(
   publicKey: PublicKey,
   actionStates?: ActionStates,
-  tokenId?: Field
+  tokenId?: Field,
+  headers?: HeadersInit
 ) {
-  return await activeInstance.fetchActions(publicKey, actionStates, tokenId);
+  return await activeInstance.fetchActions(
+    publicKey,
+    actionStates,
+    tokenId,
+    headers
+  );
 }
 
 /**

--- a/src/lib/mina/mina.network.unit-test.ts
+++ b/src/lib/mina/mina.network.unit-test.ts
@@ -1,61 +1,59 @@
 import {
-  State,
-  state,
   UInt64,
-  Bool,
-  SmartContract,
   Mina,
   AccountUpdate,
-  method,
   PublicKey,
-  Permissions,
-  VerificationKey,
   Field,
-  Int64,
   TokenId,
-  TokenContract as TokenContractBase,
-  AccountUpdateForest,
   PrivateKey,
 } from 'o1js';
-import { test, describe, it, before } from 'node:test';
+import { describe, it, before, beforeEach, afterEach } from 'node:test';
 import { expect } from 'expect';
 
-
-
 const defaultNetwork = Mina.Network({
-  networkId: "testnet",
-  mina: "https://example.com/graphql",
-  archive: "https://example.com//graphql"
+  networkId: 'testnet',
+  mina: 'https://example.com/graphql',
+  archive: 'https://example.com//graphql',
 });
 
 const enforcedNetwork = Mina.Network({
-  networkId: "testnet",
-  mina: "https://example.com/graphql",
-  archive: "https://example.com//graphql",
-  bypassTransactionLimits: false
+  networkId: 'testnet',
+  mina: 'https://example.com/graphql',
+  archive: 'https://example.com//graphql',
+  bypassTransactionLimits: false,
 });
 
 const unlimitedNetwork = Mina.Network({
-  networkId: "testnet",
-  mina: "https://unlimited.com/graphql",
-  archive: "https://unlimited.com//graphql",
-  bypassTransactionLimits: true
+  networkId: 'testnet',
+  mina: 'https://unlimited.com/graphql',
+  archive: 'https://unlimited.com//graphql',
+  bypassTransactionLimits: true,
+});
+
+const networkWithHeaders = Mina.Network({
+  networkId: 'testnet',
+  mina: 'https://mina.dummy/graphql',
+  archive: 'https://archive.dummy/graphql',
+  minaDefaultHeaders: {
+    Authorization: 'Bearer mina-default-token',
+    'X-Test': 'mina-test',
+  },
+  archiveDefaultHeaders: {
+    Authorization: 'Bearer archive-default-token',
+    'X-Test': 'archive-test',
+  },
 });
 
 describe('Test default network', () => {
-  let bobAccount: PublicKey,
-    bobKey: PrivateKey;
+  let bobAccount: PublicKey, bobKey: PrivateKey;
 
   before(async () => {
-
     Mina.setActiveInstance(defaultNetwork);
     bobKey = PrivateKey.random();
     bobAccount = bobKey.toPublicKey();
   });
 
-
   it('Simple account update', async () => {
-
     let txn = await Mina.transaction(async () => {
       const accountUpdateBob = AccountUpdate.create(bobAccount, Field.from(1));
       accountUpdateBob.account.balance.requireEquals(UInt64.zero);
@@ -63,28 +61,30 @@ describe('Test default network', () => {
     });
     await txn.prove();
     await txn.sign([bobKey]).safeSend();
-
   });
 
   it('Multiple account update', async () => {
-
     let txn = await Mina.transaction(async () => {
       for (let index = 0; index < 2; index++) {
-        const accountUpdateBob = AccountUpdate.create(bobAccount, Field.from(index));
+        const accountUpdateBob = AccountUpdate.create(
+          bobAccount,
+          Field.from(index)
+        );
         accountUpdateBob.account.balance.requireEquals(UInt64.zero);
         accountUpdateBob.balance.addInPlace(UInt64.one);
       }
     });
     await txn.prove();
     await txn.sign([bobKey]).safeSend();
-
   });
 
   it('More than limit account update', async () => {
-
     let txn = await Mina.transaction(async () => {
       for (let index = 0; index < 12; index++) {
-        const accountUpdateBob = AccountUpdate.create(bobAccount, Field.from(index));
+        const accountUpdateBob = AccountUpdate.create(
+          bobAccount,
+          Field.from(index)
+        );
         accountUpdateBob.account.balance.requireEquals(UInt64.zero);
         accountUpdateBob.balance.addInPlace(UInt64.one);
       }
@@ -96,19 +96,15 @@ describe('Test default network', () => {
 });
 
 describe('Test enforced network', () => {
-  let bobAccount: PublicKey,
-    bobKey: PrivateKey;
+  let bobAccount: PublicKey, bobKey: PrivateKey;
 
   before(async () => {
-
     Mina.setActiveInstance(enforcedNetwork);
     bobKey = PrivateKey.random();
     bobAccount = bobKey.toPublicKey();
   });
 
-
   it('Simple account update', async () => {
-
     let txn = await Mina.transaction(async () => {
       const accountUpdateBob = AccountUpdate.create(bobAccount, Field.from(1));
       accountUpdateBob.account.balance.requireEquals(UInt64.zero);
@@ -116,28 +112,30 @@ describe('Test enforced network', () => {
     });
     await txn.prove();
     await txn.sign([bobKey]).safeSend();
-
   });
 
   it('Multiple account update', async () => {
-
     let txn = await Mina.transaction(async () => {
       for (let index = 0; index < 2; index++) {
-        const accountUpdateBob = AccountUpdate.create(bobAccount, Field.from(index));
+        const accountUpdateBob = AccountUpdate.create(
+          bobAccount,
+          Field.from(index)
+        );
         accountUpdateBob.account.balance.requireEquals(UInt64.zero);
         accountUpdateBob.balance.addInPlace(UInt64.one);
       }
     });
     await txn.prove();
     await txn.sign([bobKey]).safeSend();
-
   });
 
   it('More than limit account update', async () => {
-
     let txn = await Mina.transaction(async () => {
       for (let index = 0; index < 12; index++) {
-        const accountUpdateBob = AccountUpdate.create(bobAccount, Field.from(index));
+        const accountUpdateBob = AccountUpdate.create(
+          bobAccount,
+          Field.from(index)
+        );
         accountUpdateBob.account.balance.requireEquals(UInt64.zero);
         accountUpdateBob.balance.addInPlace(UInt64.one);
       }
@@ -149,19 +147,110 @@ describe('Test enforced network', () => {
 });
 
 describe('Test unlimited network', () => {
-  let bobAccount: PublicKey,
-    bobKey: PrivateKey;
+  let bobAccount: PublicKey, bobKey: PrivateKey;
 
   before(async () => {
-
     Mina.setActiveInstance(unlimitedNetwork);
     bobKey = PrivateKey.random();
     bobAccount = bobKey.toPublicKey();
   });
 
+  it('Simple account update', async () => {
+    let txn = await Mina.transaction(async () => {
+      const accountUpdateBob = AccountUpdate.create(bobAccount, Field.from(1));
+      accountUpdateBob.account.balance.requireEquals(UInt64.zero);
+      accountUpdateBob.balance.addInPlace(UInt64.one);
+    });
+    await txn.prove();
+    await txn.sign([bobKey]).safeSend();
+  });
+
+  it('Multiple account update', async () => {
+    let txn = await Mina.transaction(async () => {
+      for (let index = 0; index < 2; index++) {
+        const accountUpdateBob = AccountUpdate.create(
+          bobAccount,
+          Field.from(index)
+        );
+        accountUpdateBob.account.balance.requireEquals(UInt64.zero);
+        accountUpdateBob.balance.addInPlace(UInt64.one);
+      }
+    });
+    await txn.prove();
+    await txn.sign([bobKey]).safeSend();
+  });
+
+  it('More than limit account update', async () => {
+    let txn = await Mina.transaction(async () => {
+      for (let index = 0; index < 12; index++) {
+        const accountUpdateBob = AccountUpdate.create(
+          bobAccount,
+          Field.from(index)
+        );
+        accountUpdateBob.account.balance.requireEquals(UInt64.zero);
+        accountUpdateBob.balance.addInPlace(UInt64.one);
+      }
+    });
+    await txn.prove();
+    // success with bypassTransactionLimits = true
+    await txn.sign([bobKey]).safeSend();
+  });
+});
+
+describe('Test network with headers', () => {
+  let bobAccount: PublicKey, bobKey: PrivateKey;
+  let originalFetch: typeof global.fetch;
+  let lastFetchOptions: any = null;
+
+  before(async () => {
+    Mina.setActiveInstance(networkWithHeaders);
+    bobKey = PrivateKey.random();
+    bobAccount = bobKey.toPublicKey();
+  });
+
+  beforeEach(() => {
+    originalFetch = global.fetch;
+    lastFetchOptions = undefined;
+    global.fetch = ((
+      input: RequestInfo | URL,
+      init?: RequestInit
+    ): Promise<Response> => {
+      lastFetchOptions = init;
+      let url: string;
+      if (typeof input === 'string') {
+        url = input;
+      } else if (input instanceof URL) {
+        url = input.toString();
+      } else {
+        url = input.url;
+      }
+
+      if (url.includes('archive.dummy')) {
+        return Promise.resolve({
+          ok: true,
+          json: async () => ({
+            data: {
+              events: [],
+            },
+          }),
+        } as Response);
+      } else {
+        return Promise.resolve({
+          ok: true,
+          json: async () => ({
+            data: {},
+          }),
+        } as Response);
+      }
+    }) as typeof fetch;
+  });
+
+  afterEach(() => {
+    global.fetch = originalFetch;
+    lastFetchOptions = null;
+  });
 
   it('Simple account update', async () => {
-
     let txn = await Mina.transaction(async () => {
       const accountUpdateBob = AccountUpdate.create(bobAccount, Field.from(1));
       accountUpdateBob.account.balance.requireEquals(UInt64.zero);
@@ -170,33 +259,59 @@ describe('Test unlimited network', () => {
     await txn.prove();
     await txn.sign([bobKey]).safeSend();
 
+    // we can check the headers here too
+    // expect(lastFetchOptions.headers).toEqual({
+    //   Authorization: 'Bearer archive-default-token',
+    //   'Content-Type': 'application/json',
+    //   'X-Test': 'archive-test',
+    // });
   });
 
   it('Multiple account update', async () => {
-
     let txn = await Mina.transaction(async () => {
       for (let index = 0; index < 2; index++) {
-        const accountUpdateBob = AccountUpdate.create(bobAccount, Field.from(index));
+        const accountUpdateBob = AccountUpdate.create(
+          bobAccount,
+          Field.from(index)
+        );
         accountUpdateBob.account.balance.requireEquals(UInt64.zero);
         accountUpdateBob.balance.addInPlace(UInt64.one);
       }
     });
     await txn.prove();
     await txn.sign([bobKey]).safeSend();
-
   });
 
   it('More than limit account update', async () => {
-
     let txn = await Mina.transaction(async () => {
       for (let index = 0; index < 12; index++) {
-        const accountUpdateBob = AccountUpdate.create(bobAccount, Field.from(index));
+        const accountUpdateBob = AccountUpdate.create(
+          bobAccount,
+          Field.from(index)
+        );
         accountUpdateBob.account.balance.requireEquals(UInt64.zero);
         accountUpdateBob.balance.addInPlace(UInt64.one);
       }
     });
     await txn.prove();
-    // success with bypassTransactionLimits = true
-    await txn.sign([bobKey]).safeSend();
+    await expect(txn.sign([bobKey]).safeSend()).rejects.toThrow();
+  });
+
+  it('Archive default headers with fetchActions', async () => {
+    await Mina.fetchActions(bobAccount);
+    expect(lastFetchOptions.headers).toMatchObject({
+      'Content-Type': 'application/json',
+      Authorization: 'Bearer archive-default-token',
+      'X-Test': 'archive-test',
+    });
+  });
+
+  it('Archive default headers with fetchEvents', async () => {
+    await Mina.fetchEvents(bobAccount, TokenId.empty());
+    expect(lastFetchOptions.headers).toMatchObject({
+      'Content-Type': 'application/json',
+      Authorization: 'Bearer archive-default-token',
+      'X-Test': 'archive-test',
+    });
   });
 });

--- a/src/lib/mina/mina.network.unit-test.ts
+++ b/src/lib/mina/mina.network.unit-test.ts
@@ -299,6 +299,7 @@ describe('Test network with headers', () => {
 
   it('Archive default headers with fetchActions', async () => {
     await Mina.fetchActions(bobAccount);
+
     expect(lastFetchOptions.headers).toMatchObject({
       'Content-Type': 'application/json',
       Authorization: 'Bearer archive-default-token',
@@ -308,10 +309,23 @@ describe('Test network with headers', () => {
 
   it('Archive default headers with fetchEvents', async () => {
     await Mina.fetchEvents(bobAccount, TokenId.empty());
+
     expect(lastFetchOptions.headers).toMatchObject({
       'Content-Type': 'application/json',
       Authorization: 'Bearer archive-default-token',
       'X-Test': 'archive-test',
+    });
+  });
+
+  it('Archive default headers with per request headers in fetchActions', async () => {
+    await Mina.fetchActions(bobAccount, undefined, undefined, {
+      'X-Test': 'per-request-test',
+    });
+
+    expect(lastFetchOptions.headers).toMatchObject({
+      'Content-Type': 'application/json',
+      Authorization: 'Bearer archive-default-token',
+      'X-Test': 'per-request-test',
     });
   });
 });

--- a/src/lib/mina/mina.ts
+++ b/src/lib/mina/mina.ts
@@ -409,7 +409,8 @@ function Network(
     async fetchEvents(
       publicKey: PublicKey,
       tokenId: Field = TokenId.default,
-      filterOptions: EventActionFilterOptions = {}
+      filterOptions: EventActionFilterOptions = {},
+      headers?: HeadersInit
     ) {
       let pubKey = publicKey.toBase58();
       let token = TokenId.toBase58(tokenId);
@@ -417,13 +418,15 @@ function Network(
       return Fetch.fetchEvents(
         { publicKey: pubKey, tokenId: token },
         archiveEndpoint,
-        filterOptions
+        filterOptions,
+        headers
       );
     },
     async fetchActions(
       publicKey: PublicKey,
       actionStates?: ActionStates,
-      tokenId: Field = TokenId.default
+      tokenId: Field = TokenId.default,
+      headers?: HeadersInit
     ) {
       let pubKey = publicKey.toBase58();
       let token = TokenId.toBase58(tokenId);
@@ -444,7 +447,8 @@ function Network(
           },
           tokenId: token,
         },
-        archiveEndpoint
+        archiveEndpoint,
+        headers
       );
     },
     getActions(
@@ -509,7 +513,10 @@ function dummyAccount(pubkey?: PublicKey): Account {
   return dummy;
 }
 
-async function waitForFunding(address: string): Promise<void> {
+async function waitForFunding(
+  address: string,
+  headers?: HeadersInit
+): Promise<void> {
   let attempts = 0;
   let maxAttempts = 30;
   let interval = 30000;
@@ -517,7 +524,11 @@ async function waitForFunding(address: string): Promise<void> {
     resolve: () => void,
     reject: (err: Error) => void | Error
   ) => {
-    let { account } = await Fetch.fetchAccount({ publicKey: address });
+    let { account } = await Fetch.fetchAccount(
+      { publicKey: address },
+      undefined,
+      { headers }
+    );
     attempts++;
     if (account) {
       return resolve();
@@ -533,7 +544,11 @@ async function waitForFunding(address: string): Promise<void> {
 /**
  * Requests the [testnet faucet](https://faucet.minaprotocol.com/api/v1/faucet) to fund a public key.
  */
-async function faucet(pub: PublicKey, network: string = 'berkeley-qanet') {
+async function faucet(
+  pub: PublicKey,
+  network: string = 'berkeley-qanet',
+  headers?: HeadersInit
+) {
   let address = pub.toBase58();
   let response = await fetch('https://faucet.minaprotocol.com/api/v1/faucet', {
     method: 'POST',
@@ -549,7 +564,7 @@ async function faucet(pub: PublicKey, network: string = 'berkeley-qanet') {
       `Error funding account ${address}, got response status: ${response.status}, text: ${response.statusText}`
     );
   }
-  await waitForFunding(address);
+  await waitForFunding(address, headers);
 }
 
 function genesisToNetworkConstants(

--- a/src/lib/mina/mina.ts
+++ b/src/lib/mina/mina.ts
@@ -105,16 +105,20 @@ function Network(options: {
   archive?: string | string[];
   lightnetAccountManager?: string;
   bypassTransactionLimits?: boolean;
+  minaDefaultHeaders?: HeadersInit;
+  archiveDefaultHeaders?: HeadersInit;
 }): Mina;
 function Network(
   options:
     | {
-      networkId?: NetworkId;
-      mina: string | string[];
-      archive?: string | string[];
-      lightnetAccountManager?: string;
-      bypassTransactionLimits?: boolean;
-    }
+        networkId?: NetworkId;
+        mina: string | string[];
+        archive?: string | string[];
+        lightnetAccountManager?: string;
+        bypassTransactionLimits?: boolean;
+        minaDefaultHeaders?: HeadersInit;
+        archiveDefaultHeaders?: HeadersInit;
+      }
     | string
 ): Mina {
   let minaNetworkId: NetworkId = 'devnet';
@@ -136,21 +140,27 @@ function Network(
       );
     if (Array.isArray(options.mina) && options.mina.length !== 0) {
       minaGraphqlEndpoint = options.mina[0];
-      Fetch.setGraphqlEndpoint(minaGraphqlEndpoint);
+      Fetch.setGraphqlEndpoint(minaGraphqlEndpoint, options.minaDefaultHeaders);
       Fetch.setMinaGraphqlFallbackEndpoints(options.mina.slice(1));
     } else if (typeof options.mina === 'string') {
       minaGraphqlEndpoint = options.mina;
-      Fetch.setGraphqlEndpoint(minaGraphqlEndpoint);
+      Fetch.setGraphqlEndpoint(minaGraphqlEndpoint, options.minaDefaultHeaders);
     }
 
     if (options.archive !== undefined) {
       if (Array.isArray(options.archive) && options.archive.length !== 0) {
         archiveEndpoint = options.archive[0];
-        Fetch.setArchiveGraphqlEndpoint(archiveEndpoint);
+        Fetch.setArchiveGraphqlEndpoint(
+          archiveEndpoint,
+          options.archiveDefaultHeaders
+        );
         Fetch.setArchiveGraphqlFallbackEndpoints(options.archive.slice(1));
       } else if (typeof options.archive === 'string') {
         archiveEndpoint = options.archive;
-        Fetch.setArchiveGraphqlEndpoint(archiveEndpoint);
+        Fetch.setArchiveGraphqlEndpoint(
+          archiveEndpoint,
+          options.archiveDefaultHeaders
+        );
       }
     }
 
@@ -162,8 +172,10 @@ function Network(
       Fetch.setLightnetAccountManagerEndpoint(lightnetAccountManagerEndpoint);
     }
 
-    if (options.bypassTransactionLimits !== undefined &&
-      typeof options.bypassTransactionLimits === 'boolean') {
+    if (
+      options.bypassTransactionLimits !== undefined &&
+      typeof options.bypassTransactionLimits === 'boolean'
+    ) {
       enforceTransactionLimits = !options.bypassTransactionLimits;
     }
   } else {
@@ -282,8 +294,8 @@ function Network(
           data: response?.data,
           errors: updatedErrors,
           transaction: txn.transaction,
-          setFee : txn.setFee,
-          setFeePerSnarkCost : txn.setFeePerSnarkCost,
+          setFee: txn.setFee,
+          setFeePerSnarkCost: txn.setFeePerSnarkCost,
           hash,
           toJSON: txn.toJSON,
           toPretty: txn.toPretty,


### PR DESCRIPTION
This PR opened for issue #1983 

Two exposed method implemented to set default headers to be passed both Mina and Archive GraphQL nodes for fetch operations. Named `setMinaDefaultHeaders`, `setArchiveDefaultHeaders` same as stated in issue. 

Also one new internal method to decide header to be sent to the server, after classify them between archive or not.

In addition optional per request header option parameters added to following methods:
`fetchAccount`
`fetchLastBlock`
`fetchCurrentSlot`
`fetchTransactionStatus`
`sendZkapp`
`fetchEvents`
`fetchActions`
`fetchGenesisConstants`
So that developers can decide between default header usage and one time only usage, and they can overwrite default headers with this usage.

Also unit-tests implemented by using mocking fetch.