### PR TITLE
Implement verification key hash validation

### DIFF
--- a/src/examples/zkapps/vk-hash-validation-zkapp.ts
+++ b/src/examples/zkapps/vk-hash-validation-zkapp.ts
@@ -1,8 +1,6 @@
 import {
   Field,
   SmartContract,
-  state,
-  State,
   method,
   VerificationKey,
   validateVkHash,
@@ -16,7 +14,7 @@ import {
 class VkHashVerifierZkApp extends SmartContract {
   init() {
     super.init();
-    
+
     // Set permissions to allow updating verification key
     this.account.permissions.set({
       ...Permissions.default(),
@@ -29,7 +27,7 @@ class VkHashVerifierZkApp extends SmartContract {
     if (Provable.inCheckedComputation()) {
       validateVkHash(verificationKey);
     }
-    
+
     // Set the verification key in the account
     this.account.verificationKey.set(verificationKey);
   }
@@ -64,7 +62,7 @@ console.log('Original verification key hash:', verificationKey.hash.toString());
 // Create a new verification key with different data for testing
 const invalidVerificationKey = new VerificationKey({
   data: verificationKey.data,
-  hash: Field(12345678) // Different hash value
+  hash: Field(12345678), // Different hash value
 });
 console.log('Invalid verification key hash:', invalidVerificationKey.hash.toString());
 
@@ -73,4 +71,4 @@ const validateAndSet_txn = await Mina.transaction(feePayer2, async () => {
   await zkApp.validateAndSetVerificationKey(invalidVerificationKey);
 });
 await validateAndSet_txn.prove();
-await validateAndSet_txn.sign([feePayer2.key]).send(); 
+await validateAndSet_txn.sign([feePayer2.key]).send();

--- a/src/examples/zkapps/vk-hash-validation-zkapp.ts
+++ b/src/examples/zkapps/vk-hash-validation-zkapp.ts
@@ -9,6 +9,8 @@ import {
   PrivateKey,
   Permissions,
   Provable,
+  State,
+  state,
 } from 'o1js';
 
 class VkHashVerifierZkApp extends SmartContract {
@@ -23,7 +25,7 @@ class VkHashVerifierZkApp extends SmartContract {
   }
 
   @method async validateAndSetVerificationKey(verificationKey: VerificationKey) {
-    // First validate the verification key hash matches the data
+    // Validate the verification key hash matches the data
     if (Provable.inCheckedComputation()) {
       validateVkHash(verificationKey);
     }
@@ -33,42 +35,128 @@ class VkHashVerifierZkApp extends SmartContract {
   }
 }
 
-let Local = await Mina.LocalBlockchain({ proofsEnabled: true });
-Mina.setActiveInstance(Local);
+// Simple increment zkApp to get a different verification key
+class IncrementZkApp extends SmartContract {
+  @state(Field) counter = State<Field>();
 
-const [feePayer1, feePayer2] = Local.testAccounts;
-console.log('Fee payer 1:', feePayer1.toBase58());
-console.log('Fee payer 2:', feePayer2.toBase58());
+  init() {
+    super.init();
+    this.counter.set(Field(0));
+  }
 
-const zkAppPrivateKey = PrivateKey.random();
-const zkAppAddress = zkAppPrivateKey.toPublicKey();
-console.log('ZkApp address:', zkAppAddress.toBase58());
+  @method async increment() {
+    const currentValue = this.counter.get();
+    this.counter.requireEquals(currentValue);
+    const newValue = currentValue.add(1);
+    this.counter.set(newValue);
+  }
+}
 
-const zkApp = new VkHashVerifierZkApp(zkAppAddress);
+async function main() {
+  let Local = await Mina.LocalBlockchain({ proofsEnabled: true });
+  Mina.setActiveInstance(Local);
 
-await VkHashVerifierZkApp.compile();
+  const [feePayer1, feePayer2] = Local.testAccounts;
+  console.log('Fee payer 1:', feePayer1.key.toPublicKey().toBase58());
+  console.log('Fee payer 2:', feePayer2.key.toPublicKey().toBase58());
 
-const deploy_txn = await Mina.transaction(feePayer1, async () => {
-  AccountUpdate.fundNewAccount(feePayer1);
-  await zkApp.deploy();
+  // Create VkHashVerifier zkApp instance
+  const vkHashVerifierKey = PrivateKey.random();
+  const vkHashVerifierAddress = vkHashVerifierKey.toPublicKey();
+  console.log('VkHashVerifier ZkApp address:', vkHashVerifierAddress.toBase58());
+  const vkHashVerifier = new VkHashVerifierZkApp(vkHashVerifierAddress);
+
+  // Create Increment zkApp instance
+  const incrementKey = PrivateKey.random();
+  const incrementAddress = incrementKey.toPublicKey();
+  console.log('Increment ZkApp address:', incrementAddress.toBase58());
+  const increment = new IncrementZkApp(incrementAddress);
+
+  // Compile both zkApps to get their verification keys
+  console.log('\nCompiling zkApps...');
+  await VkHashVerifierZkApp.compile();
+  const { verificationKey: vkHashVerifierVk } = await VkHashVerifierZkApp.compile();
+
+  console.log('Compiling IncrementZkApp...');
+  await IncrementZkApp.compile();
+  const { verificationKey: incrementVk } = await IncrementZkApp.compile();
+
+  // Deploy VkHashVerifier zkApp
+  console.log('\nDeploying VkHashVerifier zkApp...');
+  try {
+    const deploy_txn = await Mina.transaction(feePayer1.key.toPublicKey(), async () => {
+      AccountUpdate.fundNewAccount(feePayer1.key.toPublicKey());
+      await vkHashVerifier.deploy();
+    });
+    await deploy_txn.prove();
+    await deploy_txn.sign([feePayer1.key, vkHashVerifierKey]).send();
+    console.log('VkHashVerifier deployed successfully');
+  } catch (error: any) {
+    console.error('Failed to deploy VkHashVerifier:', error.message);
+    return;
+  }
+
+  // Deploy Increment zkApp
+  console.log('\nDeploying Increment zkApp...');
+  try {
+    const deploy_txn2 = await Mina.transaction(feePayer2.key.toPublicKey(), async () => {
+      AccountUpdate.fundNewAccount(feePayer2.key.toPublicKey());
+      await increment.deploy();
+    });
+    await deploy_txn2.prove();
+    await deploy_txn2.sign([feePayer2.key, incrementKey]).send();
+    console.log('Increment zkApp deployed successfully');
+  } catch (error: any) {
+    console.error('Failed to deploy Increment zkApp:', error.message);
+    return;
+  }
+
+  // Test the increment functionality
+  console.log('\nTesting Increment zkApp...');
+  try {
+    const increment_txn = await Mina.transaction(feePayer2.key.toPublicKey(), async () => {
+      await increment.increment();
+    });
+    await increment_txn.prove();
+    await increment_txn.sign([feePayer2.key]).send();
+    console.log('Increment transaction successful');
+  } catch (error: any) {
+    console.error('Failed to increment:', error.message);
+  }
+
+  console.log('\nVerification Key Information:');
+  console.log('\nVkHashVerifier verification key hash:', vkHashVerifierVk.hash.toString());
+  console.log('\nIncrement zkApp verification key hash:', incrementVk.hash.toString());
+  console.log('\nVkHashVerifier verification key data:', vkHashVerifierVk.data);
+  console.log('\nIncrement zkApp verification key data:', incrementVk.data);
+
+  // Create an invalid verification key using increment zkApp's data with VkHashVerifier's hash
+  const invalidVerificationKey = new VerificationKey({
+    data: vkHashVerifierVk.data, // Use data from increment zkApp
+    hash: incrementVk.hash, // But with hash from VkHashVerifier
+  });
+  console.log('\nInvalid verification key hash:', invalidVerificationKey.hash.toString());
+
+  // Try to validate and set the invalid verification key (should throw an error)
+  console.log('\nTesting invalid verification key...');
+  try {
+    const validateAndSet_txn = await Mina.transaction(feePayer2.key.toPublicKey(), async () => {
+      await vkHashVerifier.validateAndSetVerificationKey(invalidVerificationKey);
+    });
+    await validateAndSet_txn.prove();
+    await validateAndSet_txn.sign([feePayer2.key]).send();
+    console.log('Expected transaction to fail but it succeeded');
+  } catch (error: any) {
+    if (error.message.includes('Provided VerificationKey hash is not correct')) {
+      console.log('Transaction correctly failed: Invalid verification key hash rejected');
+    } else {
+      console.error('Transaction failed with unexpected error:', error.message);
+      console.error('Error message:', error.message);
+    }
+  }
+}
+
+main().catch((error) => {
+  console.error('Main function failed:', error);
+  process.exit(1);
 });
-await deploy_txn.prove();
-await deploy_txn.sign([feePayer1.key, zkAppPrivateKey]).send();
-
-// Get a verification key
-const { verificationKey } = await VkHashVerifierZkApp.compile();
-console.log('Original verification key hash:', verificationKey.hash.toString());
-
-// Create a new verification key with different data for testing
-const invalidVerificationKey = new VerificationKey({
-  data: verificationKey.data,
-  hash: Field(12345678), // Different hash value
-});
-console.log('Invalid verification key hash:', invalidVerificationKey.hash.toString());
-
-// Validate and set the verification key in the zkApp (it should throw an error)
-const validateAndSet_txn = await Mina.transaction(feePayer2, async () => {
-  await zkApp.validateAndSetVerificationKey(invalidVerificationKey);
-});
-await validateAndSet_txn.prove();
-await validateAndSet_txn.sign([feePayer2.key]).send();

--- a/src/examples/zkapps/vk-hash-validation-zkapp.ts
+++ b/src/examples/zkapps/vk-hash-validation-zkapp.ts
@@ -1,0 +1,76 @@
+import {
+  Field,
+  SmartContract,
+  state,
+  State,
+  method,
+  VerificationKey,
+  validateVkHash,
+  Mina,
+  AccountUpdate,
+  PrivateKey,
+  Permissions,
+  Provable,
+} from 'o1js';
+
+class VkHashVerifierZkApp extends SmartContract {
+  init() {
+    super.init();
+    
+    // Set permissions to allow updating verification key
+    this.account.permissions.set({
+      ...Permissions.default(),
+      setVerificationKey: Permissions.VerificationKey.proofDuringCurrentVersion(),
+    });
+  }
+
+  @method async validateAndSetVerificationKey(verificationKey: VerificationKey) {
+    // First validate the verification key hash matches the data
+    if (Provable.inCheckedComputation()) {
+      validateVkHash(verificationKey);
+    }
+    
+    // Set the verification key in the account
+    this.account.verificationKey.set(verificationKey);
+  }
+}
+
+let Local = await Mina.LocalBlockchain({ proofsEnabled: true });
+Mina.setActiveInstance(Local);
+
+const [feePayer1, feePayer2] = Local.testAccounts;
+console.log('Fee payer 1:', feePayer1.toBase58());
+console.log('Fee payer 2:', feePayer2.toBase58());
+
+const zkAppPrivateKey = PrivateKey.random();
+const zkAppAddress = zkAppPrivateKey.toPublicKey();
+console.log('ZkApp address:', zkAppAddress.toBase58());
+
+const zkApp = new VkHashVerifierZkApp(zkAppAddress);
+
+await VkHashVerifierZkApp.compile();
+
+const deploy_txn = await Mina.transaction(feePayer1, async () => {
+  AccountUpdate.fundNewAccount(feePayer1);
+  await zkApp.deploy();
+});
+await deploy_txn.prove();
+await deploy_txn.sign([feePayer1.key, zkAppPrivateKey]).send();
+
+// Get a verification key
+const { verificationKey } = await VkHashVerifierZkApp.compile();
+console.log('Original verification key hash:', verificationKey.hash.toString());
+
+// Create a new verification key with different data for testing
+const invalidVerificationKey = new VerificationKey({
+  data: verificationKey.data,
+  hash: Field(12345678) // Different hash value
+});
+console.log('Invalid verification key hash:', invalidVerificationKey.hash.toString());
+
+// Validate and set the verification key in the zkApp (it should throw an error)
+const validateAndSet_txn = await Mina.transaction(feePayer2, async () => {
+  await zkApp.validateAndSetVerificationKey(invalidVerificationKey);
+});
+await validateAndSet_txn.prove();
+await validateAndSet_txn.sign([feePayer2.key]).send(); 

--- a/src/index.ts
+++ b/src/index.ts
@@ -60,8 +60,17 @@ export { SmartContract, method, declareMethods } from './lib/mina/v1/zkapp.js';
 export { Reducer } from './lib/mina/v1/actions/reducer.js';
 export { state, State, declareState } from './lib/mina/v1/state.js';
 
-export type { JsonProof } from './lib/proof-system/zkprogram.js';
-export { SelfProof, verify, Empty, Undefined, Void } from './lib/proof-system/zkprogram.js';
+export {
+  ZkProgram,
+  SelfProof,
+  JsonProof,
+  verify,
+  Empty,
+  Undefined,
+  Void,
+  Method,
+  validateVkHash,
+} from './lib/proof-system/zkprogram.js';
 export { VerificationKey } from './lib/proof-system/verification-key.js';
 export { type ProofBase, Proof, DynamicProof } from './lib/proof-system/proof.js';
 export { FeatureFlags } from './lib/proof-system/feature-flags.js';
@@ -102,8 +111,6 @@ export { MerkleTree, MerkleWitness } from './lib/provable/merkle-tree.js';
 export { MerkleMap, MerkleMapWitness } from './lib/provable/merkle-map.js';
 
 export { Nullifier } from './lib/provable/crypto/nullifier.js';
-
-export { ZkProgram } from './lib/proof-system/zkprogram.js';
 
 export { Crypto } from './lib/provable/crypto/crypto.js';
 

--- a/src/lib/proof-system/zkprogram.ts
+++ b/src/lib/proof-system/zkprogram.ts
@@ -135,13 +135,13 @@ async function verify(
 /**
  * Validates that a verification key's hash matches the expected hash.
  * This is useful for verifying that a verification key is valid in a circuit.
- * 
+ *
  * @param verificationKey - The verification key to validate
  * @returns void, throws an error if the hash doesn't match
  */
 async function validateVkHash(verificationKey: VerificationKey) {
   const circuitVk = Pickles.sideLoaded.vkToCircuit(() => verificationKey.data);
-  
+
   // Assert the validity of the auxiliary vk-data by comparing the witnessed and the hash as an input
   const hash = inCircuitVkHash(circuitVk);
   Field(hash).assertEquals(verificationKey.hash, 'Provided VerificationKey hash not correct');

--- a/src/lib/proof-system/zkprogram.ts
+++ b/src/lib/proof-system/zkprogram.ts
@@ -133,11 +133,11 @@ async function verify(
 }
 
 /**
- * Validates that a verification key's hash matches the expected hash.
- * This is useful for verifying that a verification key is valid in a circuit.
+ * Asserts that the hash computed from a verification key's data matches the provided hash.
+ * This is used to ensure that the verification key data and hash are consistent.
  *
- * @param verificationKey - The verification key to validate
- * @returns void, throws an error if the hash doesn't match
+ * @param verificationKey - The verification key whose data and hash to check for consistency
+ * @returns void, throws an error if the computed hash doesn't match the provided hash
  */
 async function validateVkHash(verificationKey: VerificationKey) {
   const circuitVk = Pickles.sideLoaded.vkToCircuit(() => verificationKey.data);

--- a/src/lib/proof-system/zkprogram.ts
+++ b/src/lib/proof-system/zkprogram.ts
@@ -144,7 +144,7 @@ async function validateVkHash(verificationKey: VerificationKey) {
 
   // Assert the validity of the auxiliary vk-data by comparing the witnessed and the hash as an input
   const hash = inCircuitVkHash(circuitVk);
-  Field(hash).assertEquals(verificationKey.hash, 'Provided VerificationKey hash not correct');
+  Field(hash).assertEquals(verificationKey.hash, 'Provided VerificationKey hash is not correct');
 }
 
 /**


### PR DESCRIPTION
## Description
This PR adds functionality to validate verification key data-hash pairs, addressing the need to verify the validity of verification key, particularly when upgrading side-loaded verification keys committed on chain.

## Changes
- Added `validateVkHash` function in `zkprogram.ts` to verify if a given verification key's data matches its hash: https://github.com/o1-labs/o1js/blob/06182ba70d5b84cca15a31b0a76c87eec386627b/src/lib/proof-system/zkprogram.ts#L142
- Added example zkApp demonstrating the validation functionality: 
https://github.com/o1-labs/o1js/blob/06182ba70d5b84cca15a31b0a76c87eec386627b/src/examples/zkapps/vk-hash-validation-zkapp.ts#L29

## Related Issue
Resolves #2120

## Additional Context
This feature is particularly useful for:
- Verifying verification keys before setting them in zkApps
- Ensuring data-hash pairs are valid when upgrading verification keys
- Preventing invalid verification keys from being committed on chain?
- https://discord.com/channels/484437221055922177/915745847692636181/1357003022307295405

## To-Do
- [ ] Add test cases for different verification key scenarios
- [ ] Investigate proper circuit context handling without `Provable.inCheckedComputation()`
- [ ] Update Changelog