### PR TITLE
fix: Update broken link to hello-world example in README-dev.md

### DIFF
--- a/README-dev.md
+++ b/README-dev.md
@@ -269,7 +269,7 @@ See the [Docker Hub repository](https://hub.docker.com/r/o1labs/mina-local-netwo
 
 Next up, get the Mina blockchain accounts information to be used in your zkApp.
 After the local network is up and running, you can use the [Lightnet](https://github.com/o1-labs/o1js/blob/ec789794b2067addef6b6f9c9a91c6511e07e37c/src/lib/fetch.ts#L1012) `o1js API namespace` to get the accounts information.
-See the corresponding example in [src/examples/zkapps/hello-world/run-live.ts](https://github.com/o1-labs/o1js/blob/ec789794b2067addef6b6f9c9a91c6511e07e37c/src/examples/zkapps/hello-world/run-live.ts).
+See the corresponding example in [src/examples/zkapps/hello-world/run-live.ts](https://github.com/o1-labs/o1js/blob/main/src/examples/zkapps/hello-world/run-live.ts).
 
 ### Profiling o1js
 


### PR DESCRIPTION
The link to the hello-world/run-live.ts example in README-dev.md was pointing 
to a specific historical commit that no longer exists or has been moved. 
This commit replaces the hardcoded commit hash reference with a link to the 
main branch, ensuring the link remains valid as the codebase evolves.

Changed:
- Updated URL from:
  https://github.com/o1-labs/o1js/blob/ec789794b2067addef6b6f9c9a91c6511e07e37c/src/examples/zkapps/hello-world/run-live.ts
- To:
  https://github.com/o1-labs/o1js/blob/main/src/examples/zkapps/hello-world/run-live.ts