### PR TITLE
Export analyzeMethod

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -61,7 +61,14 @@ export { Reducer } from './lib/mina/v1/actions/reducer.js';
 export { state, State, declareState } from './lib/mina/v1/state.js';
 
 export type { JsonProof } from './lib/proof-system/zkprogram.js';
-export { SelfProof, verify, Empty, Undefined, Void } from './lib/proof-system/zkprogram.js';
+export {
+  SelfProof,
+  verify,
+  Empty,
+  Undefined,
+  Void,
+  analyzeMethod,
+} from './lib/proof-system/zkprogram.js';
 export { VerificationKey } from './lib/proof-system/verification-key.js';
 export { type ProofBase, Proof, DynamicProof } from './lib/proof-system/proof.js';
 export { FeatureFlags } from './lib/proof-system/feature-flags.js';


### PR DESCRIPTION
For protokit, we want to extract some additional data statically from any given circuit method. This is difficult using `zkprogram.analyzeMethods()` as it runs through all methods at once.
Using `analyzeMethod` directly, this becomes possible