### PR TITLE
Add toBytes() to UInt64

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - Added custom header support for `Fetch` methods such as `fetchEvents`, `fetchActions` etc. and to `Mina` instance. Also added two new methods `setMinaDefaultHeaders` and `setArchiveDefaultHeaders` https://github.com/o1-labs/o1js/pull/2004
 - Added style rules for contributors https://github.com/o1-labs/o1js/pull/2012
 - Add new helper functions `Bool.anyTrue(xs)` and `Bool.allTrue(xs)`. https://github.com/o1-labs/o1js/pull/2038
+- Add `UInt64.toBytes()`l https://github.com/o1-labs/o1js/pull/2060 [@kadirchan](https://github.com/kadirchan)
 
 ### Changed
 

--- a/src/lib/provable/int.ts
+++ b/src/lib/provable/int.ts
@@ -505,6 +505,13 @@ class UInt64 extends CircuitValue {
   }
 
   /**
+   * Split a UInt64 into 8 UInt8s, in little-endian order.
+   */
+  toBytes() {
+    return TupleN.fromArray(8, wordToBytes(this.value, 8));
+  }
+
+  /**
    * Split a UInt64 into 8 UInt8s, in big-endian order.
    */
   toBytesBE() {


### PR DESCRIPTION
Implement `toBytes()` method for `UInt64` for issue #2045 