### PR TITLE
chore: fix incorrect dual module loading in `initializeBindings()`

### DIFF
--- a/src/snarky.js
+++ b/src/snarky.js
@@ -17,10 +17,14 @@ async function initializeBindings() {
 
   // this dynamic import makes jest respect the import order
   // otherwise the cjs file gets imported before its implicit esm dependencies and fails
-  CJS: if (typeof require !== 'undefined') {
+  if (typeof require !== 'undefined') {
+    // CJS: use require when available
     snarky = require('./bindings/compiled/_node_bindings/o1js_node.bc.cjs');
+  } else {
+    // ESM: use dynamic import if require is not defined
+    snarky = (await import('./bindings/compiled/_node_bindings/o1js_node.bc.cjs')).default;
   }
-  ESM: snarky = (await import('./bindings/compiled/_node_bindings/o1js_node.bc.cjs')).default;
+
   ({ Snarky, Ledger, Pickles, Test: Test_ } = snarky);
   resolve();
   initializingPromise = undefined;


### PR DESCRIPTION
Cleaned up the module loading logic in `initializeBindings()` to prevent potential runtime errors in mixed module environments.

---

### What I changed and why:

1. **Removed misleading `CJS:` and `ESM:` labels**  
   These weren’t actual conditional branches but label statements, which do nothing in this context. They were visually confusing and served no purpose.

2. **Replaced dual execution with proper `if-else` branching**  
   Previously, both `require(...)` and `import(...)` were being executed unconditionally.  
   Now, the function properly checks:
   - if `require` is available (CJS), it uses `require(...)`
   - otherwise, it falls back to `import(...)` (ESM)

This avoids trying to use dynamic `import()` in environments that don’t support it (like pure CommonJS), which could cause crashes or unwanted side effects.