### PR TITLE
set `GIT_LFS_SKIP_SMUDGE` to 1 in .envrc

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,2 +1,5 @@
+#!/usr/bin/env bash
+
+export GIT_LFS_SKIP_SMUDGE=1
 ./pin.sh
 use flake o1js#default


### PR DESCRIPTION
This is more of a follow up on https://github.com/o1-labs/o1js/issues/1819. 

To help direnv users to prevent LFS from panicking, we should set `GIT_LFS_SKIP_SMUDGE` to 1. 