### PR TITLE
Export Internal Testing Tools

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - Added style rules for contributors https://github.com/o1-labs/o1js/pull/2012
 - Add new helper functions `Bool.anyTrue(xs)` and `Bool.allTrue(xs)`. https://github.com/o1-labs/o1js/pull/2038
 - Add `UInt64.toBytes()`l https://github.com/o1-labs/o1js/pull/2060 [@kadirchan](https://github.com/kadirchan)
+- Expose internal testing utilities through the `Testing` namespace exported from `Experimental`
 
 ### Changed
 

--- a/src/build/build-web.js
+++ b/src/build/build-web.js
@@ -89,6 +89,7 @@ async function buildWeb({ production }) {
     allowOverwrite: true,
     logLevel: 'error',
     minify,
+    external: ['node:assert/strict'],
   });
 }
 

--- a/src/build/build-web.js
+++ b/src/build/build-web.js
@@ -84,12 +84,11 @@ async function buildWeb({ production }) {
     resolveExtensions: ['.js', '.ts'],
     plugins: [wasmPlugin(), srcStringPlugin()],
     dropLabels: ['CJS'],
-    external: ['*.bc.js'],
+    external: ['*.bc.js', 'node:assert/strict'],
     target,
     allowOverwrite: true,
     logLevel: 'error',
     minify,
-    external: ['node:assert/strict'],
   });
 }
 
@@ -182,7 +181,7 @@ function srcStringPlugin() {
   };
 }
 
-function deferExecutionPlugin() {
+function _deferExecutionPlugin() {
   return {
     name: 'defer-execution-plugin',
     setup(build) {

--- a/src/examples/testing.ts
+++ b/src/examples/testing.ts
@@ -1,7 +1,7 @@
-import { Experimental, Field } from "o1js";
+import { Experimental, Field } from 'o1js';
 
 const { Testing } = Experimental;
 
-Testing.testx(Testing.Randomx.nat(1000), (n, assert) => {
-    assert(Field(n).toString() === String(n));
-  });
+Testing.test(Testing.Random.nat(1000), (n, assert) => {
+  assert(Field(n).toString() === String(n));
+});

--- a/src/examples/testing.ts
+++ b/src/examples/testing.ts
@@ -1,0 +1,7 @@
+import { Experimental, Field } from "o1js";
+
+const { Testing } = Experimental;
+
+Testing.testx(Testing.Randomx.nat(1000), (n, assert) => {
+    assert(Field(n).toString() === String(n));
+  });

--- a/src/index.ts
+++ b/src/index.ts
@@ -125,7 +125,7 @@ export { Experimental };
 const Experimental_ = {
   memoizeWitness,
   IndexedMerkleMap,
-  Testing
+  Testing,
 };
 
 /**

--- a/src/index.ts
+++ b/src/index.ts
@@ -119,11 +119,13 @@ import * as BatchReducer_ from './lib/mina/v1/actions/batch-reducer.js';
 import { Actionable } from './lib/mina/v1/actions/offchain-state-serialization.js';
 import { InferProvable } from './lib/provable/types/struct.js';
 import { Recursive as Recursive_ } from './lib/proof-system/recursive.js';
+import { Testing } from './lib/testing/testing.js';
 export { Experimental };
 
 const Experimental_ = {
   memoizeWitness,
   IndexedMerkleMap,
+  Testing
 };
 
 /**
@@ -131,6 +133,7 @@ const Experimental_ = {
  * (Not unstable in the sense that they are less functional or tested than other parts.)
  */
 namespace Experimental {
+  export let Testing = Experimental_.Testing;
   export let memoizeWitness = Experimental_.memoizeWitness;
 
   export let Recursive = Recursive_;

--- a/src/lib/testing/constraint-system.ts
+++ b/src/lib/testing/constraint-system.ts
@@ -37,7 +37,10 @@ export {
 };
 
 // TODO get rid of this top-level await by making `test` support async functions
-let { constraintSystemSync } = await synchronousRunners();
+let constraintSystemSync: any;
+(async () => {
+  constraintSystemSync = await synchronousRunners();
+})();
 
 /**
  * `constraintSystem()` is a test runner to check properties of constraint systems.

--- a/src/lib/testing/equivalent.ts
+++ b/src/lib/testing/equivalent.ts
@@ -40,7 +40,11 @@ export {
 export { Spec, ToSpec, FromSpec, SpecFromFunctions, ProvableSpec, First, Second };
 
 // TODO get rid of this top-level await by making `test` support async functions
-let { runAndCheckSync } = await synchronousRunners();
+let runAndCheckSync: any;
+
+(async () => {
+  ({ runAndCheckSync } = await synchronousRunners());
+})();
 
 // a `Spec` tells us how to compare two functions
 

--- a/src/lib/testing/testing.ts
+++ b/src/lib/testing/testing.ts
@@ -1,0 +1,15 @@
+import {
+  test as test_,
+  Random as Random_,
+  sample as sample_,
+  withHardCoded as withHardCoded_,
+} from './property.js';
+
+export { Testing };
+
+namespace Testing {
+  export let test = test_;
+  export let Random = Random_;
+  export let sample = sample_;
+  export let withHardCoded = withHardCoded_;
+}

--- a/src/lib/testing/testing.ts
+++ b/src/lib/testing/testing.ts
@@ -1,15 +1,51 @@
-import {
-  test as test_,
-  Random as Random_,
-  sample as sample_,
-  withHardCoded as withHardCoded_,
-} from './property.js';
+import * as Property from './property.js';
+import * as Equivalent from './equivalent.js';
+import * as ConstraintSystem from './constraint-system.js';
 
 export { Testing };
 
 namespace Testing {
-  export let test = test_;
-  export let Random = Random_;
-  export let sample = sample_;
-  export let withHardCoded = withHardCoded_;
+  export let test = Property.test;
+  export let Random = Property.Random;
+  export let sample = Property.sample;
+  export let withHardCoded = Property.withHardCoded;
+
+  export let equivalent = Equivalent.equivalent;
+  export let equivalentProvable = Equivalent.equivalentProvable;
+  export let equivalentAsync = Equivalent.equivalentAsync;
+  export let oneOf = Equivalent.oneOf;
+  export let throwError = Equivalent.throwError;
+  export let handleErrors = Equivalent.handleErrors;
+  export let defaultAssertEqual = Equivalent.defaultAssertEqual;
+  export let id = Equivalent.id;
+  export let spec = Equivalent.spec;
+  export let field = Equivalent.field;
+  export let fieldWithRng = Equivalent.fieldWithRng;
+  export let bigintField = Equivalent.bigintField;
+  export let bool = Equivalent.bool;
+  export let boolean = Equivalent.boolean;
+  export let unit = Equivalent.unit;
+  export let array = Equivalent.array;
+  export let record = Equivalent.record;
+  export let map = Equivalent.map;
+  export let onlyIf = Equivalent.onlyIf;
+  export let fromRandom = Equivalent.fromRandom;
+  export let first = Equivalent.first;
+  export let second = Equivalent.second;
+  export let constant = Equivalent.constant;
+
+  export let constraintSystem = ConstraintSystem.constraintSystem;
+  export let not = ConstraintSystem.not;
+  export let and = ConstraintSystem.and;
+  export let or = ConstraintSystem.or;
+  export let fulfills = ConstraintSystem.fulfills;
+  export let equals = ConstraintSystem.equals;
+  export let contains = ConstraintSystem.contains;
+  export let allConstant = ConstraintSystem.allConstant;
+  export let ifNotAllConstant = ConstraintSystem.ifNotAllConstant;
+  export let isEmpty = ConstraintSystem.isEmpty;
+  export let withoutGenerics = ConstraintSystem.withoutGenerics;
+  export let print = ConstraintSystem.print;
+  export let repeat = ConstraintSystem.repeat;
+  export type ConstraintSystemTest = ConstraintSystem.ConstraintSystemTest;
 }


### PR DESCRIPTION
This PR exposes existing internal testing tools for use of third party primitive developers.
### Changes:
* Created a`Testing` namespace in `src/lib/testing/testing.ts` that organizes the testing tools.
* `Testing` namespace is exported from `Experimental`.
* Added an example in `src/examples/testing.ts` to demonstrate the use of `Testing` utilities.

