### PR TITLE
Optimize bigint sub method

### DIFF
--- a/src/lib/provable/bigint.ts
+++ b/src/lib/provable/bigint.ts
@@ -228,30 +228,74 @@ function createProvableBigInt(modulus: bigint, config?: BigIntParameter) {
     /**
      * Subtracts one ProvableBigInt from another
      * @param a The ProvableBigInt to substract
-     * @returns The difference as a ProvableBigInt
+     * @returns The remainder of the difference as a ProvableBigInt
      */
-    sub(a: ProvableBigInt_): ProvableBigInt_ {
-      let fields = [];
-      let borrow = Field.from(0);
+    sub(a: ProvableBigInt_) {
+      // witness q, r so that this-a = q*p + r
+      let { q, r } = Provable.witness(
+        Struct({ q: ProvableBigInt_, r: ProvableBigInt_ }),
+        () => {
+          let diff = this.toBigint() - a.toBigint();
+          let p0 = this.Constructor.modulus.toBigint();
+          let q = diff / p0;
+          let r = diff - q * p0;
+          return {
+            q: ProvableBigInt_.fromBigint(q),
+            r: ProvableBigInt_.fromBigint(r),
+          };
+        }
+      );
+
+      let delta: Field[] = Array.from(
+        { length: this.Constructor.config.limb_num },
+        () => Field.from(0)
+      );
+      let [X, Y, Q, R, P] = [
+        this.fields,
+        a.fields,
+        q.fields,
+        r.fields,
+        this.Constructor.modulus.fields,
+      ];
+
+      // compute X - Y limb-by-limb
       for (let i = 0; i < this.Constructor.config.limb_num; i++) {
-        let diff = this.fields[i].sub(a.fields[i]).sub(borrow);
-        borrow = diff
-          .lessThan(Field.from(this.Constructor.config.mask + 1n))
-          .not()
-          .toField();
-        fields.push(
-          diff.add(borrow.mul(Field.from(this.Constructor.config.mask + 1n)))
-        );
-        rangeCheck(fields[i], Number(this.Constructor.config.limb_size));
+        delta[i] = X[i].sub(Y[i]);
       }
 
-      return new ProvableBigInt_(
-        fields,
-        Unconstrained.from(
-          (this.value.get() - a.value.get()) %
-            this.Constructor.modulus.toBigint()
-        )
-      );
+      // subtract q*p limb-by-limb
+      for (let i = 0; i < this.Constructor.config.limb_num; i++) {
+        for (let j = 0; j < this.Constructor.config.limb_num; j++) {
+          if (i + j < this.Constructor.config.limb_num) {
+            delta[i + j] = delta[i + j].sub(Q[i].mul(P[j]));
+          }
+        }
+      }
+
+      // subtract r limb-by-limb
+      for (let i = 0; i < this.Constructor.config.limb_num; i++) {
+        delta[i] = delta[i].sub(R[i]).seal();
+      }
+
+      let carry = Field.from(0);
+
+      for (let i = 0; i < this.Constructor.config.limb_num - 1; i++) {
+        let deltaPlusCarry = delta[i].add(carry).seal();
+
+        carry = Provable.witness(Field, () =>
+          deltaPlusCarry.div(1n << this.Constructor.config.limb_size)
+        );
+        rangeCheck128Signed(carry);
+
+        // ensure that after adding the carry, the limb is a multiple of 2^limb_size
+        deltaPlusCarry.assertEquals(
+          carry.mul(1n << this.Constructor.config.limb_size)
+        );
+      }
+      // the final limb plus carry should be zero to assert correctness
+      delta[17].add(carry).assertEquals(0n);
+
+      return r;
     }
 
     /**

--- a/src/lib/provable/test/bigint.test.ts
+++ b/src/lib/provable/test/bigint.test.ts
@@ -82,7 +82,7 @@ describe('BigInt17', () => {
     it('should satisfy subtraction with identity element for BigInt17 numbers', () => {
       const a = BigInt17.fromBigint(9n);
       const b = BigInt17.fromBigint(0n);
-      expect(a.sub(b)).toStrictEqual(a);
+      expect(a.sub(b).toBigint()).toStrictEqual(a.toBigint());
     });
 
     it('should correctly subtract two BigInt17 numbers resulting in zero', () => {


### PR DESCRIPTION
## Changes

- Replaced the sub method with a new optimized one.

## Description 

- Supports unreduced bigint entries where  `this`, `a` > `p`
- More efficient than the vanilla `subMod` implementation
  - Total rows: `483` compared to `558`
- Returns the **remainder** of the difference modulo **p**. 