### PR TITLE
Add a new bigint double method

### DIFF
--- a/src/lib/provable/bigint.ts
+++ b/src/lib/provable/bigint.ts
@@ -247,6 +247,10 @@ function createProvableBigInt(modulus: bigint, config?: BigIntParameter) {
       return r;
     }
 
+    double(): ProvableBigInt_ {
+      return this.add(this, true);
+    }
+
     /**
      * Subtracts one ProvableBigInt from another
      * @param a The ProvableBigInt to substract
@@ -733,6 +737,7 @@ abstract class ProvableBigInt<T extends ProvableBigInt<T>> {
   abstract toBits(): Bool[];
   abstract clone(): T;
   abstract add(a: T, isDouble?: boolean): T;
+  abstract double(): T;
   abstract sub(a: T): T;
   abstract mul(a: T, isSquare?: boolean): T;
   abstract square(): T;


### PR DESCRIPTION
## Changes

- Add a new bigint `double` method.

## Description 

- Supports unreduced bigint entries where  `this` > `p`
- More efficient than the `add` method if adding a bigint to itself is needed.
  - Total rows (Bigint2048): `429` compared to `483` for the add method.
- Returns the **remainder** modulo **p**. 

## TODO

- Add unit tests.
