### PR TITLE
pass accept-flake-config globaly

### DIFF
--- a/.github/actions/build/action.yml
+++ b/.github/actions/build/action.yml
@@ -24,6 +24,7 @@ runs:
         nix_conf: |
           keep-env-derivations = true
           keep-outputs = true
+          accept-flake-config = true
     - name: Fallback to persistant nix
       # only available on some runners
       shell: bash
@@ -55,7 +56,7 @@ runs:
       run: |
         set -Eeu
         ./pin.sh
-        nix build o1js#bindings --accept-flake-config
+        nix build o1js#bindings
         temp_key=$(mktemp)
         echo ${{ inputs.nar_secret }} > "$temp_key"
         nix store sign --key-file "$temp_key" --recursive ./result


### PR DESCRIPTION
Currently `./pin.sh` invokes nix first and ends up declining the flake config in ci.
This should fix that.