### PR TITLE
Add toBits and fromBits support for UInt32 and UInt64

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
   - New transaction construction API `new ZkappCommand()`. https://github.com/o1-labs/o1js/pull/2042
 - Bump up Rust version to 1.79.0. Bindings now depends on nightly-2024-06-13.
   https://github.com/o1-labs/o1js/pull/2063
+- `toBits()` and `fromBits()` methods added for `UInt32` and `UInt64` classes. https://github.com/o1-labs/o1js/pull/2099
 
 ## [2.3.0](https://github.com/o1-labs/o1js/compare/b857516...fb625f)
 

--- a/src/lib/provable/int.ts
+++ b/src/lib/provable/int.ts
@@ -19,7 +19,6 @@ import {
 import { assert } from '../util/assert.js';
 import { TupleN } from '../util/types.js';
 import { bytesToWord, wordToBytes } from './gadgets/bit-slices.js';
-import { Fp } from '../../bindings/crypto/finite-field.js';
 import { BinableFp } from '../../mina-signer/src/field-bigint.js';
 
 // external API

--- a/src/lib/provable/int.ts
+++ b/src/lib/provable/int.ts
@@ -536,7 +536,17 @@ class UInt64 extends CircuitValue {
   }
 
   /**
-   * Turns the {@link UInt64} into a {@link Bool} array. Default length is 64.
+   * Returns an array of {@link Bool} elements representing [little endian binary representation](https://en.wikipedia.org/wiki/Endianness) of this {@link UInt64} element.
+   *
+   * If you use the optional `length` argument, proves that the UInt64 element fits in `length` bits.
+   * The `length` has to be between 0 and 64 and the method throws if it isn't.
+   *
+   * **Warning**: The cost of this operation in a zk proof depends on the `length` you specify,
+   * which by default is 64 bits. Prefer to pass a smaller `length` if possible.
+   *
+   * @param length - the number of bits to fit the element. If the element does not fit in `length` bits, the functions throws an error.
+   *
+   * @return An array of {@link Bool} element representing little endian binary representation of this {@link UInt64}.
    */
   toBits(length: number = 64) {
     checkBitLength('UInt64.toBits()', length, 64);
@@ -555,7 +565,17 @@ class UInt64 extends CircuitValue {
   }
 
   /**
-   * Create a {@link UInt64} from a {@link Bool} array.
+   * Convert a bit array into a {@link UInt64} element using [little endian binary representation](https://en.wikipedia.org/wiki/Endianness)
+   *
+   * The method throws if the given bits do not fit in a single UInt64 element. In this case, no more than 64 bits are allowed.
+   *
+   * **Important**: If the given `bits` array is an array of `booleans` or {@link Bool} elements that all are `constant`,
+   *  the resulting {@link UInt64} element will be a constant as well. Or else, if the given array is a mixture of constants and variables of {@link Bool} type,
+   *  the resulting {@link UInt64} will be a variable as well.
+   *
+   * @param bits - An array of {@link Bool} or `boolean` type.
+   *
+   * @return A {@link UInt64} element matching the [little endian binary representation](https://en.wikipedia.org/wiki/Endianness) of the given `bits` array.
    */
   static fromBits(bits: (Bool | boolean)[]) {
     const length = bits.length;
@@ -1069,7 +1089,17 @@ class UInt32 extends CircuitValue {
   }
 
   /**
-   * Turns the {@link UInt32} into a {@link Bool} array. Default length is 32.
+   * Returns an array of {@link Bool} elements representing [little endian binary representation](https://en.wikipedia.org/wiki/Endianness) of this {@link UInt32} element.
+   *
+   * If you use the optional `length` argument, proves that the UInt32 element fits in `length` bits.
+   * The `length` has to be between 0 and 32 and the method throws if it isn't.
+   *
+   * **Warning**: The cost of this operation in a zk proof depends on the `length` you specify,
+   * which by default is 32 bits. Prefer to pass a smaller `length` if possible.
+   *
+   * @param length - the number of bits to fit the element. If the element does not fit in `length` bits, the functions throws an error.
+   *
+   * @return An array of {@link Bool} element representing little endian binary representation of this {@link UInt32}.
    */
   toBits(length: number = 32) {
     checkBitLength('UInt32.toBits()', length, 32);
@@ -1088,7 +1118,17 @@ class UInt32 extends CircuitValue {
   }
 
   /**
-   * Create a {@link UInt32} from a {@link Bool} array.
+   * Convert a bit array into a {@link UInt32} element using [little endian binary representation](https://en.wikipedia.org/wiki/Endianness)
+   *
+   * The method throws if the given bits do not fit in a single UInt32 element. In this case, no more than 32 bits are allowed.
+   *
+   * **Important**: If the given `bits` array is an array of `booleans` or {@link Bool} elements that all are `constant`,
+   *  the resulting {@link UInt32} element will be a constant as well. Or else, if the given array is a mixture of constants and variables of {@link Bool} type,
+   *  the resulting {@link UInt32} will be a variable as well.
+   *
+   * @param bits - An array of {@link Bool} or `boolean` type.
+   *
+   * @return A {@link UInt32} element matching the [little endian binary representation](https://en.wikipedia.org/wiki/Endianness) of the given `bits` array.
    */
   static fromBits(bits: (Bool | boolean)[]) {
     const length = bits.length;

--- a/src/lib/provable/test/int.test.ts
+++ b/src/lib/provable/test/int.test.ts
@@ -1015,6 +1015,28 @@ describe('int', () => {
       });
 
       describe('toBits() and fromBits()', () => {
+        it('fromBits from raw bits 4 bit', () => {
+          const bits = [Bool(false), Bool(true), Bool(false), Bool(true)];
+          const uint = UInt64.fromBits(bits);
+          expect(uint.toString()).toEqual('10');
+          expect(uint.toBits(4)).toEqual(bits);
+        });
+
+        it('fromBits from raw bits 5 bit', () => {
+          const bits = [Bool(false), Bool(true), Bool(false), Bool(true), Bool(true)];
+          const uint = UInt64.fromBits(bits);
+          expect(uint.toString()).toEqual('26');
+          expect(uint.toBits(5)).toEqual(bits);
+        });
+
+        it('fromBits from raw bits 45 bit', () => {
+          const bits = Array(44).fill(Bool(false));
+          bits.push(Bool(true));
+          const uint = UInt64.fromBits(bits);
+          expect(uint.toString()).toEqual((2n ** 44n).toString());
+          expect(uint.toBits(45)).toEqual(bits);
+        });
+
         it('test with some random values', () => {
           const testValues = [
             0,
@@ -1864,6 +1886,28 @@ describe('int', () => {
       });
 
       describe('toBits() and fromBits()', () => {
+        it('fromBits from raw bits 4 bit', () => {
+          const bits = [Bool(false), Bool(true), Bool(false), Bool(true)];
+          const uint = UInt32.fromBits(bits);
+          expect(uint.toString()).toEqual('10');
+          expect(uint.toBits(4)).toEqual(bits);
+        });
+
+        it('fromBits from raw bits 5 bit', () => {
+          const bits = [Bool(false), Bool(true), Bool(false), Bool(true), Bool(true)];
+          const uint = UInt32.fromBits(bits);
+          expect(uint.toString()).toEqual('26');
+          expect(uint.toBits(5)).toEqual(bits);
+        });
+
+        it('fromBits from raw bits 25 bit', () => {
+          const bits = Array(24).fill(Bool(false));
+          bits.push(Bool(true));
+          const uint = UInt32.fromBits(bits);
+          expect(uint.toString()).toEqual((2n ** 24n).toString());
+          expect(uint.toBits(25)).toEqual(bits);
+        });
+
         it('test with some random values', () => {
           const testValues = [0, 1, 123, 255, 256, 65535, 65536, 2 ** 31 - 1, UInt32.MAXINT()];
           for (let val of testValues) {

--- a/src/lib/provable/test/int.test.ts
+++ b/src/lib/provable/test/int.test.ts
@@ -2696,6 +2696,49 @@ describe('int', () => {
           });
         });
       });
+
+      describe('toBits() and fromBits()', () => {
+        it('fromBits from raw bits 4 bit', () => {
+          const bits = [Bool(false), Bool(true), Bool(false), Bool(true)];
+          const uint = UInt8.fromBits(bits);
+          expect(uint.toString()).toEqual('10');
+          expect(uint.toBits(4)).toEqual(bits);
+        });
+
+        it('fromBits from raw bits 7 bit', () => {
+          const bits = Array(6).fill(Bool(false));
+          bits.push(Bool(true));
+          const uint = UInt8.fromBits(bits);
+          expect(uint.toString()).toEqual((2n ** 6n).toString());
+          expect(uint.toBits(7)).toEqual(bits);
+        });
+
+        it('test with some random values', () => {
+          const testValues = [0, 1, 123, 255];
+          for (let val of testValues) {
+            const original = UInt8.from(val);
+            const bits = original.toBits();
+            const reconstructed = UInt8.fromBits(bits);
+            expect(reconstructed.toString()).toEqual(original.toString());
+          }
+        });
+
+        it('fails if we ask for fewer bits than the value needs', () => {
+          const len = 6;
+          const val = UInt8.from(0xfe);
+          expect(() => val.toBits(len)).toThrow(
+            `UInt8.toBits(): ${val.toString()} does not fit in ${len} bits`
+          );
+        });
+
+        it('fails if we provide a bits array that is longer than 8 in fromBits()', () => {
+          const len = 10;
+          const badBits = Array(len).fill(Bool(true));
+          expect(() => UInt8.fromBits(badBits)).toThrow(
+            `UInt8.fromBits(): bit length must be 8 or less, got ${len}`
+          );
+        });
+      });
     });
   });
 });

--- a/src/lib/provable/test/int.test.ts
+++ b/src/lib/provable/test/int.test.ts
@@ -625,6 +625,35 @@ describe('int', () => {
           });
         });
       });
+
+      describe('toBits() / fromBits()', () => {
+        it('should be the same as 12345678', async () => {
+          await Provable.runAndCheck(async () => {
+            const x = Provable.witness(UInt64, () => UInt64.from(12345678n));
+            const bits = x.toBits();
+            const xReconstructed = UInt64.fromBits(bits);
+            xReconstructed.assertEquals(x);
+          });
+        });
+
+        it('should be the same as 2^53-1', async () => {
+          await Provable.runAndCheck(async () => {
+            const x = Provable.witness(UInt64, () => UInt64.from(NUMBERMAX));
+            const bits = x.toBits();
+            const xReconstructed = UInt64.fromBits(bits);
+            xReconstructed.assertEquals(x);
+          });
+        });
+
+        it('should be the same as 2^64-1', async () => {
+          await Provable.runAndCheck(async () => {
+            const x = Provable.witness(UInt64, () => UInt64.MAXINT());
+            const bits = x.toBits();
+            const xReconstructed = UInt64.fromBits(bits);
+            xReconstructed.assertEquals(x);
+          });
+        });
+      });
     });
 
     describe('Outside of circuit', () => {
@@ -982,6 +1011,44 @@ describe('int', () => {
             const uint = UInt64.from(String(NUMBERMAX));
             expect(uint.value).toEqual(Field(String(NUMBERMAX)));
           });
+        });
+      });
+
+      describe('toBits() and fromBits()', () => {
+        it('test with some random values', () => {
+          const testValues = [
+            0,
+            1,
+            256,
+            1234567,
+            2 ** 32 - 1,
+            Number.MAX_SAFE_INTEGER,
+            2n ** 53n,
+            (1n << 63n) - 1n,
+            UInt64.MAXINT(),
+          ];
+          for (let val of testValues) {
+            const original = UInt64.from(val);
+            const bits = original.toBits();
+            const reconstructed = UInt64.fromBits(bits);
+            expect(reconstructed.value).toEqual(original.value);
+          }
+        });
+
+        it('fails if we ask for fewer bits than needed', () => {
+          const len = 16;
+          const val = UInt64.from(0xffff_ffffn);
+          expect(() => val.toBits(len)).toThrow(
+            `UInt64.toBits(): ${val.toString()} does not fit in ${len} bits`
+          );
+        });
+
+        it('fails if we provide a bits array that is too long for UInt64', () => {
+          const len = 65;
+          const badBits = Array(len).fill(Bool(true));
+          expect(() => UInt64.fromBits(badBits)).toThrow(
+            `UInt64.fromBits(): bit length must be 64 or less, got ${len}`
+          );
         });
       });
     });
@@ -1416,6 +1483,26 @@ describe('int', () => {
           });
         });
       });
+
+      describe('toBits() / fromBits()', () => {
+        it('should be the same as 12345', async () => {
+          await Provable.runAndCheck(async () => {
+            const x = Provable.witness(UInt32, () => UInt32.from(12345n));
+            const bits = x.toBits();
+            const xReconstructed = UInt32.fromBits(bits);
+            xReconstructed.assertEquals(x);
+          });
+        });
+
+        it('should be the same as 2^32-1', async () => {
+          await Provable.runAndCheck(async () => {
+            const x = Provable.witness(UInt32, () => UInt32.MAXINT());
+            const bits = x.toBits();
+            const xReconstructed = UInt32.fromBits(bits);
+            xReconstructed.assertEquals(x);
+          });
+        });
+      });
     });
 
     describe('Outside of circuit', () => {
@@ -1773,6 +1860,34 @@ describe('int', () => {
             const x = UInt32.from(String(NUMBERMAX));
             expect(x.value).toEqual(Field(String(NUMBERMAX)));
           });
+        });
+      });
+
+      describe('toBits() and fromBits()', () => {
+        it('test with some random values', () => {
+          const testValues = [0, 1, 123, 255, 256, 65535, 65536, 2 ** 31 - 1, UInt32.MAXINT()];
+          for (let val of testValues) {
+            const original = UInt32.from(val);
+            const bits = original.toBits();
+            const reconstructed = UInt32.fromBits(bits);
+            expect(reconstructed.toString()).toEqual(original.toString());
+          }
+        });
+
+        it('fails if we ask for fewer bits than the value needs', () => {
+          const len = 8;
+          const val = UInt32.from(0xfffe);
+          expect(() => val.toBits(len)).toThrow(
+            `UInt32.toBits(): ${val.toString()} does not fit in ${len} bits`
+          );
+        });
+
+        it('fails if we provide a bits array that is longer than 32 in fromBits()', () => {
+          const len = 33;
+          const badBits = Array(len).fill(Bool(true));
+          expect(() => UInt32.fromBits(badBits)).toThrow(
+            `UInt32.fromBits(): bit length must be 32 or less, got ${len}`
+          );
         });
       });
     });


### PR DESCRIPTION
Corresponding issue: #2098 

Implemented `toBits()` and `fromBits()` methods for `UInt32` and `UInt64` classes and their tests.