### PR TITLE
Fix CI remote build

### DIFF
--- a/src/bindings/scripts/download-bindings.sh
+++ b/src/bindings/scripts/download-bindings.sh
@@ -7,7 +7,8 @@ set -e
 REV=${REV:=$(git rev-parse HEAD)}
 RUN_ID=$( \
     gh run list --commit "${REV}" --json name,databaseId | \
-    jq -r '.[] | select(.name == "Checks" or .name == "Build and upload bindings") | .databaseId' \
+    jq -r '.[] | select(.name == "Checks" or .name == "Build and upload bindings") | .databaseId' | \
+    head -1 \
   )
 
 if [ -z "$RUN_ID" ]


### PR DESCRIPTION
## Summary

In the `download-bindings.sh`, `jq` was emitting multiple workflow‐run objects for the commit
`gh run list --commit "${REV}" --json name,databaseId`. Therefore, capturing all of its stdout, the `RUN_ID` became a multi-line string resulting in malformed URLs and fetch submodule failures. 

## Fix 

The CI fix is to pipe the output to `head -1`, ensuring we only grab the most recent run ID.


closes https://github.com/o1-labs/o1js/issues/2271