### PR TITLE
Make ECDSA easier to use with alternative hash functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,13 +18,16 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 ## [Unreleased](https://github.com/o1-labs/o1js/compare/b857516...HEAD)
 
 ### Added
+
 - `setFee` and `setFeePerSnarkCost` for `Transaction` and `PendingTransaction` https://github.com/o1-labs/o1js/pull/1968
 - Doc comments for various ZkProgram methods https://github.com/o1-labs/o1js/pull/1974
 - `MerkleList.popOption()` for popping the last element and also learning if there was one https://github.com/o1-labs/o1js/pull/1997
 
 ### Changed
+
 - Sort order for actions now includes the transaction sequence number and the exact account id sequence https://github.com/o1-labs/o1js/pull/1917
 - Updated typedoc version for generating docs https://github.com/o1-labs/o1js/pull/1973
+- ECDSA `verifySignedHash()` accepts hash `Bytes` directly for easy use with alternative hash functions https://github.com/o1-labs/o1js/pull/2005
 
 ### Fixed
 
@@ -381,7 +384,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - `Reducer.reduce()` requires the maximum number of actions per method as an explicit (optional) argument https://github.com/o1-labs/o1js/pull/1450
   - The default value is 1 and should work for most existing contracts
 - `new UInt64()` and `UInt64.from()` no longer unsafely accept a field element as input. https://github.com/o1-labs/o1js/pull/1438 [@julio4](https://github.com/julio4)
-   As a replacement, `UInt64.Unsafe.fromField()` was introduced
+  As a replacement, `UInt64.Unsafe.fromField()` was introduced
   - This prevents you from accidentally creating a `UInt64` without proving that it fits in 64 bits
   - Equivalent changes were made to `UInt32`
 - Fixed vulnerability in `Field.to/fromBits()` outlined in [#1023](https://github.com/o1-labs/o1js/issues/1023) by imposing a limit of 254 bits https://github.com/o1-labs/o1js/pull/1461

--- a/src/examples/crypto/ecdsa/ecdsa.ts
+++ b/src/examples/crypto/ecdsa/ecdsa.ts
@@ -68,7 +68,7 @@ const ecdsaEthers = ZkProgram({
  * We can also use a different hash function with ECDSA, like SHA-256.
  */
 const sha256AndEcdsa = ZkProgram({
-  name: 'ecdsa',
+  name: 'ecdsa-sha256',
   publicInput: Bytes32,
   publicOutput: Bool,
 

--- a/src/examples/crypto/ecdsa/ecdsa.ts
+++ b/src/examples/crypto/ecdsa/ecdsa.ts
@@ -5,6 +5,7 @@ import {
   createForeignCurve,
   Bool,
   Bytes,
+  Hash,
 } from 'o1js';
 
 export { keccakAndEcdsa, ecdsa, Secp256k1, Ecdsa, Bytes32, ecdsaEthers };
@@ -58,6 +59,27 @@ const ecdsaEthers = ZkProgram({
       privateInputs: [Ecdsa, Secp256k1],
       async method(message: Bytes32, signature: Ecdsa, publicKey: Secp256k1) {
         return { publicOutput: signature.verifyEthers(message, publicKey) };
+      },
+    },
+  },
+});
+
+/**
+ * We can also use a different hash function with ECDSA, like SHA-256.
+ */
+const sha256AndEcdsa = ZkProgram({
+  name: 'ecdsa',
+  publicInput: Bytes32,
+  publicOutput: Bool,
+
+  methods: {
+    verifyEcdsa: {
+      privateInputs: [Ecdsa, Secp256k1],
+      async method(message: Bytes32, signature: Ecdsa, publicKey: Secp256k1) {
+        let messageHash = Hash.SHA2_256.hash(message);
+        return {
+          publicOutput: signature.verifySignedHash(messageHash, publicKey),
+        };
       },
     },
   },


### PR DESCRIPTION
By default, ECDSA uses the `Keccak.ethereum()` hash function, e.g. in `EcdsaSignature.verify()` and `EcdsaSignature.verifyEthers()`.

In principle, the code was intended to also be usable with other hash functions. That's why there are `verifySignedHash()` and `signHash()` methods which let you pass in the curve scalar directly, not making any assumptions how that scalar was obtained.

However, this is still kinda hard to use with alternative hash functions because the caller has to convert the hash function output, usually `Bytes`, to a `ForeignField` element (the curve scalar). Internally, o1js does this with the `keccakOutputToScalar` method.

To not make it necessary that callers reimplement `keccakOutputToScalar()`, this PR makes `verifySignedHash()` and `signHash()` optionally accept the `Bytes` output directly, and internally call `keccakOutputToScalar()` on it.

Thus, it's now very easy to use ECDSA with a different hash implementation!

I'll be using this for making ECDSA work for dynamic length inputs https://github.com/zksecurity/mina-attestations/pull/95