### PR TITLE
Update bindings with Nix

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -265,8 +265,8 @@
         "utils": "utils"
       },
       "locked": {
-        "lastModified": 1744034815,
-        "narHash": "sha256-cDtExOhwuLEVq+wdyMhpq7UXYZxUfpAETXNGM5D/8aA=",
+        "lastModified": 1744054069,
+        "narHash": "sha256-38qjclymVxBkeWgxgp3Zf9fNak66bAOneLb6M3zIcIg=",
         "path": "src/mina",
         "type": "path"
       },


### PR DESCRIPTION
This is https://github.com/o1-labs/o1js/pull/2128, but the bindings are built using `nix run o1js#update-bindings --max-jobs 32 --show-trac`

See counterpart: https://github.com/o1-labs/o1js-bindings/pull/355