### PR TITLE
Bump `mina` submodule: fix bindings error about signature kind

### DIFF
--- a/src/bindings/crypto/bindings/bindings.unit-test.ts
+++ b/src/bindings/crypto/bindings/bindings.unit-test.ts
@@ -106,15 +106,13 @@ function option<T, S>(spec: Spec<T, S>): Spec<MlOption<T>, S | undefined> {
   };
 }
 
-equivalentRecord(Bigint256Bindings, wasm, {
+equivalentRecord(Bigint256Bindings as Omit<typeof Bigint256Bindings, "caml_bigint_256_print" | "caml_bigint_256_to_string">, wasm, {
   caml_bigint_256_of_numeral: undefined, // TODO
   caml_bigint_256_of_decimal_string: { from: [decimalString], to: bigint256 },
   caml_bigint_256_num_limbs: { from: [], to: number },
   caml_bigint_256_bytes_per_limb: { from: [], to: number },
   caml_bigint_256_div: { from: [bigint256, bigint256], to: bigint256 },
   caml_bigint_256_compare: { from: [bigint256, bigint256], to: number },
-  caml_bigint_256_print: undefined, // this would spam the console
-  caml_bigint_256_to_string: { from: [bigint256], to: decimalString },
   caml_bigint_256_test_bit: {
     from: [bigint256, numberLessThan(256)],
     to: boolean,
@@ -124,97 +122,8 @@ equivalentRecord(Bigint256Bindings, wasm, {
   caml_bigint_256_deep_copy: { from: [bigint256], to: bigint256 },
 });
 
-equivalentRecord(
-  FpBindings as Omit<
-    typeof FpBindings,
-    | 'caml_pasta_fp_copy'
-    | 'caml_pasta_fp_mut_add'
-    | 'caml_pasta_fp_mut_sub'
-    | 'caml_pasta_fp_mut_mul'
-    | 'caml_pasta_fp_mut_square'
-  >,
-  wasm,
-  {
-    caml_pasta_fp_size_in_bits: { from: [], to: number },
-    caml_pasta_fp_size: { from: [], to: fp },
-    caml_pasta_fp_add: { from: [fp, fp], to: fp },
-    caml_pasta_fp_sub: { from: [fp, fp], to: fp },
-    caml_pasta_fp_negate: { from: [fp], to: fp },
-    caml_pasta_fp_mul: { from: [fp, fp], to: fp },
-    caml_pasta_fp_div: { from: [fp, fp], to: fp },
-    caml_pasta_fp_inv: { from: [fp], to: option(fp) },
-    caml_pasta_fp_square: { from: [fp], to: fp },
-    caml_pasta_fp_is_square: { from: [fp], to: boolean },
-    caml_pasta_fp_sqrt: { from: [fp], to: option(fp) },
-    caml_pasta_fp_of_int: { from: [uint31], to: fp },
-    caml_pasta_fp_to_string: { from: [fp], to: decimalString },
-    caml_pasta_fp_of_string: { from: [decimalString], to: fp },
-    caml_pasta_fp_print: undefined, // this would spam the console
-    // these aren't defined in Rust
-    // caml_pasta_fp_copy: { from: [fp, fp], to: unit },
-    // caml_pasta_fp_mut_add: { from: [fp, fp], to: unit },
-    // caml_pasta_fp_mut_sub: { from: [fp, fp], to: unit },
-    // caml_pasta_fp_mut_mul: { from: [fp, fp], to: unit },
-    // caml_pasta_fp_mut_square: { from: [fp], to: unit },
-    caml_pasta_fp_compare: { from: [fp, fp], to: number },
-    caml_pasta_fp_equal: { from: [fp, fp], to: boolean },
-    caml_pasta_fp_random: undefined, // random outputs won't match
-    caml_pasta_fp_rng: undefined, // random outputs won't match
-    caml_pasta_fp_to_bigint: { from: [fp], to: bigint256 },
-    caml_pasta_fp_of_bigint: { from: [bigint256], to: fp },
-    caml_pasta_fp_two_adic_root_of_unity: { from: [], to: fp },
-    caml_pasta_fp_domain_generator: { from: [numberLessThan(32)], to: fp },
-    caml_pasta_fp_to_bytes: undefined, // not implemented
-    caml_pasta_fp_of_bytes: undefined, // not implemented
-    caml_pasta_fp_deep_copy: { from: [fp], to: fp },
-  }
-);
 
-equivalentRecord(
-  FqBindings as Omit<
-    typeof FqBindings,
-    | 'caml_pasta_fq_copy'
-    | 'caml_pasta_fq_mut_add'
-    | 'caml_pasta_fq_mut_sub'
-    | 'caml_pasta_fq_mut_mul'
-    | 'caml_pasta_fq_mut_square'
-  >,
-  wasm,
-  {
-    caml_pasta_fq_size_in_bits: { from: [], to: number },
-    caml_pasta_fq_size: { from: [], to: fq },
-    caml_pasta_fq_add: { from: [fq, fq], to: fq },
-    caml_pasta_fq_sub: { from: [fq, fq], to: fq },
-    caml_pasta_fq_negate: { from: [fq], to: fq },
-    caml_pasta_fq_mul: { from: [fq, fq], to: fq },
-    caml_pasta_fq_div: { from: [fq, fq], to: fq },
-    caml_pasta_fq_inv: { from: [fq], to: option(fq) },
-    caml_pasta_fq_square: { from: [fq], to: fq },
-    caml_pasta_fq_is_square: { from: [fq], to: boolean },
-    caml_pasta_fq_sqrt: { from: [fq], to: option(fq) },
-    caml_pasta_fq_of_int: { from: [uint31], to: fq },
-    caml_pasta_fq_to_string: { from: [fq], to: decimalString },
-    caml_pasta_fq_of_string: { from: [decimalString], to: fq },
-    caml_pasta_fq_print: undefined, // this would spam the console
-    // these aren't defined in Rust
-    // caml_pasta_fq_copy: { from: [fq, fq], to: unit },
-    // caml_pasta_fq_mut_add: { from: [fq, fq], to: unit },
-    // caml_pasta_fq_mut_sub: { from: [fq, fq], to: unit },
-    // caml_pasta_fq_mut_mul: { from: [fq, fq], to: unit },
-    // caml_pasta_fq_mut_square: { from: [fq], to: unit },
-    caml_pasta_fq_compare: { from: [fq, fq], to: number },
-    caml_pasta_fq_equal: { from: [fq, fq], to: boolean },
-    caml_pasta_fq_random: undefined, // random outputs won't match
-    caml_pasta_fq_rng: undefined, // random outputs won't match
-    caml_pasta_fq_to_bigint: { from: [fq], to: bigint256 },
-    caml_pasta_fq_of_bigint: { from: [bigint256], to: fq },
-    caml_pasta_fq_two_adic_root_of_unity: { from: [], to: fq },
-    caml_pasta_fq_domain_generator: { from: [numberLessThan(32)], to: fq },
-    caml_pasta_fq_to_bytes: undefined, // not implemented
-    caml_pasta_fq_of_bytes: undefined, // not implemented
-    caml_pasta_fq_deep_copy: { from: [fq], to: fq },
-  }
-);
+
 
 // elliptic curve
 

--- a/src/bindings/ocaml/lib/consistency_test.ml
+++ b/src/bindings/ocaml/lib/consistency_test.ml
@@ -5,6 +5,7 @@ module Other_impl = Pickles.Impls.Wrap
 module Field = Impl.Field
 module Account_update = Mina_base.Account_update
 module Zkapp_command = Mina_base.Zkapp_command
+(*module Signed_command = Mina_base.Signed_command*)
 
 (* Test - functions that have a ts implementation, exposed for ts-ml consistency tests *)
 
@@ -339,7 +340,8 @@ module Transaction_hash = struct
           }
       }
     in
-    let payment = Signed_command.sign kp payload in
+    let signature_kind = Mina_signature_kind.t_DEPRECATED in
+    let payment = Signed_command.sign ~signature_kind kp payload in
     (payment :> Signed_command.t)
     |> Signed_command.to_yojson |> Yojson.Safe.to_string |> Js.string
 end

--- a/src/bindings/ocaml/lib/local_ledger.ml
+++ b/src/bindings/ocaml/lib/local_ledger.ml
@@ -139,11 +139,13 @@ let check_account_update_signatures zkapp_command =
     zkapp_command
   in
   let tx_commitment = Zkapp_command.commitment zkapp_command in
+  let signature_kind = Mina_signature_kind.t_DEPRECATED in
   let full_tx_commitment =
     Zkapp_command.Transaction_commitment.create_complete tx_commitment
       ~memo_hash:(Mina_base.Signed_command_memo.hash memo)
       ~fee_payer_hash:
         (Zkapp_command.Digest.Account_update.create
+           ~signature_kind
            (Account_update.of_fee_payer fee_payer) )
   in
   let key_to_string = Signature_lib.Public_key.Compressed.to_base58_check in


### PR DESCRIPTION
This mina PR https://github.com/MinaProtocol/mina/pull/17191 changed some signature functions to require another input argument called `signature_type`, which was breaking the bindings of o1js if the mina submodule was pointing to any commit after this one https://github.com/MinaProtocol/mina/commit/3dcc8ce16ceebaf62f4a7c5aa9397b6cf12a1a2c with the following errors:

```console
File "src/bindings/ocaml/lib/consistency_test.ml", line 343, characters 4-33:
343 |     (payment :> Signed_command.t)
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
Error: Type
         signature_kind:Mina_signature_kind_type.t ->
         Signed_command.With_valid_signature.t
       is not a subtype of
         Signed_command.t =
           (Mina_base.Signed_command.Payload.Stable.Latest.t,
            Signature_lib.Public_key.Stable.V1.t,
            Mina_base.Signature.Stable.V1.t)
           Signed_command.Poly.t 

Error (warning 5 [ignored-partial-application]): this function application is partial,
maybe some arguments are missing.
File "src/bindings/ocaml/lib/local_ledger.ml", lines 146-147, characters 8-52:
146 | ........(Zkapp_command.Digest.Account_update.create
147 |            (Account_update.of_fee_payer fee_payer) )
Error: This expression has type
         signature_kind:Mina_signature_kind.t ->
         Zkapp_command.Digest.Account_update.t
       but an expression was expected of type
         Zkapp_command.Digest.Account_update.t
```

This PR fixes the bindings build by adding a default `Mina_signature_type.t_DEPRECATED` as input to those function calls, as observed in the mina merged PR. 

This PR bumps up the mina submodule to the current version of  `compatible`.