### PR TITLE
Add block height filters to fetchActions and fetchEvents

### DIFF
--- a/src/lib/mina/v1/local-blockchain.ts
+++ b/src/lib/mina/v1/local-blockchain.ts
@@ -37,6 +37,8 @@ import {
   verifyAccountUpdate,
 } from './transaction-validation.js';
 import { prettifyStacktrace } from '../../util/errors.js';
+import { NetworkValue } from './precondition.js';
+import type { EventActionFilterOptions } from './graphql.js';
 
 export { LocalBlockchain, TestPublicKey };
 
@@ -315,7 +317,12 @@ async function LocalBlockchain({ proofsEnabled = true, enforceTransactionLimits 
         JSON.stringify(networkState)
       );
     },
-    async fetchEvents(publicKey: PublicKey, tokenId: Field = TokenId.default) {
+    async fetchEvents(
+      publicKey: PublicKey, 
+      tokenId: Field = TokenId.default,
+      filterOptions?: EventActionFilterOptions,
+      _headers?: HeadersInit
+    ) {
       // Return events in reverse chronological order (latest events at the beginning)
       const reversedEvents = (
         events?.[publicKey.toBase58()]?.[TokenId.toBase58(tokenId)] ?? []
@@ -326,8 +333,8 @@ async function LocalBlockchain({ proofsEnabled = true, enforceTransactionLimits 
       publicKey: PublicKey,
       actionStates?: ActionStates,
       tokenId: Field = TokenId.default,
-      _from?: number,
-      _to?: number
+      filterOptions?: EventActionFilterOptions,
+      _headers?: HeadersInit
     ) {
       return this.getActions(publicKey, actionStates, tokenId);
     },

--- a/src/lib/mina/v1/mina-instance.ts
+++ b/src/lib/mina/v1/mina-instance.ts
@@ -87,8 +87,7 @@ type Mina = {
     publicKey: PublicKey,
     actionStates?: ActionStates,
     tokenId?: Field,
-    from?: number,
-    to?: number,
+    filterOptions?: EventActionFilterOptions,
     headers?: HeadersInit
   ) => ReturnType<typeof Fetch.fetchActions>;
   getActions: (
@@ -194,11 +193,16 @@ async function fetchActions(
   publicKey: PublicKey,
   actionStates?: ActionStates,
   tokenId?: Field,
-  from?: number,
-  to?: number,
+  filterOptions?: EventActionFilterOptions,
   headers?: HeadersInit
 ) {
-  return await activeInstance.fetchActions(publicKey, actionStates, tokenId, from, to, headers);
+  return await activeInstance.fetchActions(
+    publicKey,
+    actionStates,
+    tokenId,
+    filterOptions,
+    headers
+  );
 }
 
 /**

--- a/src/lib/mina/v1/mina.network.unit-test.ts
+++ b/src/lib/mina/v1/mina.network.unit-test.ts
@@ -283,7 +283,7 @@ describe('Test network with headers', () => {
   });
 
   it('Archive default headers with per request headers in fetchActions', async () => {
-    await Mina.fetchActions(bobAccount, undefined, undefined, undefined, undefined, {
+    await Mina.fetchActions(bobAccount, undefined, undefined, {}, {
       'X-Test': 'per-request-test',
     });
 


### PR DESCRIPTION
## Description

This PR adds support for block height filtering to fetchActions and fetchEvents functions, allowing more efficient queries by specifying a specific block range using to and from parameters within the filterOptions object.

Changes include:
- Updated fetchActions and fetchEvents in mina.ts to accept block height filters via the filterOptions parameter
- Modified the function signatures in mina-instance.ts to maintain a consistent API across the library
- Adapted the LocalBlockchain implementation to match the updated interface
- Updated relevant tests to work with the new parameter structure

Without specifying a block range, requests will default to returning the most recent 10,000 blocks, as enforced by the Archive Node API.

This improvement allows developers to make more targeted queries, reducing network overhead and improving application performance.