### PR TITLE
trivial workflow

### DIFF
--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -1,0 +1,24 @@
+name: nix
+on:
+  workflow_dispatch:
+    inputs:
+      name:
+        description: 'Commit nix fixes'
+        default: 'World'
+        required: true
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  nix-fixes:
+    runs-on: [sdk-self-hosted-linux-amd64-build-system]
+    steps:
+      - name: Set up Nix
+        run: echo "PATH=$PATH:/nix/var/nix/profiles/default/bin" >> $GITHUB_ENV
+      - name: Disable smudging
+        run: echo "GIT_LFS_SKIP_SMUDGE=1" >> $GITHUB_ENV
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive


### PR DESCRIPTION
Github doesn't let you trigger workflows that don't exist on main. I assume this is somehow a security issue.
I'd like to merge this (almost) empty one so I can test out the workflow.