### PR TITLE
update changelog job runner

### DIFF
--- a/.github/workflows/changelog-entry.yml
+++ b/.github/workflows/changelog-entry.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   Check-Changelog:
     name: Check Changelog Action
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - uses: tarides/changelog-check-action@v2
         with:


### PR DESCRIPTION
20.04 is dropping support:

https://github.com/actions/runner-images/issues/11101