### PR TITLE
update build:bindings

### DIFF
--- a/src/bindings/scripts/build-o1js-node-artifacts.sh
+++ b/src/bindings/scripts/build-o1js-node-artifacts.sh
@@ -46,6 +46,10 @@ dune b src/bindings/mina-transaction/gen/v1/js-layout.ts \
 rm -rf "src/config" \
 && rm "src/config.mlh" || exit 1
 
+mkdir -p src/bindings/compiled/node_bindings
+echo '// this file exists to prevent TS from type-checking `o1js_node.bc.cjs`' \
+  > src/bindings/compiled/node_bindings/o1js_node.bc.d.cts
+
 BINDINGS_PATH=src/bindings/compiled/_node_bindings/
 mkdir -p "${BINDINGS_PATH}"
 chmod -R 777 "${BINDINGS_PATH}"
@@ -73,3 +77,5 @@ sed -i 's/function raise(t){throw caml_call1(to_exn$0,t)}/function raise(t){thro
 
 chmod 777 "${BINDINGS_PATH}"/*
 node "src/build/fix-wasm-bindings-node.js" "${BINDINGS_PATH}"/plonk_wasm.cjs
+
+cp -R "${BINDINGS_PATH}"/* "src/bindings/compiled/node_bindings"/


### PR DESCRIPTION
Adds commands to create `node_bindings` dir and `o1js_node.bc.d.cts` file.

Running `npm run build:bindings` on a fresh clone of the repo inside of the mina devshell was failing because the `node_bindings` directory didn't exist and the `o1js_node.bc.d.cts` file wasn't being created.

Note that the o1js flake.nix creates `o1js_node.bc.d.cts` in the `o1js_bindings` derivation build:
https://github.com/o1-labs/o1js/blob/7dfaaa39dc349b7329bab9ffdf8ca472c592b375/flake.nix#L292