### PR TITLE
Don't replace substituters in flake.nix

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -16,12 +16,12 @@
   nixConfig = {
     auto-optimize-store = true;
     max-jobs = "auto";
-    #coppied from flake.nix in mina
+    # taken from flake.nix in mina
     allow-import-from-derivation = "true";
-    substituters =
+    extra-substituters =
       [ "https://storage.googleapis.com/mina-nix-cache"
       ];
-    trusted-public-keys =
+    extra-trusted-public-keys =
       [ "mina-nix-cache-1:djtioLfv2oxuK2lqPUgmZbf8bY8sK/BnYZCU2iU5Q10="
         "nix-cache.minaprotocol.org:fdcuDzmnM0Kbf7yU4yywBuUEJWClySc1WIF6t6Mm8h4="
         "nix-cache.minaprotocol.org:D3B1W+V7ND1Fmfii8EhbAbF1JXoe2Ct4N34OKChwk2c="


### PR DESCRIPTION
Previous flake config was replacing substituters instead of adding some extra substituters.

It resulted in build failures because of not using cache.nixos.org.
