### PR TITLE
Add check to verification key struct

### DIFF
--- a/src/examples/zkapps/zkapp-self-update.ts
+++ b/src/examples/zkapps/zkapp-self-update.ts
@@ -59,7 +59,29 @@ Provable.log('original verification key', fooVerificationKey);
 
 const { verificationKey: barVerificationKey } = await Bar.compile();
 
+try {
+  const illegalVerificationKey = new VerificationKey({
+    data: fooVerificationKey!.data,
+    hash: barVerificationKey.hash,
+  });
+
+  const tx2 = await Mina.transaction(deployer, async () => {
+    // VK with mismatched hash and data should throw
+    await contract.replaceVerificationKey(illegalVerificationKey);
+  });
+  await tx2.prove();
+} catch (error: any) {
+  if (
+    error.message.includes('The verification key hash is not consistent with the provided data')
+  ) {
+    console.log('correctly threw on illegal verification key');
+  } else {
+    throw error;
+  }
+}
+
 const tx2 = await Mina.transaction(deployer, async () => {
+  // This call will work because the vk is valid
   await contract.replaceVerificationKey(barVerificationKey);
 });
 await tx2.prove();

--- a/src/lib/proof-system/zkprogram.ts
+++ b/src/lib/proof-system/zkprogram.ts
@@ -60,6 +60,7 @@ export {
   TupleToInstances,
   PrivateInput,
   Proof,
+  inCircuitVkHash,
 };
 
 type Undefined = undefined;


### PR DESCRIPTION
This PR adds a `static check()` method to the verification key struct.  The result is that we add assertions on the value of the VK such that the data and hash must match.

It's possible that adding these assertions are overkill, since the Protocol should not allow an updated VK that is not internally valid.  It does provide a more consistent API experience though.