### PR TITLE
Run fetchGenesisConstants even if fetchLastBlock fails

### DIFF
--- a/src/lib/mina/v1/fetch.ts
+++ b/src/lib/mina/v1/fetch.ts
@@ -373,9 +373,13 @@ async function fetchMissingData(graphqlEndpoint: string, archiveEndpoint?: strin
       (async () => {
         try {
           await fetchLastBlock(graphqlEndpoint);
-          await fetchGenesisConstants(graphqlEndpoint);
-          delete networksToFetch[network[0]];
         } catch {}
+
+        try {
+          await fetchGenesisConstants(graphqlEndpoint);
+        } catch {}
+
+        delete networksToFetch[network[0]];
       })()
     );
   }

--- a/src/lib/mina/v1/fetch.ts
+++ b/src/lib/mina/v1/fetch.ts
@@ -371,15 +371,18 @@ async function fetchMissingData(graphqlEndpoint: string, archiveEndpoint?: strin
   if (network !== undefined) {
     promises.push(
       (async () => {
-        try {
-          await fetchLastBlock(graphqlEndpoint);
-        } catch {}
+        const [lastBlockOk, genesisOk] = await Promise.all([
+          fetchLastBlock(graphqlEndpoint)
+            .then(() => true)
+            .catch(() => false),
+          fetchGenesisConstants(graphqlEndpoint)
+            .then(() => true)
+            .catch(() => false),
+        ]);
 
-        try {
-          await fetchGenesisConstants(graphqlEndpoint);
-        } catch {}
-
-        delete networksToFetch[network[0]];
+        if (lastBlockOk && genesisOk) {
+          delete networksToFetch[network[0]];
+        }
       })()
     );
   }

--- a/src/lib/mina/v1/fetch.ts
+++ b/src/lib/mina/v1/fetch.ts
@@ -371,7 +371,7 @@ async function fetchMissingData(graphqlEndpoint: string, archiveEndpoint?: strin
   if (network !== undefined) {
     promises.push(
       (async () => {
-        const [lastBlockOk, genesisOk] = await Promise.all([
+        const [lastBlockOk, constantsOk] = await Promise.all([
           fetchLastBlock(graphqlEndpoint)
             .then(() => true)
             .catch(() => false),
@@ -380,7 +380,7 @@ async function fetchMissingData(graphqlEndpoint: string, archiveEndpoint?: strin
             .catch(() => false),
         ]);
 
-        if (lastBlockOk && genesisOk) {
+        if (lastBlockOk && constantsOk) {
           delete networksToFetch[network[0]];
         }
       })()


### PR DESCRIPTION
Genesis constants do not get fetched if `fetchLastBlock` fails. On [Zeko](https://github.com/zeko-labs/zeko), we don't have a last block query so it's fine if it fails, however we still want the o1js to query correct `accountCreationFee`.