### PR TITLE
update node in devshell

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -6,7 +6,7 @@
           "flake-utils"
         ],
         "nixpkgs": [
-          "nixpkgs"
+          "nixpkgs-mina"
         ]
       },
       "locked": {
@@ -35,11 +35,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1724407960,
-        "narHash": "sha256-pUKTVMYEtsD1AGlHFTdPourowt+tJ3htKhRu7VALFzc=",
+        "lastModified": 1742933373,
+        "narHash": "sha256-sW6ZheQeXe+GULDKLcgRJN4eucP3IXWHz0bHL9KKU1w=",
         "owner": "o1-labs",
         "repo": "describe-dune",
-        "rev": "be828239c05671209e979f9d5c2e3094e3be7a46",
+        "rev": "ba71baa26329399ca2f1d158f15e7c32bba1d072",
         "type": "github"
       },
       "original": {
@@ -54,7 +54,7 @@
           "flake-utils"
         ],
         "nixpkgs": [
-          "nixpkgs"
+          "nixpkgs-mina"
         ]
       },
       "locked": {
@@ -83,11 +83,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1724418497,
-        "narHash": "sha256-HjTh7o02QhGXmbxmpE5HRWei3H/pyh/NKCMCnucDaYs=",
+        "lastModified": 1742933757,
+        "narHash": "sha256-FI8sVvIJuKscrnOUj/cqbZRVOxTzgBwYMyZSNcXq+58=",
         "owner": "o1-labs",
         "repo": "dune-nix",
-        "rev": "26dc164a4c3976888e13eabd73a210b78505820f",
+        "rev": "5eedc211a4cfc3bae1833c5a85542be49b4a9f6b",
         "type": "github"
       },
       "original": {
@@ -265,14 +265,15 @@
         "utils": "utils"
       },
       "locked": {
-        "lastModified": 1739454056,
-        "narHash": "sha256-qwW1JF2Rceh2su6gEkCZNQOZQCGTg1rWp7ldbmhGJO4=",
+        "lastModified": 1743773784,
+        "narHash": "sha256-qqfGRT7iWZFF1f/ULJaEhD4KcV32S72DzQKHQshYQg4=",
         "path": "src/mina",
         "type": "path"
       },
       "original": {
-        "path": "src/mina",
-        "type": "path"
+        "submodules": true,
+        "type": "git",
+        "url": "file:src/mina"
       }
     },
     "mirage-opam-overlays": {
@@ -391,6 +392,22 @@
         "type": "github"
       }
     },
+    "nixpkgs-mina": {
+      "locked": {
+        "lastModified": 1720535198,
+        "narHash": "sha256-zwVvxrdIzralnSbcpghA92tWu2DV2lwv89xZc8MTrbg=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "205fd4226592cc83fd4c0885a3e4c9c400efabb5",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "nixos-23.11-small",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
     "nixpkgs-mozilla": {
       "flake": false,
       "locked": {
@@ -423,6 +440,22 @@
         "type": "github"
       }
     },
+    "nixpkgs-newer": {
+      "locked": {
+        "lastModified": 1743703532,
+        "narHash": "sha256-s1KLDALEeqy+ttrvqV3jx9mBZEvmthQErTVOAzbjHZs=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "bdb91860de2f719b57eef819b5617762f7120c70",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "nixos-24.11-small",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
     "nixpkgs_2": {
       "locked": {
         "lastModified": 1713180868,
@@ -430,22 +463,6 @@
         "owner": "nixos",
         "repo": "nixpkgs",
         "rev": "140546acf30a8212a03a88ded8506413fa3b5d21",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nixos",
-        "ref": "nixos-23.11-small",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
-    "nixpkgs_3": {
-      "locked": {
-        "lastModified": 1720535198,
-        "narHash": "sha256-zwVvxrdIzralnSbcpghA92tWu2DV2lwv89xZc8MTrbg=",
-        "owner": "nixos",
-        "repo": "nixpkgs",
-        "rev": "205fd4226592cc83fd4c0885a3e4c9c400efabb5",
         "type": "github"
       },
       "original": {
@@ -561,8 +578,9 @@
         "dune-nix": "dune-nix",
         "flake-utils": "flake-utils",
         "mina": "mina",
-        "nixpkgs": "nixpkgs_3",
-        "nixpkgs-mozilla": "nixpkgs-mozilla_2"
+        "nixpkgs-mina": "nixpkgs-mina",
+        "nixpkgs-mozilla": "nixpkgs-mozilla_2",
+        "nixpkgs-newer": "nixpkgs-newer"
       }
     },
     "systems": {


### PR DESCRIPTION
The tests started failing in the devshell because we now depend on node >= 20.
We've been using node 18 because we use the same nixpkgs version as mina and it only has node 18.
I added an overlay to use node and npm from a newer version of nixpkgs, this is probably a bit bad for `/nix/store` size but updating nixpkgs in mina seems daunting.