### PR TITLE
DynamicArray support reverse feature

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 ### Added
 
 - Lazy mode for prover index computation. https://github.com/o1-labs/o1js/pull/2143
+- Added reverse functionality to `DynamicArray` and indexed `forEach` and `forEachReverse` variants.
 - Added `ZkProgram.analyzeSingleMethod(methodName: string)` to analyze a single method of a ZkProgram. https://github.com/o1-labs/o1js/pull/2217
   - This is an addition to `ZkProgram.analyzeMethods()` which analyzes all methods of a ZkProgram by executing them.
   - Now only a single method is analyzed at a time.

--- a/src/lib/provable/dynamic-array.ts
+++ b/src/lib/provable/dynamic-array.ts
@@ -270,8 +270,6 @@ class DynamicArrayBase<ProvableValue = any, Value = any> {
     return newArray;
   }
 
-  forEach(f: (t: ProvableValue, isDummy: Bool) => void): void;
-  forEach(f: (t: ProvableValue, isDummy: Bool, i: number) => void): void;
   /**
    * Iterate over all elements of the array.
    *
@@ -279,14 +277,8 @@ class DynamicArrayBase<ProvableValue = any, Value = any> {
    * whether the value is part of the actual array. Optionally, an index can be
    * passed as a third argument (used in `forEachReversed`)
    */
-  forEach(f: (...args: any[]) => void): void {
-    zip(this.array, this.#dummyMask()).forEach(([t, isDummy], i) => {
-      if (f.length === 2) {
-        f(t, isDummy);
-      } else {
-        f(t, isDummy, i); 
-      }
-    });
+  forEach(f: (t: ProvableValue, isDummy: Bool, i?: number) => void): void {
+    zip(this.array, this.#dummyMask()).forEach(([t, isDummy], i) => f(t, isDummy, i));
   }
 
   /**

--- a/src/lib/provable/dynamic-array.ts
+++ b/src/lib/provable/dynamic-array.ts
@@ -270,16 +270,38 @@ class DynamicArrayBase<ProvableValue = any, Value = any> {
     return newArray;
   }
 
+  forEach(f: (t: ProvableValue, isDummy: Bool) => void): void;
+  forEach(f: (t: ProvableValue, isDummy: Bool, i: number) => void): void;
   /**
    * Iterate over all elements of the array.
    *
    * The callback will be passed an element and a boolean `isDummy` indicating
-   * whether the value is part of the actual array.
+   * whether the value is part of the actual array. Optionally, an index can be
+   * passed as a third argument (used in `forEachReversed`)
    */
-  forEach(f: (t: ProvableValue, isDummy: Bool) => void) {
-    zip(this.array, this.#dummyMask()).forEach(([t, isDummy]) => {
-      f(t, isDummy);
+  forEach(f: (...args: any[]) => void): void {
+    zip(this.array, this.#dummyMask()).forEach(([t, isDummy], i) => {
+      if (f.length === 2) {
+        f(t, isDummy);
+      } else {
+        f(t, isDummy, i); 
+      }
     });
+  }
+
+  /**
+   * Iterate over all elements of the array, in reverse order.
+   *
+   * The callback will be passed an element and a boolean `isDummy` indicating whether the value is part of the actual array.
+   *
+   * Note: the indices are also passed in reverse order, i.e. we always have `t = this.array[i]`.
+   */
+  forEachReverse(f: (t: ProvableValue, isDummy: Bool, i: number) => void) {
+    zip(this.array, this.#dummyMask())
+      .reverse()
+      .forEach(([t, isDummy], i) => {
+        f(t, isDummy, this.capacity - 1 - i);
+      });
   }
 
   /**
@@ -517,6 +539,21 @@ class DynamicArrayBase<ProvableValue = any, Value = any> {
     sliced.shiftLeft(start, `slice(): provided start is greater than current length`);
     sliced.pop(this.length.sub(end), `slice(): provided end is greater than current length`);
     return sliced;
+  }
+
+  /**
+   * Returns a new array with the elements reversed.
+   */
+  reverse(): DynamicArray<ProvableValue, Value> {
+    let Array = DynamicArray(this.innerType, { capacity: this.capacity });
+    // first, copy the inner array of length capacity and reverse it
+    let array = this.array.slice().reverse();
+
+    // now, slice off the padding that is now at the beginning of the array
+    let capacity = new Field(this.capacity);
+    return new Array(array, capacity).slice(
+      capacity.sub(this.length).seal()
+    );
   }
 
   /**

--- a/src/lib/provable/test/dynamic-array.unit-test.ts
+++ b/src/lib/provable/test/dynamic-array.unit-test.ts
@@ -581,6 +581,14 @@ import { Provable } from '../provable.js';
           // Checking inclusion of elements
           assert(bytes.includes(new UInt8(1)));
           assert(bytes.includes(new UInt8(20)).not());
+
+          // Reverse the array
+          let reversed = bytes.reverse();
+          for (let i = 0; i < 8; i++) {
+            assert(reversed.get(new Field(i)).value.equals(new Field(8 - i)));
+            // the original array is not modified
+            assert(bytes.get(new Field(i)).value.equals(new Field(i + 1)));
+          }
         },
       },
     },


### PR DESCRIPTION
This PR adds the `reverse` feature to the `DynamicArray` API using an indexed variant of the `forEach` function. This was initially launched as a request from @45930 given that the Nori team was already using zk-security's indexed variant. The proposed change in the code overloads the `forEach` definition to accept both indexed and non-indexed function parameters. Using the indexed variant, this PR adds `forEachReverse` functionality to apply `forEach` in reverse order of the array. Similarly, it adds the `reverse` function to return a copy of the current array but in reversed order. Unit tests have been updated to test this new function.