### PR TITLE
Fixed error in download-bindings.sh for multiple workflow runs

### DIFF
--- a/src/bindings/scripts/download-bindings.sh
+++ b/src/bindings/scripts/download-bindings.sh
@@ -10,6 +10,10 @@ RUN_ID=$( \
     jq -r '.[] | select(.name == "Checks" or .name == "Build and upload bindings") | .databaseId' \
   )
 
+# In case gh returns multiple runs, extract the last one
+WORKFLOW_COUNT=$(echo $RUN_ID | wc -w)
+RUN_ID=$(echo $RUN_ID | cut -d " " -f $WORKFLOW_COUNT)
+
 if [ -z "$RUN_ID" ]
 then
   echo bindings have not been built for this commit


### PR DESCRIPTION
If there existed multiple workflow runs for any given head, then the `RUN_ID` would contain all of the runs, delimited by a whitespace. This broke the script, this PR fixes that by extracting the latest build before downloading