### PR TITLE
Fix release workflow 

### DIFF
--- a/.github/workflows/push_main.yml
+++ b/.github/workflows/push_main.yml
@@ -1,6 +1,9 @@
 name: Jobs for new commits on main (and similar branches)
 on:
-  push:
+  workflow_run:
+    workflows: ["checks"]
+    types:
+      - completed
     branches:
       - main
       - v1
@@ -105,7 +108,6 @@ jobs:
   Gc-root-bindings:
     name: add a gc root for the latest bindings build
     if: github.ref == 'refs/heads/main'
-    needs: Prepare
     runs-on: [sdk-self-hosted-linux-amd64-build-system]
     steps:
       - uses: actions/checkout@v4
@@ -123,7 +125,6 @@ jobs:
     if: github.ref == 'refs/heads/main'
     timeout-minutes: 180
     runs-on: ubuntu-latest
-    needs: [Build-And-Test-Server, Run-Unit-Tests, Build-And-Test-Web]
     steps:
       - name: Restore repository
         uses: actions/cache@v4


### PR DESCRIPTION
The issue was that we cannot require a `need` on jobs from a different workflow. 