### PR TITLE
Update js-sha256 to v0.10.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "blakejs": "1.2.1",
         "cachedir": "^2.4.0",
-        "js-sha256": "^0.9.0",
+        "js-sha256": "^0.10.0",
         "libsodium-wrappers-sumo": "^0.7.15",
         "reflect-metadata": "^0.1.13",
         "stacktrace-js": "^2.0.2",
@@ -4912,9 +4912,9 @@
       }
     },
     "node_modules/js-sha256": {
-      "version": "0.9.0",
-      "resolved": "https://registry.npmjs.org/js-sha256/-/js-sha256-0.9.0.tgz",
-      "integrity": "sha512-sga3MHh9sgQN2+pJ9VYZ+1LPwXOxuBJBA5nrR5/ofPfuiJBE2hnjsaN8se8JznOmGLN2p49Pe5U/ttafcs/apA=="
+      "version": "0.10.1",
+      "resolved": "https://registry.npmjs.org/js-sha256/-/js-sha256-0.10.1.tgz",
+      "integrity": "sha512-5obBtsz9301ULlsgggLg542s/jqtddfOpV5KJc4hajc9JV8GeY2gZHSVpYBn4nWqAUTJ9v+xwtbJ1mIBgIH5Vw=="
     },
     "node_modules/js-tokens": {
       "version": "4.0.0",

--- a/package.json
+++ b/package.json
@@ -113,7 +113,7 @@
   "dependencies": {
     "blakejs": "1.2.1",
     "cachedir": "^2.4.0",
-    "js-sha256": "^0.9.0",
+    "js-sha256": "^0.10.0",
     "reflect-metadata": "^0.1.13",
     "tslib": "^2.3.0",
     "libsodium-wrappers-sumo": "^0.7.15",


### PR DESCRIPTION
Updated `js-sha256` package to `v0.10.0`

References:
- [Navigator Proposal Blocker](https://forums.minaprotocol.com/t/mina-wallet-via-google-oauth-lit-protocol-integration/6703/14?u=invoicez)
- [Library GitHub Issue](https://github.com/emn178/js-sha256/issues/18)
- [Resolution Comment](https://github.com/emn178/js-sha256/issues/18#issuecomment-1699358229)