### PR TITLE
Add markdown formatting with 80-character line wrapping

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -96,6 +96,9 @@ jobs:
         if: steps.get_changed_files.outputs.files_changed == 'true'
         run: xargs npm run lint:strict < changed_files.txt
 
+      - name: Run Markdown Format Check
+        run: npm run format:md:check
+
       - name: Run codespell
         if: steps.get_changed_files.outputs.files_changed == 'true' && github.event.pull_request.labels.*.name != 'no-typo-check'
         uses: codespell-project/actions-codespell@master

--- a/.prettierrc.md.cjs
+++ b/.prettierrc.md.cjs
@@ -1,0 +1,17 @@
+module.exports = {
+  trailingComma: 'es5',
+  tabWidth: 2,
+  semi: true,
+  singleQuote: true,
+  printWidth: 80,
+  proseWrap: 'always',
+  overrides: [
+    {
+      files: '*.md',
+      options: {
+        printWidth: 80,
+        proseWrap: 'always',
+      },
+    },
+  ],
+};

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,8 @@
 All notable changes to this project are documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
-This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+This project adheres to
+[Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 <!--
   Possible subsections:
@@ -21,10 +22,14 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ### Added
 
-- Lazy mode for prover index computation. https://github.com/o1-labs/o1js/pull/2143
-- Added reverse functionality to `DynamicArray` and indexed `forEach` and `forEachReverse` variants. https://github.com/o1-labs/o1js/pull/2250
-- Added `ZkProgram.analyzeSingleMethod(methodName: string)` to analyze a single method of a ZkProgram. https://github.com/o1-labs/o1js/pull/2217
-  - This is an addition to `ZkProgram.analyzeMethods()` which analyzes all methods of a ZkProgram by executing them.
+- Lazy mode for prover index computation.
+  https://github.com/o1-labs/o1js/pull/2143
+- Added reverse functionality to `DynamicArray` and indexed `forEach` and
+  `forEachReverse` variants.
+- Added `ZkProgram.analyzeSingleMethod(methodName: string)` to analyze a single
+  method of a ZkProgram. https://github.com/o1-labs/o1js/pull/2217
+  - This is an addition to `ZkProgram.analyzeMethods()` which analyzes all
+    methods of a ZkProgram by executing them.
   - Now only a single method is analyzed at a time.
 
 ## [2.6.0](https://github.com/o1-labs/o1js/compare/4e23a60...3eef10d) - 2025-05-30
@@ -39,135 +44,202 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ### Fixed
 
-- Correct handling of actions and events lists as well as internal `AccountUpdate` consistency tests for the new V2 API. https://github.com/o1-labs/o1js/pull/2134
+- Correct handling of actions and events lists as well as internal
+  `AccountUpdate` consistency tests for the new V2 API.
+  https://github.com/o1-labs/o1js/pull/2134
 
 ### Added
 
-- Improved developer experience and build process. https://github.com/o1-labs/o1js/pull/2076
+- Improved developer experience and build process.
+  https://github.com/o1-labs/o1js/pull/2076
   - o1js-bindings is no longer a submodule (same directory structure)
   - compiled artifacts are now gitignored
   - `npm run build:bindings-download` downloads compiled artifacts from github
-  - `npm run build:bindings-remote` triggers a github workflow to build the compiled artifacts then downloads them
-- Added bitwise operation methods (xor, not, and, or) to `UInt8` class. https://github.com/o1-labs/o1js/pull/2144
+  - `npm run build:bindings-remote` triggers a github workflow to build the
+    compiled artifacts then downloads them
+- Added bitwise operation methods (xor, not, and, or) to `UInt8` class.
+  https://github.com/o1-labs/o1js/pull/2144
 
 ### Changed
 
 - Bump up Mina to the commit
-  [5a9145feaba3138cd1a1090d8421a8e67a5485e1](https://github.com/MinaProtocol/mina/blob/5a9145feaba3138cd1a1090d8421a8e67a5485e1) https://github.com/o1-labs/o1js/pull/2126
-- Bump up Mina to the commit [eaca9201](https://github.com/MinaProtocol/mina/tree/eaca9201e0df37f244e341155f253dc9551fb451),
+  [5a9145feaba3138cd1a1090d8421a8e67a5485e1](https://github.com/MinaProtocol/mina/blob/5a9145feaba3138cd1a1090d8421a8e67a5485e1)
+  https://github.com/o1-labs/o1js/pull/2126
+- Bump up Mina to the commit
+  [eaca9201](https://github.com/MinaProtocol/mina/tree/eaca9201e0df37f244e341155f253dc9551fb451),
   to include the latest changes reg. the move of the Rust codebase to the
   repository proof-systems. https://github.com/o1-labs/o1js/pull/2128
-- Added verification key validity checks to `LocalBlockchain`. https://github.com/o1-labs/o1js/pull/2171
+- Added verification key validity checks to `LocalBlockchain`.
+  https://github.com/o1-labs/o1js/pull/2171
 
 ## [2.4.0](https://github.com/o1-labs/o1js/compare/fb625f...6ff7f8470a) - 2025-04-01
 
 ### Added
 
 - Support of runtime tables https://github.com/o1-labs/o1js/pull/1858
-- _Experimental_ Introducing `MinaProgram`, a new powerful API for interacting with Mina Protocol. https://github.com/o1-labs/o1js/pull/2095
+- _Experimental_ Introducing `MinaProgram`, a new powerful API for interacting
+  with Mina Protocol. https://github.com/o1-labs/o1js/pull/2095
   - New functions and types for `MinaProgram`
-- Export various internal functions and types. https://github.com/o1-labs/o1js/pull/2083
-- Export part of the core cryptography layer via the `Core` namespace. https://github.com/o1-labs/o1js/pull/2083
-- _Experimental_ New bindings layer for new API types. https://github.com/o1-labs/o1js/pull/2032
+- Export various internal functions and types.
+  https://github.com/o1-labs/o1js/pull/2083
+- Export part of the core cryptography layer via the `Core` namespace.
+  https://github.com/o1-labs/o1js/pull/2083
+- _Experimental_ New bindings layer for new API types.
+  https://github.com/o1-labs/o1js/pull/2032
 - _Experimental_ New API types for https://github.com/o1-labs/o1js/pull/2042
   - `AccountUpdate`, `Account`, `Authorization`, `Permissions` etc.
-  - New transaction construction API `new ZkappCommand()`. https://github.com/o1-labs/o1js/pull/2042
+  - New transaction construction API `new ZkappCommand()`.
+    https://github.com/o1-labs/o1js/pull/2042
 - Bump up Rust version to 1.79.0. Bindings now depends on nightly-2024-06-13.
   https://github.com/o1-labs/o1js/pull/2063
-- `setVerificationKeyUnsafe` static method to `SmartContract` [#2091](https://github.com/o1-labs/o1js/pull/2091)
-- `toBits()` and `fromBits()` methods added for `UInt32` and `UInt64` classes. https://github.com/o1-labs/o1js/pull/2099
-- **Provable BigInt** exposed through the `createProvableBigInt()` class factory https://github.com/o1-labs/o1js/pull/2008
+- `setVerificationKeyUnsafe` static method to `SmartContract`
+  [#2091](https://github.com/o1-labs/o1js/pull/2091)
+- `toBits()` and `fromBits()` methods added for `UInt32` and `UInt64` classes.
+  https://github.com/o1-labs/o1js/pull/2099
+- **Provable BigInt** exposed through the `createProvableBigInt()` class factory
+  https://github.com/o1-labs/o1js/pull/2008
 
 ## [2.3.0](https://github.com/o1-labs/o1js/compare/b857516...fb625f)
 
 ### Added
 
-- `to` and `from` are added as query parameters for `fetchActions` and `fetchEvents` https://github.com/o1-labs/o1js/pull/2066
+- `to` and `from` are added as query parameters for `fetchActions` and
+  `fetchEvents` https://github.com/o1-labs/o1js/pull/2066
 - Exported the type `FlexibleBytes`, previously being used only internally
   https://github.com/o1-labs/o1js/pull/2015.
-- Gadgets for 224, 384 and 512 bit variants of SHA2 https://github.com/o1-labs/o1js/pull/1957
-- `setFee` and `setFeePerSnarkCost` for `Transaction` and `PendingTransaction` https://github.com/o1-labs/o1js/pull/1968
-- Doc comments for various ZkProgram methods https://github.com/o1-labs/o1js/pull/1974
-- `MerkleList.popOption()` for popping the last element and also learning if there was one https://github.com/o1-labs/o1js/pull/1997
-- Added custom header support for `Fetch` methods such as `fetchEvents`, `fetchActions` etc. and to `Mina` instance. Also added two new methods `setMinaDefaultHeaders` and `setArchiveDefaultHeaders` https://github.com/o1-labs/o1js/pull/2004
-- Added new method `CircuitString.setEncoding()` to change default behavior of the `CircuitString` encoding, possible value is `"ascii" | "uft-8"` default to `"ascii"`. Also added an optional `encoding: CircuitStringEncoding` parameter in `.toString()` and `.fromString()` to switch encoding temporary.
+- Gadgets for 224, 384 and 512 bit variants of SHA2
+  https://github.com/o1-labs/o1js/pull/1957
+- `setFee` and `setFeePerSnarkCost` for `Transaction` and `PendingTransaction`
+  https://github.com/o1-labs/o1js/pull/1968
+- Doc comments for various ZkProgram methods
+  https://github.com/o1-labs/o1js/pull/1974
+- `MerkleList.popOption()` for popping the last element and also learning if
+  there was one https://github.com/o1-labs/o1js/pull/1997
+- Added custom header support for `Fetch` methods such as `fetchEvents`,
+  `fetchActions` etc. and to `Mina` instance. Also added two new methods
+  `setMinaDefaultHeaders` and `setArchiveDefaultHeaders`
+  https://github.com/o1-labs/o1js/pull/2004
+- Added new method `CircuitString.setEncoding()` to change default behavior of
+  the `CircuitString` encoding, possible value is `"ascii" | "uft-8"` default to
+  `"ascii"`. Also added an optional `encoding: CircuitStringEncoding` parameter
+  in `.toString()` and `.fromString()` to switch encoding temporary.
 - Added style rules for contributors https://github.com/o1-labs/o1js/pull/2012
-- Add new helper functions `Bool.anyTrue(xs)` and `Bool.allTrue(xs)`. https://github.com/o1-labs/o1js/pull/2038
+- Add new helper functions `Bool.anyTrue(xs)` and `Bool.allTrue(xs)`.
+  https://github.com/o1-labs/o1js/pull/2038
 
 ### Changed
 
-- Sort order for actions now includes the transaction sequence number and the exact account id sequence https://github.com/o1-labs/o1js/pull/1917
-- Updated typedoc version for generating docs https://github.com/o1-labs/o1js/pull/1973
-- Enable to pass normal JS values (e.g., `bigint` instead of `Field`) to ZkProgram provers https://github.com/o1-labs/o1js/pull/1934
-  - Also improves the supported JS values for a few important types like `Signature` and `UIntX`
-- ECDSA `verifySignedHash()` accepts hash `Bytes` directly for easy use with alternative hash functions https://github.com/o1-labs/o1js/pull/2005
+- Sort order for actions now includes the transaction sequence number and the
+  exact account id sequence https://github.com/o1-labs/o1js/pull/1917
+- Updated typedoc version for generating docs
+  https://github.com/o1-labs/o1js/pull/1973
+- Enable to pass normal JS values (e.g., `bigint` instead of `Field`) to
+  ZkProgram provers https://github.com/o1-labs/o1js/pull/1934
+  - Also improves the supported JS values for a few important types like
+    `Signature` and `UIntX`
+- ECDSA `verifySignedHash()` accepts hash `Bytes` directly for easy use with
+  alternative hash functions https://github.com/o1-labs/o1js/pull/2005
 
 ### Fixed
 
-- Fix behavior of `initializeBindings()` when called concurrently, to improve error messages in common failure scenarios https://github.com/o1-labs/o1js/pull/1996
-- Fix `ZkProgram` public input/output types https://github.com/o1-labs/o1js/pull/1998
+- Fix behavior of `initializeBindings()` when called concurrently, to improve
+  error messages in common failure scenarios
+  https://github.com/o1-labs/o1js/pull/1996
+- Fix `ZkProgram` public input/output types
+  https://github.com/o1-labs/o1js/pull/1998
 
 ## [2.2.0](https://github.com/o1-labs/o1js/compare/e1bac02...b857516) - 2024-12-10
 
 ### Added
 
-- `ZkProgram` to support non-pure provable types as inputs and outputs https://github.com/o1-labs/o1js/pull/1828
-- APIs for recursively proving a ZkProgram method from within another https://github.com/o1-labs/o1js/pull/1931 https://github.com/o1-labs/o1js/pull/1932
+- `ZkProgram` to support non-pure provable types as inputs and outputs
+  https://github.com/o1-labs/o1js/pull/1828
+- APIs for recursively proving a ZkProgram method from within another
+  https://github.com/o1-labs/o1js/pull/1931
+  https://github.com/o1-labs/o1js/pull/1932
   - `let recursive = Experimental.Recursive(program);`
   - `recursive.<methodName>(...args): Promise<PublicOutput>`
   - `recursive.<methodName>.if(condition, ...args): Promise<PublicOutput>`
-  - This also works within the same program, as long as the return value is type-annotated
-- Add `enforceTransactionLimits` parameter on Network https://github.com/o1-labs/o1js/issues/1910
-- Method for optional types to assert none https://github.com/o1-labs/o1js/pull/1922
-- Increased maximum supported amount of methods in a `SmartContract` or `ZkProgram` to 30. https://github.com/o1-labs/o1js/pull/1918
-- Expose low-level conversion methods `Proof.{_proofToBase64,_proofFromBase64}` https://github.com/o1-labs/o1js/pull/1928
-- Expose `maxProofsVerified()` and a `Proof` class directly on ZkPrograms https://github.com/o1-labs/o1js/pull/1933
+  - This also works within the same program, as long as the return value is
+    type-annotated
+- Add `enforceTransactionLimits` parameter on Network
+  https://github.com/o1-labs/o1js/issues/1910
+- Method for optional types to assert none
+  https://github.com/o1-labs/o1js/pull/1922
+- Increased maximum supported amount of methods in a `SmartContract` or
+  `ZkProgram` to 30. https://github.com/o1-labs/o1js/pull/1918
+- Expose low-level conversion methods `Proof.{_proofToBase64,_proofFromBase64}`
+  https://github.com/o1-labs/o1js/pull/1928
+- Expose `maxProofsVerified()` and a `Proof` class directly on ZkPrograms
+  https://github.com/o1-labs/o1js/pull/1933
 
 ### Changed
 
-- Changed an internal type to improve IntelliSense on ZkProgram methods https://github.com/o1-labs/o1js/pull/1933
-- Updated o1js nix devshell to build rust on all executions of `npm run build:update-bindings`
+- Changed an internal type to improve IntelliSense on ZkProgram methods
+  https://github.com/o1-labs/o1js/pull/1933
+- Updated o1js nix devshell to build rust on all executions of
+  `npm run build:update-bindings`
 
 ### Fixed
 
-- Compiling stuck in the browser for recursive zkprograms https://github.com/o1-labs/o1js/pull/1906
-- Error message in `rangeCheck16` gadget https://github.com/o1-labs/o1js/pull/1920
-- Deprecate `testnet` `networkId` in favor of `devnet` https://github.com/o1-labs/o1js/pull/1938
-- Fix event data type inconsistency between LocalBlockchain and Mina https://github.com/o1-labs/o1js/pull/1975
+- Compiling stuck in the browser for recursive zkprograms
+  https://github.com/o1-labs/o1js/pull/1906
+- Error message in `rangeCheck16` gadget
+  https://github.com/o1-labs/o1js/pull/1920
+- Deprecate `testnet` `networkId` in favor of `devnet`
+  https://github.com/o1-labs/o1js/pull/1938
+- Fix event data type inconsistency between LocalBlockchain and Mina
+  https://github.com/o1-labs/o1js/pull/1975
 
 ## [2.1.0](https://github.com/o1-labs/o1js/compare/b04520d...e1bac02) - 2024-11-13
 
 ### Added
 
-- Support secp256r1 in elliptic curve and ECDSA gadgets https://github.com/o1-labs/o1js/pull/1885
+- Support secp256r1 in elliptic curve and ECDSA gadgets
+  https://github.com/o1-labs/o1js/pull/1885
 
 ### Fixed
 
-- Witness generation error in `Gadgets.arrayGet()` when accessing out-of-bounds indices https://github.com/o1-labs/o1js/pull/1886
+- Witness generation error in `Gadgets.arrayGet()` when accessing out-of-bounds
+  indices https://github.com/o1-labs/o1js/pull/1886
 
 ## [2.0.0](https://github.com/o1-labs/o1js/compare/7e9394...b04520d)
 
 ### Breaking Changes
 
-- The `divMod32()` gadget was modified to accept `nBits` instead of `quotientBits`, and assert it is in the range [0, 2\*\*255) to address an issue previously where the bound on `quotientBits` was too low https://github.com/o1-labs/o1js/pull/1763.
-- `Provable.equal()` now turns both types into canonical form before comparing them https://github.com/o1-labs/o1js/pull/1759
-  - Removed implicit version `Provable.equal(x, y)` where you didn't have to pass in the type
-- The return signature of a zkProgram has changed. https://github.com/o1-labs/o1js/pull/1809
-  - A zkProgram method must now explicitly define the return type of the method when the method has a public or auxiliary output defined.
+- The `divMod32()` gadget was modified to accept `nBits` instead of
+  `quotientBits`, and assert it is in the range [0, 2\*\*255) to address an
+  issue previously where the bound on `quotientBits` was too low
+  https://github.com/o1-labs/o1js/pull/1763.
+- `Provable.equal()` now turns both types into canonical form before comparing
+  them https://github.com/o1-labs/o1js/pull/1759
+  - Removed implicit version `Provable.equal(x, y)` where you didn't have to
+    pass in the type
+- The return signature of a zkProgram has changed.
+  https://github.com/o1-labs/o1js/pull/1809
+  - A zkProgram method must now explicitly define the return type of the method
+    when the method has a public or auxiliary output defined.
   - The return type of a proven method has changed as a result of this.
-- Various breaking constraint changes in internal methods or circuits because of audit fix.
+- Various breaking constraint changes in internal methods or circuits because of
+  audit fix.
 - Removal of various deprecated methods and functions.
   - Promotion of various methods and functions to stable as part of change.
-  - A slightly modified encryption and decryption algorithm. https://github.com/o1-labs/o1js/pull/1729
-- Promotion of `TokenContractV2` to `TokenContract` with a correct amount of maximum account updates.
+  - A slightly modified encryption and decryption algorithm.
+    https://github.com/o1-labs/o1js/pull/1729
+- Promotion of `TokenContractV2` to `TokenContract` with a correct amount of
+  maximum account updates.
 
 ### Added
 
-- `ZkProgram` methods now support `auxiliaryOutput`. https://github.com/o1-labs/o1js/pull/1809
+- `ZkProgram` methods now support `auxiliaryOutput`.
+  https://github.com/o1-labs/o1js/pull/1809
   - Each program method now accepts an optional property `auxiliaryOutput`
   - Auxiliary output is additional output that the zkProgram method returns
-- New method `toCanonical()` in the `Provable<T>` interface to protect against incompleteness of certain operations on malicious witness inputs https://github.com/o1-labs/o1js/pull/1759
-- `divMod64()` division modulo 2^64 that returns the remainder and quotient of the operation
+- New method `toCanonical()` in the `Provable<T>` interface to protect against
+  incompleteness of certain operations on malicious witness inputs
+  https://github.com/o1-labs/o1js/pull/1759
+- `divMod64()` division modulo 2^64 that returns the remainder and quotient of
+  the operation
 - `addMod64()` addition modulo 2^64
 - Bitwise OR via `{UInt32, UInt64}.or()`
 - **BLAKE2B hash function** gadget. https://github.com/o1-labs/o1js/pull/1767
@@ -176,365 +248,593 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ### Fixes
 
-- Performance regression when compiling recursive circuits is fixed https://github.com/o1-labs/o1js/pull/1874
-- Decouple offchain state instances from their definitions https://github.com/o1-labs/o1js/pull/1834
+- Performance regression when compiling recursive circuits is fixed
+  https://github.com/o1-labs/o1js/pull/1874
+- Decouple offchain state instances from their definitions
+  https://github.com/o1-labs/o1js/pull/1834
 
 ## [1.9.0](https://github.com/o1-labs/o1js/compare/450943...f15293a69) - 2024-10-15
 
 ### Added
 
-- Added `VerificationKey.dummy()` method to get the dummy value of a verification key https://github.com/o1-labs/o1js/pull/1852 [@rpanic](https://github.com/rpanic)
+- Added `VerificationKey.dummy()` method to get the dummy value of a
+  verification key https://github.com/o1-labs/o1js/pull/1852
+  [@rpanic](https://github.com/rpanic)
 
 ### Changed
 
-- Make `Proof` a normal provable type, that can be witnessed and composed into Structs https://github.com/o1-labs/o1js/pull/1847, https://github.com/o1-labs/o1js/pull/1851
-  - ZkProgram and SmartContract now also support private inputs that are not proofs themselves, but contain proofs nested within a Struct or array
+- Make `Proof` a normal provable type, that can be witnessed and composed into
+  Structs https://github.com/o1-labs/o1js/pull/1847,
+  https://github.com/o1-labs/o1js/pull/1851
+  - ZkProgram and SmartContract now also support private inputs that are not
+    proofs themselves, but contain proofs nested within a Struct or array
   - Only `SelfProof` can still not be nested because it needs special treatment
 
 ### Fixes
 
-- Fix verification of serialized proofs done before compiling any circuits https://github.com/o1-labs/o1js/pull/1857
+- Fix verification of serialized proofs done before compiling any circuits
+  https://github.com/o1-labs/o1js/pull/1857
 
 ## [1.8.0](https://github.com/o1-labs/o1js/compare/5006e4f...450943) - 2024-09-18
 
 ### Added
 
-- Added `verifyEthers` method to verify Ethereum signatures using the EIP-191 message hashing standard. https://github.com/o1-labs/o1js/pull/1815
-  - Added `fromEthers` method for parsing and converting Ethereum public keys into `ForeignCurve` points, supporting both compressed and uncompressed formats.
-  - Added `fromHex` method for converting hexadecimal strings into `ForeignCurve` points.
+- Added `verifyEthers` method to verify Ethereum signatures using the EIP-191
+  message hashing standard. https://github.com/o1-labs/o1js/pull/1815
+  - Added `fromEthers` method for parsing and converting Ethereum public keys
+    into `ForeignCurve` points, supporting both compressed and uncompressed
+    formats.
+  - Added `fromHex` method for converting hexadecimal strings into
+    `ForeignCurve` points.
 
 ### Fixes
 
-- Fix incorrect behavior of optional proving for zkPrograms where `myProgram.setProofsEnabled(false)` wouldn't work when called before `myProgram.compile()`. https://github.com/o1-labs/o1js/pull/1827
-- Fix incorrect behavior of `state.fetch()` for custom token contracts. [@rpanic](https://github.com/rpanic) https://github.com/o1-labs/o1js/pull/1853
+- Fix incorrect behavior of optional proving for zkPrograms where
+  `myProgram.setProofsEnabled(false)` wouldn't work when called before
+  `myProgram.compile()`. https://github.com/o1-labs/o1js/pull/1827
+- Fix incorrect behavior of `state.fetch()` for custom token contracts.
+  [@rpanic](https://github.com/rpanic) https://github.com/o1-labs/o1js/pull/1853
 
 ## [1.7.0](https://github.com/o1-labs/o1js/compare/d6abf1d97...5006e4f) - 2024-09-04
 
 ### Added
 
-- Added `Encryption.encryptV2()` and `Encryption.decryptV2()` for an updated encryption algorithm that guarantees cipher text integrity.
-  - Also added `Encryption.encryptBytes()` and `Encryption.decryptBytes()` using the same algorithm.
-- New option `proofsEnabled` for `zkProgram` (default value: `true`), to quickly test circuit logic with proofs disabled https://github.com/o1-labs/o1js/pull/1805
-  - Additionally added `MyProgram.proofsEnabled` to get the internal value of `proofsEnabled` and `MyProgram.setProofsEnabled(proofsEnabled)` to set the value dynamically.
+- Added `Encryption.encryptV2()` and `Encryption.decryptV2()` for an updated
+  encryption algorithm that guarantees cipher text integrity.
+  - Also added `Encryption.encryptBytes()` and `Encryption.decryptBytes()` using
+    the same algorithm.
+- New option `proofsEnabled` for `zkProgram` (default value: `true`), to quickly
+  test circuit logic with proofs disabled
+  https://github.com/o1-labs/o1js/pull/1805
+  - Additionally added `MyProgram.proofsEnabled` to get the internal value of
+    `proofsEnabled` and `MyProgram.setProofsEnabled(proofsEnabled)` to set the
+    value dynamically.
 
 ### Deprecated
 
-- `this.sender.getAndRequireSignature()` / `getUnconstrained()` deprecated in favor of `V2` versions due to a vulnerability https://github.com/o1-labs/o1js/pull/1799
+- `this.sender.getAndRequireSignature()` / `getUnconstrained()` deprecated in
+  favor of `V2` versions due to a vulnerability
+  https://github.com/o1-labs/o1js/pull/1799
 
 ### Fixes
 
-- Fix behavior of `Int64.modV2()` when the input is negative and the remainder should be 0 https://github.com/o1-labs/o1js/pull/1797
+- Fix behavior of `Int64.modV2()` when the input is negative and the remainder
+  should be 0 https://github.com/o1-labs/o1js/pull/1797
 
 ## [1.6.0](https://github.com/o1-labs/o1js/compare/1ad7333e9e...d6abf1d97) - 2024-07-23
 
 ### Added
 
-- `SmartContract.emitEventIf()` to conditionally emit an event https://github.com/o1-labs/o1js/pull/1746
-- Added `Encryption.encryptV2()` and `Encryption.decryptV2()` for an updated encryption algorithm that guarantees cipher text integrity.
-  - Also added `Encryption.encryptBytes()` and `Encryption.decryptBytes()` using the same algorithm.
+- `SmartContract.emitEventIf()` to conditionally emit an event
+  https://github.com/o1-labs/o1js/pull/1746
+- Added `Encryption.encryptV2()` and `Encryption.decryptV2()` for an updated
+  encryption algorithm that guarantees cipher text integrity.
+  - Also added `Encryption.encryptBytes()` and `Encryption.decryptBytes()` using
+    the same algorithm.
 
 ### Changed
 
-- Reduced maximum bit length for `xor`, `not`, and `and`, operations from 254 to 240 bits to prevent overflow vulnerabilities. https://github.com/o1-labs/o1js/pull/1745
-- Allow using `Type` instead of `Type.provable` in APIs that expect a provable type https://github.com/o1-labs/o1js/pull/1751
+- Reduced maximum bit length for `xor`, `not`, and `and`, operations from 254 to
+  240 bits to prevent overflow vulnerabilities.
+  https://github.com/o1-labs/o1js/pull/1745
+- Allow using `Type` instead of `Type.provable` in APIs that expect a provable
+  type https://github.com/o1-labs/o1js/pull/1751
   - Example: `Provable.witness(Bytes32, () => bytes)`
-- Automatically wrap and unwrap `Unconstrained` in `fromValue` and `toValue`, so that we don't need to deal with "unconstrained" values outside provable code https://github.com/o1-labs/o1js/pull/1751
+- Automatically wrap and unwrap `Unconstrained` in `fromValue` and `toValue`, so
+  that we don't need to deal with "unconstrained" values outside provable code
+  https://github.com/o1-labs/o1js/pull/1751
 
 ## [1.5.0](https://github.com/o1-labs/o1js/compare/ed198f305...1c736add) - 2024-07-09
 
 ### Breaking changes
 
-- Fixed a vulnerability in `OffchainState` where it didn't store the `IndexedMerkleTree` length onchain and left it unconstrained https://github.com/o1-labs/o1js/pull/1676
+- Fixed a vulnerability in `OffchainState` where it didn't store the
+  `IndexedMerkleTree` length onchain and left it unconstrained
+  https://github.com/o1-labs/o1js/pull/1676
 
 ### Added
 
-- A warning about the current reducer API limitations, as well as a mention of active work to mitigate them was added to doc comments and examples https://github.com/o1-labs/o1js/pull/1728
-- `ForeignField`-based representation of scalars via `ScalarField` https://github.com/o1-labs/o1js/pull/1705
-- Introduced new V2 methods for nullifier operations: `isUnusedV2()`, `assertUnusedV2()`, and `setUsedV2()` https://github.com/o1-labs/o1js/pull/1715
-- `Int64.create()` method for safe instance creation with canonical zero representation https://github.com/o1-labs/o1js/pull/1735
-- New V2 methods for `Int64` operations: `fromObjectV2`, `divV2()` https://github.com/o1-labs/o1js/pull/1735
-- `Experimental.BatchReducer` to reduce actions in batches https://github.com/o1-labs/o1js/pull/1676
+- A warning about the current reducer API limitations, as well as a mention of
+  active work to mitigate them was added to doc comments and examples
+  https://github.com/o1-labs/o1js/pull/1728
+- `ForeignField`-based representation of scalars via `ScalarField`
+  https://github.com/o1-labs/o1js/pull/1705
+- Introduced new V2 methods for nullifier operations: `isUnusedV2()`,
+  `assertUnusedV2()`, and `setUsedV2()`
+  https://github.com/o1-labs/o1js/pull/1715
+- `Int64.create()` method for safe instance creation with canonical zero
+  representation https://github.com/o1-labs/o1js/pull/1735
+- New V2 methods for `Int64` operations: `fromObjectV2`, `divV2()`
+  https://github.com/o1-labs/o1js/pull/1735
+- `Experimental.BatchReducer` to reduce actions in batches
+  https://github.com/o1-labs/o1js/pull/1676
   - Avoids the account update limit
-  - Handles arbitrary numbers of pending actions thanks to recursive validation of the next batch
-- Add conditional versions of all preconditions: `.requireEqualsIf()` https://github.com/o1-labs/o1js/pull/1676
-- `AccountUpdate.createIf()` to conditionally add an account update to the current transaction https://github.com/o1-labs/o1js/pull/1676
-- `IndexedMerkleMap.setIf()` to set a key-value pair conditionally https://github.com/o1-labs/o1js/pull/1676
-- `Provable.assertEqualIf()` to conditionally assert that two values are equal https://github.com/o1-labs/o1js/pull/1676
-- Add `offchainState.setContractClass()` which enables us to declare the connected contract at the top level, without creating a contract instance https://github.com/o1-labs/o1js/pull/1676
+  - Handles arbitrary numbers of pending actions thanks to recursive validation
+    of the next batch
+- Add conditional versions of all preconditions: `.requireEqualsIf()`
+  https://github.com/o1-labs/o1js/pull/1676
+- `AccountUpdate.createIf()` to conditionally add an account update to the
+  current transaction https://github.com/o1-labs/o1js/pull/1676
+- `IndexedMerkleMap.setIf()` to set a key-value pair conditionally
+  https://github.com/o1-labs/o1js/pull/1676
+- `Provable.assertEqualIf()` to conditionally assert that two values are equal
+  https://github.com/o1-labs/o1js/pull/1676
+- Add `offchainState.setContractClass()` which enables us to declare the
+  connected contract at the top level, without creating a contract instance
+  https://github.com/o1-labs/o1js/pull/1676
   - This is enough to call `offchainState.compile()`
-- More low-level methods to interact with `MerkleList` https://github.com/o1-labs/o1js/pull/1676
+- More low-level methods to interact with `MerkleList`
+  https://github.com/o1-labs/o1js/pull/1676
   - `popIfUnsafe()`, `toArrayUnconstrained()` and `lengthUnconstrained()`
 
 ### Changed
 
-- Improve error message when o1js global state is accessed in an invalid way https://github.com/o1-labs/o1js/pull/1676
-- Start developing an internal framework for local zkapp testing https://github.com/o1-labs/o1js/pull/1676
-- Internally upgrade o1js to TypeScript 5.4 https://github.com/o1-labs/o1js/pull/1676
+- Improve error message when o1js global state is accessed in an invalid way
+  https://github.com/o1-labs/o1js/pull/1676
+- Start developing an internal framework for local zkapp testing
+  https://github.com/o1-labs/o1js/pull/1676
+- Internally upgrade o1js to TypeScript 5.4
+  https://github.com/o1-labs/o1js/pull/1676
 
 ### Deprecated
 
-- Deprecated `Nullifier.isUnused()`, `Nullifier.assertUnused()`, and `Nullifier.setUsed()` methods https://github.com/o1-labs/o1js/pull/1715
-- `createEcdsa`, `createForeignCurve`, `ForeignCurve` and `EcdsaSignature` deprecated in favor of `V2` versions due to a security vulnerability found in the current implementation https://github.com/o1-labs/o1js/pull/1703
-- `Int64` constructor, recommending `Int64.create()` instead https://github.com/o1-labs/o1js/pull/1735
-- Original `div()` and `fromObject`, methods in favor of V2 versions https://github.com/o1-labs/o1js/pull/1735
-- Deprecate `AccountUpdate.defaultAccountUpdate()` in favor of `AccountUpdate.default()` https://github.com/o1-labs/o1js/pull/1676
+- Deprecated `Nullifier.isUnused()`, `Nullifier.assertUnused()`, and
+  `Nullifier.setUsed()` methods https://github.com/o1-labs/o1js/pull/1715
+- `createEcdsa`, `createForeignCurve`, `ForeignCurve` and `EcdsaSignature`
+  deprecated in favor of `V2` versions due to a security vulnerability found in
+  the current implementation https://github.com/o1-labs/o1js/pull/1703
+- `Int64` constructor, recommending `Int64.create()` instead
+  https://github.com/o1-labs/o1js/pull/1735
+- Original `div()` and `fromObject`, methods in favor of V2 versions
+  https://github.com/o1-labs/o1js/pull/1735
+- Deprecate `AccountUpdate.defaultAccountUpdate()` in favor of
+  `AccountUpdate.default()` https://github.com/o1-labs/o1js/pull/1676
 
 ### Fixed
 
-- Fix reversed order of account updates when using `TokenContract.approveAccountUpdates()` https://github.com/o1-labs/o1js/pull/1722
-- Fixed the static `check()` method in Struct classes to properly handle inheritance, preventing issues with under-constrained circuits. Added error handling to avoid using Struct directly as a field type. https://github.com/o1-labs/o1js/pull/1707
-- Fixed that `Option` could not be used as `@state` or event https://github.com/o1-labs/o1js/pull/1736
+- Fix reversed order of account updates when using
+  `TokenContract.approveAccountUpdates()`
+  https://github.com/o1-labs/o1js/pull/1722
+- Fixed the static `check()` method in Struct classes to properly handle
+  inheritance, preventing issues with under-constrained circuits. Added error
+  handling to avoid using Struct directly as a field type.
+  https://github.com/o1-labs/o1js/pull/1707
+- Fixed that `Option` could not be used as `@state` or event
+  https://github.com/o1-labs/o1js/pull/1736
 
 ## [1.4.0](https://github.com/o1-labs/o1js/compare/40c597775...ed198f305) - 2024-06-25
 
 ### Added
 
-- **SHA256 low-level API** exposed via `Gadgets.SHA256`. https://github.com/o1-labs/o1js/pull/1689 [@Shigoto-dev19](https://github.com/Shigoto-dev19)
-- Added the option to specify custom feature flags for sided loaded proofs in the `DynamicProof` class. https://github.com/o1-labs/o1js/pull/1688
-  - Feature flags are required to tell Pickles what proof structure it should expect when side loading dynamic proofs and verification keys.
-  - `FeatureFlags` is now exported and provides a set of helper functions to compute feature flags correctly.
+- **SHA256 low-level API** exposed via `Gadgets.SHA256`.
+  https://github.com/o1-labs/o1js/pull/1689
+  [@Shigoto-dev19](https://github.com/Shigoto-dev19)
+- Added the option to specify custom feature flags for sided loaded proofs in
+  the `DynamicProof` class. https://github.com/o1-labs/o1js/pull/1688
+  - Feature flags are required to tell Pickles what proof structure it should
+    expect when side loading dynamic proofs and verification keys.
+  - `FeatureFlags` is now exported and provides a set of helper functions to
+    compute feature flags correctly.
 
 ### Deprecated
 
-- `MerkleMap.computeRootAndKey()` deprecated in favor of `MerkleMap.computeRootAndKeyV2()` due to a potential issue of computing hash collisions in key indices https://github.com/o1-labs/o1js/pull/1694
+- `MerkleMap.computeRootAndKey()` deprecated in favor of
+  `MerkleMap.computeRootAndKeyV2()` due to a potential issue of computing hash
+  collisions in key indices https://github.com/o1-labs/o1js/pull/1694
 
 ## [1.3.1](https://github.com/o1-labs/o1js/compare/1ad7333e9e...40c597775) - 2024-06-11
 
 ### Breaking Changes
 
-- Improve efficiency of `Experimental.OffchainState` implementation https://github.com/o1-labs/o1js/pull/1672
+- Improve efficiency of `Experimental.OffchainState` implementation
+  https://github.com/o1-labs/o1js/pull/1672
   - Comes with breaking changes to the internal circuits of `OffchainState`
-  - Also, introduce `offchainState.commitments()` to initialize the state commitments onchain. Using `OffchainStateCommitments.empty()` no longer works.
+  - Also, introduce `offchainState.commitments()` to initialize the state
+    commitments onchain. Using `OffchainStateCommitments.empty()` no longer
+    works.
 
 ### Added
 
-- `Experimental.IndexedMerkleMap`, a better primitive for Merkleized storage https://github.com/o1-labs/o1js/pull/1666 https://github.com/o1-labs/o1js/pull/1671
+- `Experimental.IndexedMerkleMap`, a better primitive for Merkleized storage
+  https://github.com/o1-labs/o1js/pull/1666
+  https://github.com/o1-labs/o1js/pull/1671
   - Uses 4-8x fewer constraints than `MerkleMap`
-  - In contrast to `MerkleTree` and `MerkleMap`, `IndexedMerkleMap` has a high-level API that can be used in provable code
-- Added `Ecdsa.verifyV2()` and `Ecdsa.verifySignedHashV2` methods to the `Ecdsa` class. https://github.com/o1-labs/o1js/pull/1669
+  - In contrast to `MerkleTree` and `MerkleMap`, `IndexedMerkleMap` has a
+    high-level API that can be used in provable code
+- Added `Ecdsa.verifyV2()` and `Ecdsa.verifySignedHashV2` methods to the `Ecdsa`
+  class. https://github.com/o1-labs/o1js/pull/1669
 
 ### Deprecated
 
-- `Int64.isPositive()` and `Int64.mod()` deprecated because they behave incorrectly on `-0` https://github.com/o1-labs/o1js/pull/1660
-  - This can pose an attack surface, since it is easy to maliciously pick either the `+0` or the `-0` representation
+- `Int64.isPositive()` and `Int64.mod()` deprecated because they behave
+  incorrectly on `-0` https://github.com/o1-labs/o1js/pull/1660
+  - This can pose an attack surface, since it is easy to maliciously pick either
+    the `+0` or the `-0` representation
   - Use `Int64.isPositiveV2()` and `Int64.modV2()` instead
-  - Also deprecated `Int64.neg()` in favor of `Int64.negV2()`, for compatibility with v2 version of `Int64` that will use `Int64.checkV2()`
-- `Ecdsa.verify()` and `Ecdsa.verifySignedHash()` deprecated in favor of `Ecdsa.verifyV2()` and `Ecdsa.verifySignedHashV2()` due to a security vulnerability found in the current implementation https://github.com/o1-labs/o1js/pull/1669
+  - Also deprecated `Int64.neg()` in favor of `Int64.negV2()`, for compatibility
+    with v2 version of `Int64` that will use `Int64.checkV2()`
+- `Ecdsa.verify()` and `Ecdsa.verifySignedHash()` deprecated in favor of
+  `Ecdsa.verifyV2()` and `Ecdsa.verifySignedHashV2()` due to a security
+  vulnerability found in the current implementation
+  https://github.com/o1-labs/o1js/pull/1669
 
 ### Fixed
 
-- Fix handling of fetch response for non-existing accounts https://github.com/o1-labs/o1js/pull/1679
+- Fix handling of fetch response for non-existing accounts
+  https://github.com/o1-labs/o1js/pull/1679
 
 ## [1.3.0](https://github.com/o1-labs/o1js/compare/6a1012162...54d6545bf) - 2024-05-23
 
 ### Added
 
-- Added `base64Encode()` and `base64Decode(byteLength)` methods to the `Bytes` class. https://github.com/o1-labs/o1js/pull/1659
+- Added `base64Encode()` and `base64Decode(byteLength)` methods to the `Bytes`
+  class. https://github.com/o1-labs/o1js/pull/1659
 
 ### Fixes
 
-- Fix type inference for `method.returns(Type)`, to require a matching return signature https://github.com/o1-labs/o1js/pull/1653
-- Fix `Struct.empty()` returning a garbage object when one of the base types doesn't support `empty()` https://github.com/o1-labs/o1js/pull/1657
-- Fix `Option.value_exn None` error when using certain custom gates in combination with recursion https://github.com/o1-labs/o1js/issues/1336 https://github.com/MinaProtocol/mina/pull/15588
+- Fix type inference for `method.returns(Type)`, to require a matching return
+  signature https://github.com/o1-labs/o1js/pull/1653
+- Fix `Struct.empty()` returning a garbage object when one of the base types
+  doesn't support `empty()` https://github.com/o1-labs/o1js/pull/1657
+- Fix `Option.value_exn None` error when using certain custom gates in
+  combination with recursion https://github.com/o1-labs/o1js/issues/1336
+  https://github.com/MinaProtocol/mina/pull/15588
 
 ## [1.2.0](https://github.com/o1-labs/o1js/compare/4a17de857...6a1012162) - 2024-05-14
 
 ### Added
 
-- **Offchain state MVP** exported under `Experimental.OffchainState` https://github.com/o1-labs/o1js/pull/1630 https://github.com/o1-labs/o1js/pull/1652
+- **Offchain state MVP** exported under `Experimental.OffchainState`
+  https://github.com/o1-labs/o1js/pull/1630
+  https://github.com/o1-labs/o1js/pull/1652
   - allows you to store any number of fields and key-value maps on your zkApp
   - implemented using actions which define an offchain Merkle tree
-- `Option` for defining an optional version of any provable type https://github.com/o1-labs/o1js/pull/1630
-- `MerkleTree.clone()` and `MerkleTree.getLeaf()`, new convenience methods for merkle trees https://github.com/o1-labs/o1js/pull/1630
-- `MerkleList.forEach()`, a simple and safe way for iterating over a `MerkleList`
-- `Unconstrained.provableWithEmpty()` to create an unconstrained provable type with a known `empty()` value https://github.com/o1-labs/o1js/pull/1630
-- `Permissions.VerificationKey`, a namespace for verification key permissions https://github.com/o1-labs/o1js/pull/1639
-  - Includes more accurate names for the `impossible` and `proof` permissions for verification keys, which are now called `impossibleDuringCurrentVersion` and `proofDuringCurrentVersion` respectively.
+- `Option` for defining an optional version of any provable type
+  https://github.com/o1-labs/o1js/pull/1630
+- `MerkleTree.clone()` and `MerkleTree.getLeaf()`, new convenience methods for
+  merkle trees https://github.com/o1-labs/o1js/pull/1630
+- `MerkleList.forEach()`, a simple and safe way for iterating over a
+  `MerkleList`
+- `Unconstrained.provableWithEmpty()` to create an unconstrained provable type
+  with a known `empty()` value https://github.com/o1-labs/o1js/pull/1630
+- `Permissions.VerificationKey`, a namespace for verification key permissions
+  https://github.com/o1-labs/o1js/pull/1639
+  - Includes more accurate names for the `impossible` and `proof` permissions
+    for verification keys, which are now called `impossibleDuringCurrentVersion`
+    and `proofDuringCurrentVersion` respectively.
 
 ### Changed
 
-- `State()` now optionally accepts an initial value as input parameter https://github.com/o1-labs/o1js/pull/1630
+- `State()` now optionally accepts an initial value as input parameter
+  https://github.com/o1-labs/o1js/pull/1630
   - Example: `@state(Field) x = State(Field(1));`
   - Initial values will be set in the default `init()` method
   - You no longer need a custom `init()` method to set initial values
 
 ### Fixes
 
-- Fix absolute imports which prevented compilation in some TS projects that used o1js https://github.com/o1-labs/o1js/pull/1628
+- Fix absolute imports which prevented compilation in some TS projects that used
+  o1js https://github.com/o1-labs/o1js/pull/1628
 
 ## [1.1.0](https://github.com/o1-labs/o1js/compare/1ad7333e9e...4a17de857) - 2024-04-30
 
 ### Added
 
-- Exposed **sideloaded verification keys** https://github.com/o1-labs/o1js/pull/1606 [@rpanic](https://github.com/rpanic)
-  - Added Proof type `DynamicProof` that allows verification through specifying a verification key in-circuit
-- `Provable.witnessFields()` to easily witness a tuple of field elements https://github.com/o1-labs/o1js/pull/1229
-- Example for implementing RSA verification in o1js https://github.com/o1-labs/o1js/pull/1229 [@Shigoto-dev19](https://github.com/Shigoto-dev19)
-  - Check out https://github.com/o1-labs/o1js/blob/main/src/examples/crypto/rsa/rsa.ts and tests in the same folder
+- Exposed **sideloaded verification keys**
+  https://github.com/o1-labs/o1js/pull/1606 [@rpanic](https://github.com/rpanic)
+  - Added Proof type `DynamicProof` that allows verification through specifying
+    a verification key in-circuit
+- `Provable.witnessFields()` to easily witness a tuple of field elements
+  https://github.com/o1-labs/o1js/pull/1229
+- Example for implementing RSA verification in o1js
+  https://github.com/o1-labs/o1js/pull/1229
+  [@Shigoto-dev19](https://github.com/Shigoto-dev19)
+  - Check out
+    https://github.com/o1-labs/o1js/blob/main/src/examples/crypto/rsa/rsa.ts and
+    tests in the same folder
 
 ### Changed
 
-- `Gadgets.rangeCheck64()` now returns individual range-checked limbs for advanced use cases https://github.com/o1-labs/o1js/pull/1229
+- `Gadgets.rangeCheck64()` now returns individual range-checked limbs for
+  advanced use cases https://github.com/o1-labs/o1js/pull/1229
 
 ### Fixed
 
-- Fixed issue in `UInt64.rightShift()` where it incorrectly performed a left shift instead of a right shift. https://github.com/o1-labs/o1js/pull/1617
-- Fixed issue in `ForeignField.toBits()` where high limbs were under-constrained for input length less than 176. https://github.com/o1-labs/o1js/pull/1617
-- Make `dummyBase64Proof()` lazy. Significant speed up when generating many account updates with authorization `Proof` while proofs turned off. https://github.com/o1-labs/o1js/pull/1624
+- Fixed issue in `UInt64.rightShift()` where it incorrectly performed a left
+  shift instead of a right shift. https://github.com/o1-labs/o1js/pull/1617
+- Fixed issue in `ForeignField.toBits()` where high limbs were under-constrained
+  for input length less than 176. https://github.com/o1-labs/o1js/pull/1617
+- Make `dummyBase64Proof()` lazy. Significant speed up when generating many
+  account updates with authorization `Proof` while proofs turned off.
+  https://github.com/o1-labs/o1js/pull/1624
 
 ## [1.0.1](https://github.com/o1-labs/o1js/compare/1b6fd8b8e...02c5e8d4d) - 2024-04-22
 
 ### Breaking changes
 
 - Native curve improvements https://github.com/o1-labs/o1js/pull/1530
-  - Change the internal representation of `Scalar` from 255 Bools to 1 Bool and 1 Field (low bit and high 254 bits)
-  - Make `Group.scale()` support all scalars (previously did not support 0, 1 and -1)
-  - Make `Group.scale()` directly accept `Field` elements, and much more efficient than previous methods of scaling by Fields
-    - As a result, `Signature.verify()` and `Nullifier.verify()` use much fewer constraints
-  - Fix `Scalar.fromBits()` to not produce a shifted scalar; shifting is no longer exposed to users of `Scalar`.
-- Add assertion to the foreign EC addition gadget that prevents degenerate cases https://github.com/o1-labs/o1js/pull/1545
-  - Fixes soundness of ECDSA; slightly increases its constraints from ~28k to 29k
+  - Change the internal representation of `Scalar` from 255 Bools to 1 Bool and
+    1 Field (low bit and high 254 bits)
+  - Make `Group.scale()` support all scalars (previously did not support 0, 1
+    and -1)
+  - Make `Group.scale()` directly accept `Field` elements, and much more
+    efficient than previous methods of scaling by Fields
+    - As a result, `Signature.verify()` and `Nullifier.verify()` use much fewer
+      constraints
+  - Fix `Scalar.fromBits()` to not produce a shifted scalar; shifting is no
+    longer exposed to users of `Scalar`.
+- Add assertion to the foreign EC addition gadget that prevents degenerate cases
+  https://github.com/o1-labs/o1js/pull/1545
+  - Fixes soundness of ECDSA; slightly increases its constraints from ~28k to
+    29k
   - Breaks circuits that used EC addition, like ECDSA
-- `Mina.LocalBlockchain()` and `Proof.fromJSON()` are made async https://github.com/o1-labs/o1js/pull/1583
-  - These were the last remaining sync APIs that depended on an async setup task; making them async enables removing top-level await
-- `Mina.LocalBlockchain` no longer supports the network kind configuration https://github.com/o1-labs/o1js/pull/1581
-- `Poseidon.hashToGroup()` now returns a `Group` directly, and constrains it to be deterministic https://github.com/o1-labs/o1js/pull/1546
-  - Added `Poseidon.Unsafe.hashToGroup()` as a more efficient, non-deterministic version for advanced use cases
-- A `Transaction`'s `prove` method no longer returns the proofs promise directly, but rather returns a `Transaction` promise, the resolved value of which contains a `proofs` prop. https://github.com/o1-labs/o1js/pull/1567
-- The `Transaction` type now has two type params `Proven extends boolean` and `Signed extends boolean`, which are used to conditionally show/hide relevant state. https://github.com/o1-labs/o1js/pull/1567
-- Improved functionality of `MerkleList` and `MerkleListIterator` for easier traversal of `MerkleList`s. https://github.com/o1-labs/o1js/pull/1562
-- Simplified internal logic of reducer. https://github.com/o1-labs/o1js/pull/1577
+- `Mina.LocalBlockchain()` and `Proof.fromJSON()` are made async
+  https://github.com/o1-labs/o1js/pull/1583
+  - These were the last remaining sync APIs that depended on an async setup
+    task; making them async enables removing top-level await
+- `Mina.LocalBlockchain` no longer supports the network kind configuration
+  https://github.com/o1-labs/o1js/pull/1581
+- `Poseidon.hashToGroup()` now returns a `Group` directly, and constrains it to
+  be deterministic https://github.com/o1-labs/o1js/pull/1546
+  - Added `Poseidon.Unsafe.hashToGroup()` as a more efficient, non-deterministic
+    version for advanced use cases
+- A `Transaction`'s `prove` method no longer returns the proofs promise
+  directly, but rather returns a `Transaction` promise, the resolved value of
+  which contains a `proofs` prop. https://github.com/o1-labs/o1js/pull/1567
+- The `Transaction` type now has two type params `Proven extends boolean` and
+  `Signed extends boolean`, which are used to conditionally show/hide relevant
+  state. https://github.com/o1-labs/o1js/pull/1567
+- Improved functionality of `MerkleList` and `MerkleListIterator` for easier
+  traversal of `MerkleList`s. https://github.com/o1-labs/o1js/pull/1562
+- Simplified internal logic of reducer.
+  https://github.com/o1-labs/o1js/pull/1577
   - `contract.getActions()` now returns a `MerkleList`
-- Add `toValue()` and `fromValue()` interface to `Provable<T>` to encode how provable types map to plain JS values https://github.com/o1-labs/o1js/pull/1271
-  - You can now return the plain value from a `Provable.witness()` callback, and it will be transformed into the provable type
-- Remove `Account()` constructor which was no different from `AccountUpdate.create().account`, and export `Account` type instead. https://github.com/o1-labs/o1js/pull/1598
+- Add `toValue()` and `fromValue()` interface to `Provable<T>` to encode how
+  provable types map to plain JS values
+  https://github.com/o1-labs/o1js/pull/1271
+  - You can now return the plain value from a `Provable.witness()` callback, and
+    it will be transformed into the provable type
+- Remove `Account()` constructor which was no different from
+  `AccountUpdate.create().account`, and export `Account` type instead.
+  https://github.com/o1-labs/o1js/pull/1598
 
 ### Added
 
-- Export `Events` under `AccountUpdate.Events`. https://github.com/o1-labs/o1js/pull/1563
-- `Mina.transaction` has been reworked such that one can call methods directly on the returned promise (now a `TransactionPromise`). This enables a fluent / method-chaining API. https://github.com/o1-labs/o1js/pull/1567
-- `TransactionPendingPromise` enables calling `wait` directly on the promise returned by calling `send` on a `Transaction`. https://github.com/o1-labs/o1js/pull/1567
-- `initializeBindings()` to explicitly trigger setup work that is needed when running provable code https://github.com/o1-labs/o1js/pull/1583
+- Export `Events` under `AccountUpdate.Events`.
+  https://github.com/o1-labs/o1js/pull/1563
+- `Mina.transaction` has been reworked such that one can call methods directly
+  on the returned promise (now a `TransactionPromise`). This enables a fluent /
+  method-chaining API. https://github.com/o1-labs/o1js/pull/1567
+- `TransactionPendingPromise` enables calling `wait` directly on the promise
+  returned by calling `send` on a `Transaction`.
+  https://github.com/o1-labs/o1js/pull/1567
+- `initializeBindings()` to explicitly trigger setup work that is needed when
+  running provable code https://github.com/o1-labs/o1js/pull/1583
   - calling this function is optional
 
 ### Changed
 
 - Remove top-level await https://github.com/o1-labs/o1js/pull/1583
   - To simplify integration with bundlers like webpack
-- Make `MerkleTree.{nodes,zeroes}` public properties https://github.com/o1-labs/o1js/pull/1555
+- Make `MerkleTree.{nodes,zeroes}` public properties
+  https://github.com/o1-labs/o1js/pull/1555
   - This makes it possible to clone merkle trees, which is often needed
 
 ### Fixed
 
-- Fix error when computing Merkle map witnesses, introduced in the last version due to the `toBits()` change https://github.com/o1-labs/o1js/pull/1559
-- Improved error message when compiling a program that has no methods. https://github.com/o1-labs/o1js/pull/1563
+- Fix error when computing Merkle map witnesses, introduced in the last version
+  due to the `toBits()` change https://github.com/o1-labs/o1js/pull/1559
+- Improved error message when compiling a program that has no methods.
+  https://github.com/o1-labs/o1js/pull/1563
 
 ## [0.18.0](https://github.com/o1-labs/o1js/compare/74948acac...1b6fd8b8e) - 2024-04-09
 
 ### Breaking changes
 
-- **Async circuits**. Require all smart contract and zkprogram methods to be async https://github.com/o1-labs/o1js/pull/1477
-  - This change allows you to use `await` inside your methods. Change the method signature by adding the `async` keyword.
-  - Don't forget to add `await` to all contract calls! `await MyContract.myMethod();`
-  - To declare a return value from a method, use the new `@method.returns()` decorator
-- Require the callback to `Mina.transaction()` to be async https://github.com/o1-labs/o1js/pull/1468
-- Change `{SmartContract,ZkProgram}.analyzeMethods()` to be async https://github.com/o1-labs/o1js/pull/1450
-  - `Provable.runAndCheck()`, `Provable.constraintSystem()` and `{SmartContract,ZkProgram}.digest()` are also async now
+- **Async circuits**. Require all smart contract and zkprogram methods to be
+  async https://github.com/o1-labs/o1js/pull/1477
+  - This change allows you to use `await` inside your methods. Change the method
+    signature by adding the `async` keyword.
+  - Don't forget to add `await` to all contract calls!
+    `await MyContract.myMethod();`
+  - To declare a return value from a method, use the new `@method.returns()`
+    decorator
+- Require the callback to `Mina.transaction()` to be async
+  https://github.com/o1-labs/o1js/pull/1468
+- Change `{SmartContract,ZkProgram}.analyzeMethods()` to be async
+  https://github.com/o1-labs/o1js/pull/1450
+  - `Provable.runAndCheck()`, `Provable.constraintSystem()` and
+    `{SmartContract,ZkProgram}.digest()` are also async now
 - **Remove deprecated APIs**
-  - Remove `CircuitValue`, `prop`, `arrayProp` and `matrixProp` https://github.com/o1-labs/o1js/pull/1507
-  - Remove `Mina.accountCreationFee()`, `Mina.BerkeleyQANet`, all APIs which accept private keys for feepayers, `Token`, `AccountUpdate.tokenSymbol`, `SmartContract.{token, setValue, setPermissions}`, "assert" methods for preconditions, `MerkleTee.calculateRootSlow()`, `Scalar.fromBigInt()`, `UInt64.lt()` and friends, deprecated static methods on `Group`, utility methods on `Circuit` like `Circuit.if()`, `Field.isZero()`, `isReady` and `shutdown()` https://github.com/o1-labs/o1js/pull/1515
-- Remove `privateKey` from the accepted arguments of `SmartContract.deploy()` https://github.com/o1-labs/o1js/pull/1515
-- **Efficient comparisons**. Support arbitrary bit lengths for `Field` comparisons and massively reduce their constraints https://github.com/o1-labs/o1js/pull/1523
-  - `Field.assertLessThan()` goes from 510 to 24 constraints, `Field.lessThan()` from 509 to 38
-  - Moderately improve other comparisons: `UInt64.assertLessThan()` from 27 to 14, `UInt64.lessThan()` from 27 to 15, `UInt32` similar.
+  - Remove `CircuitValue`, `prop`, `arrayProp` and `matrixProp`
+    https://github.com/o1-labs/o1js/pull/1507
+  - Remove `Mina.accountCreationFee()`, `Mina.BerkeleyQANet`, all APIs which
+    accept private keys for feepayers, `Token`, `AccountUpdate.tokenSymbol`,
+    `SmartContract.{token, setValue, setPermissions}`, "assert" methods for
+    preconditions, `MerkleTee.calculateRootSlow()`, `Scalar.fromBigInt()`,
+    `UInt64.lt()` and friends, deprecated static methods on `Group`, utility
+    methods on `Circuit` like `Circuit.if()`, `Field.isZero()`, `isReady` and
+    `shutdown()` https://github.com/o1-labs/o1js/pull/1515
+- Remove `privateKey` from the accepted arguments of `SmartContract.deploy()`
+  https://github.com/o1-labs/o1js/pull/1515
+- **Efficient comparisons**. Support arbitrary bit lengths for `Field`
+  comparisons and massively reduce their constraints
+  https://github.com/o1-labs/o1js/pull/1523
+  - `Field.assertLessThan()` goes from 510 to 24 constraints, `Field.lessThan()`
+    from 509 to 38
+  - Moderately improve other comparisons: `UInt64.assertLessThan()` from 27 to
+    14, `UInt64.lessThan()` from 27 to 15, `UInt32` similar.
   - Massively improve `Field.isEven()`, add `Field.isOdd()`
   - `PrivateKey.toPublicKey()` from 358 to 119 constraints thanks to `isOdd()`
-  - Add `Gadgets.ForeignField.assertLessThanOrEqual()` and support two variables as input to `ForeignField.assertLessThan()`
-- Remove `this.sender` which unintuitively did not prove that its value was the actual sender of the transaction https://github.com/o1-labs/o1js/pull/1464 [@julio4](https://github.com/julio4)
-  Replaced by more explicit APIs:
-  - `this.sender.getUnconstrained()` which has the old behavior of `this.sender`, and returns an unconstrained value (which means that the prover can set it to any value they want)
-  - `this.sender.getAndRequireSignature()` which requires a signature from the sender's public key and therefore proves that whoever created the transaction really owns the sender account
-- `Reducer.reduce()` requires the maximum number of actions per method as an explicit (optional) argument https://github.com/o1-labs/o1js/pull/1450
+  - Add `Gadgets.ForeignField.assertLessThanOrEqual()` and support two variables
+    as input to `ForeignField.assertLessThan()`
+- Remove `this.sender` which unintuitively did not prove that its value was the
+  actual sender of the transaction https://github.com/o1-labs/o1js/pull/1464
+  [@julio4](https://github.com/julio4) Replaced by more explicit APIs:
+  - `this.sender.getUnconstrained()` which has the old behavior of
+    `this.sender`, and returns an unconstrained value (which means that the
+    prover can set it to any value they want)
+  - `this.sender.getAndRequireSignature()` which requires a signature from the
+    sender's public key and therefore proves that whoever created the
+    transaction really owns the sender account
+- `Reducer.reduce()` requires the maximum number of actions per method as an
+  explicit (optional) argument https://github.com/o1-labs/o1js/pull/1450
   - The default value is 1 and should work for most existing contracts
-- `new UInt64()` and `UInt64.from()` no longer unsafely accept a field element as input. https://github.com/o1-labs/o1js/pull/1438 [@julio4](https://github.com/julio4)
-  As a replacement, `UInt64.Unsafe.fromField()` was introduced
-  - This prevents you from accidentally creating a `UInt64` without proving that it fits in 64 bits
+- `new UInt64()` and `UInt64.from()` no longer unsafely accept a field element
+  as input. https://github.com/o1-labs/o1js/pull/1438
+  [@julio4](https://github.com/julio4) As a replacement,
+  `UInt64.Unsafe.fromField()` was introduced
+  - This prevents you from accidentally creating a `UInt64` without proving that
+    it fits in 64 bits
   - Equivalent changes were made to `UInt32`
-- Fixed vulnerability in `Field.to/fromBits()` outlined in [#1023](https://github.com/o1-labs/o1js/issues/1023) by imposing a limit of 254 bits https://github.com/o1-labs/o1js/pull/1461
-- Remove `Field.rangeCheckHelper()` which was too low-level and easy to misuse https://github.com/o1-labs/o1js/pull/1485
-  - Also, rename the misleadingly named `Gadgets.isInRangeN()` to `Gadgets.isDefinitelyInRangeN()`
-- Rename `Bool.Unsafe.ofField()` to `Bool.Unsafe.fromField()` https://github.com/o1-labs/o1js/pull/1485
-- Replace the namespaced type exports `Gadgets.Field3` and `Gadgets.ForeignField.Sum` with `Field3` and `ForeignFieldSum`
-  - Unfortunately, the namespace didn't play well with auto-imports in TypeScript
-- Add `Gadgets.rangeCheck3x12()` and fix proof system bug that prevented it from working https://github.com/o1-labs/o1js/pull/1534
-- Update transaction version and other bindings changes to ensure berkeley compatibility https://github.com/o1-labs/o1js/pull/1542
+- Fixed vulnerability in `Field.to/fromBits()` outlined in
+  [#1023](https://github.com/o1-labs/o1js/issues/1023) by imposing a limit of
+  254 bits https://github.com/o1-labs/o1js/pull/1461
+- Remove `Field.rangeCheckHelper()` which was too low-level and easy to misuse
+  https://github.com/o1-labs/o1js/pull/1485
+  - Also, rename the misleadingly named `Gadgets.isInRangeN()` to
+    `Gadgets.isDefinitelyInRangeN()`
+- Rename `Bool.Unsafe.ofField()` to `Bool.Unsafe.fromField()`
+  https://github.com/o1-labs/o1js/pull/1485
+- Replace the namespaced type exports `Gadgets.Field3` and
+  `Gadgets.ForeignField.Sum` with `Field3` and `ForeignFieldSum`
+  - Unfortunately, the namespace didn't play well with auto-imports in
+    TypeScript
+- Add `Gadgets.rangeCheck3x12()` and fix proof system bug that prevented it from
+  working https://github.com/o1-labs/o1js/pull/1534
+- Update transaction version and other bindings changes to ensure berkeley
+  compatibility https://github.com/o1-labs/o1js/pull/1542
 
 ### Added
 
-- `Provable.witnessAsync()` to introduce provable values from an async callback https://github.com/o1-labs/o1js/pull/1468
-- Internal benchmarking tooling to keep track of performance https://github.com/o1-labs/o1js/pull/1481
-- Add `toInput` method for `Group` instance https://github.com/o1-labs/o1js/pull/1483
+- `Provable.witnessAsync()` to introduce provable values from an async callback
+  https://github.com/o1-labs/o1js/pull/1468
+- Internal benchmarking tooling to keep track of performance
+  https://github.com/o1-labs/o1js/pull/1481
+- Add `toInput` method for `Group` instance
+  https://github.com/o1-labs/o1js/pull/1483
 
 ### Changed
 
-- `field.assertBool()` now also returns the `Field` as a `Bool` for ergonomics https://github.com/o1-labs/o1js/pull/1523
+- `field.assertBool()` now also returns the `Field` as a `Bool` for ergonomics
+  https://github.com/o1-labs/o1js/pull/1523
 
 ## [0.17.0](https://github.com/o1-labs/o1js/compare/1ad7333e9e...74948acac) - 2024-03-06
 
 ### Breaking changes
 
-- Fixed parity between `Mina.LocalBlockchain` and `Mina.Network` to have the same behaviors https://github.com/o1-labs/o1js/pull/1422 https://github.com/o1-labs/o1js/pull/1480
-  - Changed the `TransactionId` type to `Transaction`. Additionally added `PendingTransaction` and `RejectedTransaction` types to better represent the state of a transaction.
-  - `Transaction.safeSend()` and `PendingTransaction.safeWait()` are introduced to return a `IncludedTransaction` or `RejectedTransaction` object without throwing errors.
-  - `transaction.send()` throws an error if the transaction was not successful for both `Mina.LocalBlockchain` and `Mina.Network` and returns a `PendingTransaction` object if it was successful. Use `transaction.safeSend` to send a transaction that will not throw an error and either return a `PendingTransaction` or `RejectedTransaction`.
-  - `transaction.wait()` throws an error if the transaction was not successful for both `Mina.LocalBlockchain` and `Mina.Network` and returns a `IncludedTransaction` object if it was successful. Use `transaction.safeWait` to send a transaction that will not throw an error and either return a `IncludedTransaction` or `RejectedTransaction`.
-  - `transaction.hash()` is no longer a function, it is now a property that returns the hash of the transaction.
-  - Changed `Transaction.isSuccess` to `Transaction.status` to better represent the state of a transaction.
-- Improved efficiency of computing `AccountUpdate.callData` by packing field elements into as few field elements as possible https://github.com/o1-labs/o1js/pull/1458
-  - This leads to a large reduction in the number of constraints used when inputs to a zkApp method are many field elements (e.g. a long list of `Bool`s)
-- Return events in the `LocalBlockchain` in reverse chronological order (latest events at the beginning) to match the behavior of the `Network` https://github.com/o1-labs/o1js/pull/1460
+- Fixed parity between `Mina.LocalBlockchain` and `Mina.Network` to have the
+  same behaviors https://github.com/o1-labs/o1js/pull/1422
+  https://github.com/o1-labs/o1js/pull/1480
+  - Changed the `TransactionId` type to `Transaction`. Additionally added
+    `PendingTransaction` and `RejectedTransaction` types to better represent the
+    state of a transaction.
+  - `Transaction.safeSend()` and `PendingTransaction.safeWait()` are introduced
+    to return a `IncludedTransaction` or `RejectedTransaction` object without
+    throwing errors.
+  - `transaction.send()` throws an error if the transaction was not successful
+    for both `Mina.LocalBlockchain` and `Mina.Network` and returns a
+    `PendingTransaction` object if it was successful. Use `transaction.safeSend`
+    to send a transaction that will not throw an error and either return a
+    `PendingTransaction` or `RejectedTransaction`.
+  - `transaction.wait()` throws an error if the transaction was not successful
+    for both `Mina.LocalBlockchain` and `Mina.Network` and returns a
+    `IncludedTransaction` object if it was successful. Use
+    `transaction.safeWait` to send a transaction that will not throw an error
+    and either return a `IncludedTransaction` or `RejectedTransaction`.
+  - `transaction.hash()` is no longer a function, it is now a property that
+    returns the hash of the transaction.
+  - Changed `Transaction.isSuccess` to `Transaction.status` to better represent
+    the state of a transaction.
+- Improved efficiency of computing `AccountUpdate.callData` by packing field
+  elements into as few field elements as possible
+  https://github.com/o1-labs/o1js/pull/1458
+  - This leads to a large reduction in the number of constraints used when
+    inputs to a zkApp method are many field elements (e.g. a long list of
+    `Bool`s)
+- Return events in the `LocalBlockchain` in reverse chronological order (latest
+  events at the beginning) to match the behavior of the `Network`
+  https://github.com/o1-labs/o1js/pull/1460
 
 ### Added
 
-- Support for custom network identifiers other than `mainnet` or `testnet` https://github.com/o1-labs/o1js/pull/1444
-- `PrivateKey.randomKeypair()` to generate private and public key in one command https://github.com/o1-labs/o1js/pull/1446
-- `setNumberOfWorkers()` to allow developer to override the number of workers used during compilation and proof generation/verification https://github.com/o1-labs/o1js/pull/1456
+- Support for custom network identifiers other than `mainnet` or `testnet`
+  https://github.com/o1-labs/o1js/pull/1444
+- `PrivateKey.randomKeypair()` to generate private and public key in one command
+  https://github.com/o1-labs/o1js/pull/1446
+- `setNumberOfWorkers()` to allow developer to override the number of workers
+  used during compilation and proof generation/verification
+  https://github.com/o1-labs/o1js/pull/1456
 
 ### Changed
 
-- Improve all-around performance by reverting the Apple silicon workaround (https://github.com/o1-labs/o1js/pull/683) as the root problem is now fixed upstream https://github.com/o1-labs/o1js/pull/1456
-- Improved error message when trying to use `fetchActions`/`fetchEvents` with a missing Archive Node endpoint https://github.com/o1-labs/o1js/pull/1459
+- Improve all-around performance by reverting the Apple silicon workaround
+  (https://github.com/o1-labs/o1js/pull/683) as the root problem is now fixed
+  upstream https://github.com/o1-labs/o1js/pull/1456
+- Improved error message when trying to use `fetchActions`/`fetchEvents` with a
+  missing Archive Node endpoint https://github.com/o1-labs/o1js/pull/1459
 
 ### Deprecated
 
-- `SmartContract.token` is deprecated in favor of new methods on `TokenContract` https://github.com/o1-labs/o1js/pull/1446
+- `SmartContract.token` is deprecated in favor of new methods on `TokenContract`
+  https://github.com/o1-labs/o1js/pull/1446
   - `TokenContract.deriveTokenId()` to get the ID of the managed token
-  - `TokenContract.internal.{send, mint, burn}` to perform token operations from within the contract
+  - `TokenContract.internal.{send, mint, burn}` to perform token operations from
+    within the contract
 
 ### Fixed
 
-- Mitigate security hazard of deploying token contracts https://github.com/o1-labs/o1js/issues/1439
-- Make `Circuit` handle types with a `.provable` property (like those used in ECDSA) https://github.com/o1-labs/o1js/pull/1471
+- Mitigate security hazard of deploying token contracts
+  https://github.com/o1-labs/o1js/issues/1439
+- Make `Circuit` handle types with a `.provable` property (like those used in
+  ECDSA) https://github.com/o1-labs/o1js/pull/1471
   - To support offchain, non-Pickles proofs of ECDSA signatures
 
 ## [0.16.1](https://github.com/o1-labs/o1js/compare/834a44002...3b5f7c7)
 
 ### Breaking changes
 
-- Remove `AccountUpdate.children` and `AccountUpdate.parent` properties https://github.com/o1-labs/o1js/pull/1402
+- Remove `AccountUpdate.children` and `AccountUpdate.parent` properties
+  https://github.com/o1-labs/o1js/pull/1402
   - Also removes the optional `AccountUpdatesLayout` argument to `approve()`
-  - Adds `AccountUpdateTree` and `AccountUpdateForest`, new classes that represent a layout of account updates explicitly
+  - Adds `AccountUpdateTree` and `AccountUpdateForest`, new classes that
+    represent a layout of account updates explicitly
   - Both of the new types are now accepted as inputs to `approve()`
-  - `accountUpdate.extractTree()` to obtain the tree associated with an account update in the current transaction context.
+  - `accountUpdate.extractTree()` to obtain the tree associated with an account
+    update in the current transaction context.
 - Remove `Experimental.Callback` API https://github.com/o1-labs/o1js/pull/1430
 
 ### Added
 
-- `MerkleList<T>` to enable provable operations on a dynamically-sized list https://github.com/o1-labs/o1js/pull/1398
+- `MerkleList<T>` to enable provable operations on a dynamically-sized list
+  https://github.com/o1-labs/o1js/pull/1398
   - including `MerkleListIterator<T>` to iterate over a merkle list
-- `TokenContract`, a new base smart contract class for token contracts https://github.com/o1-labs/o1js/pull/1384
-  - Usage example: `https://github.com/o1-labs/o1js/blob/main/src/lib/mina/token/token-contract.unit-test.ts`
-- `TokenAccountUpdateIterator`, a primitive to iterate over all token account updates in a transaction https://github.com/o1-labs/o1js/pull/1398
+- `TokenContract`, a new base smart contract class for token contracts
+  https://github.com/o1-labs/o1js/pull/1384
+  - Usage example:
+    `https://github.com/o1-labs/o1js/blob/main/src/lib/mina/token/token-contract.unit-test.ts`
+- `TokenAccountUpdateIterator`, a primitive to iterate over all token account
+  updates in a transaction https://github.com/o1-labs/o1js/pull/1398
   - this is used to implement `TokenContract` under the hood
 
 ### Fixed
@@ -545,189 +845,287 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ### Breaking changes
 
-- Protocol change that adds a "transaction version" to the permission to set verification keys https://github.com/MinaProtocol/mina/pull/14407
-  - See [the relevant RFC](https://github.com/MinaProtocol/mina/blob/9577ad689a8e4d4f97e1d0fc3d26e20219f4abd1/rfcs/0051-verification-key-permissions.md) for the motivation behind this change
+- Protocol change that adds a "transaction version" to the permission to set
+  verification keys https://github.com/MinaProtocol/mina/pull/14407
+  - See
+    [the relevant RFC](https://github.com/MinaProtocol/mina/blob/9577ad689a8e4d4f97e1d0fc3d26e20219f4abd1/rfcs/0051-verification-key-permissions.md)
+    for the motivation behind this change
   - Breaks all deployed contracts, as it changes the account update layout
 
 ### Added
 
-- Provable type `Packed<T>` to pack small field elements into fewer field elements https://github.com/o1-labs/o1js/pull/1376
-- Provable type `Hashed<T>` to represent provable types by their hash https://github.com/o1-labs/o1js/pull/1377
-  - This also exposes `Poseidon.hashPacked()` to efficiently hash an arbitrary type
+- Provable type `Packed<T>` to pack small field elements into fewer field
+  elements https://github.com/o1-labs/o1js/pull/1376
+- Provable type `Hashed<T>` to represent provable types by their hash
+  https://github.com/o1-labs/o1js/pull/1377
+  - This also exposes `Poseidon.hashPacked()` to efficiently hash an arbitrary
+    type
 
 ### Changed
 
-- Reduce number of constraints of ECDSA verification by 5% https://github.com/o1-labs/o1js/pull/1376
+- Reduce number of constraints of ECDSA verification by 5%
+  https://github.com/o1-labs/o1js/pull/1376
 
 ## [0.15.4](https://github.com/o1-labs/o1js/compare/be748e42e...e5d1e0f)
 
 ### Changed
 
-- Improve performance of Wasm Poseidon hashing by a factor of 13x https://github.com/o1-labs/o1js/pull/1378
+- Improve performance of Wasm Poseidon hashing by a factor of 13x
+  https://github.com/o1-labs/o1js/pull/1378
   - Speeds up local blockchain tests without proving by ~40%
 - Improve performance of Field inverse https://github.com/o1-labs/o1js/pull/1373
   - Speeds up proving by ~2-4%
 
 ### Added
 
-- Configurable `networkId` when declaring a Mina instance. https://github.com/o1-labs/o1js/pull/1387
+- Configurable `networkId` when declaring a Mina instance.
+  https://github.com/o1-labs/o1js/pull/1387
   - Defaults to `"testnet"`, the other option is `"mainnet"`
-  - The `networkId` parameter influences the algorithm used for signatures, and ensures that testnet transactions can't be replayed on mainnet
+  - The `networkId` parameter influences the algorithm used for signatures, and
+    ensures that testnet transactions can't be replayed on mainnet
 
 ## [0.15.3](https://github.com/o1-labs/o1js/compare/1ad7333e9e...be748e42e)
 
 ### Added
 
-- **SHA256 hash function** exposed via `Hash.SHA2_256` or `Gadgets.SHA256`. https://github.com/o1-labs/o1js/pull/1285
+- **SHA256 hash function** exposed via `Hash.SHA2_256` or `Gadgets.SHA256`.
+  https://github.com/o1-labs/o1js/pull/1285
 
 ### Changed
 
-- `Mina.accountCreationFee()` is deprecated in favor of `Mina.getNetworkConstants().accountCreationFee`. https://github.com/o1-labs/o1js/pull/1367
+- `Mina.accountCreationFee()` is deprecated in favor of
+  `Mina.getNetworkConstants().accountCreationFee`.
+  https://github.com/o1-labs/o1js/pull/1367
   - `Mina.getNetworkConstants()` returns:
-    - [default](https://github.com/o1-labs/o1js/pull/1367/files#diff-ef2c3547d64a8eaa8253cd82b3623288f3271e14f1dc893a0a3ddc1ff4b9688fR7) network constants if used outside of the transaction scope.
-    - [actual](https://github.com/o1-labs/o1js/pull/1367/files#diff-437f2c15df7c90ad8154c5de1677ec0838d51859bcc0a0cefd8a0424b5736f31R1051) network constants if used within the transaction scope.
+    - [default](https://github.com/o1-labs/o1js/pull/1367/files#diff-ef2c3547d64a8eaa8253cd82b3623288f3271e14f1dc893a0a3ddc1ff4b9688fR7)
+      network constants if used outside of the transaction scope.
+    - [actual](https://github.com/o1-labs/o1js/pull/1367/files#diff-437f2c15df7c90ad8154c5de1677ec0838d51859bcc0a0cefd8a0424b5736f31R1051)
+      network constants if used within the transaction scope.
 
 ### Fixed
 
-- Fix approving of complex account update layouts https://github.com/o1-labs/o1js/pull/1364
+- Fix approving of complex account update layouts
+  https://github.com/o1-labs/o1js/pull/1364
 
 ## [0.15.2](https://github.com/o1-labs/o1js/compare/1ad7333e9e...08ba27329)
 
 ### Fixed
 
-- Fix bug in `Hash.hash()` which always resulted in an error https://github.com/o1-labs/o1js/pull/1346
+- Fix bug in `Hash.hash()` which always resulted in an error
+  https://github.com/o1-labs/o1js/pull/1346
 
 ## [0.15.1](https://github.com/o1-labs/o1js/compare/1ad7333e9e...19115a159)
 
 ### Breaking changes
 
-- Rename `Gadgets.rotate()` to `Gadgets.rotate64()` to better reflect the amount of bits the gadget operates on. https://github.com/o1-labs/o1js/pull/1259
-- Rename `Gadgets.{leftShift(), rightShift()}` to `Gadgets.{leftShift64(), rightShift64()}` to better reflect the amount of bits the gadget operates on. https://github.com/o1-labs/o1js/pull/1259
+- Rename `Gadgets.rotate()` to `Gadgets.rotate64()` to better reflect the amount
+  of bits the gadget operates on. https://github.com/o1-labs/o1js/pull/1259
+- Rename `Gadgets.{leftShift(), rightShift()}` to
+  `Gadgets.{leftShift64(), rightShift64()}` to better reflect the amount of bits
+  the gadget operates on. https://github.com/o1-labs/o1js/pull/1259
 
 ### Added
 
-- Non-native elliptic curve operations exposed through `createForeignCurve()` class factory https://github.com/o1-labs/o1js/pull/1007
-- **ECDSA signature verification** exposed through `createEcdsa()` class factory https://github.com/o1-labs/o1js/pull/1240 https://github.com/o1-labs/o1js/pull/1007 https://github.com/o1-labs/o1js/pull/1307
+- Non-native elliptic curve operations exposed through `createForeignCurve()`
+  class factory https://github.com/o1-labs/o1js/pull/1007
+- **ECDSA signature verification** exposed through `createEcdsa()` class factory
+  https://github.com/o1-labs/o1js/pull/1240
+  https://github.com/o1-labs/o1js/pull/1007
+  https://github.com/o1-labs/o1js/pull/1307
   - For an example, see `./src/examples/crypto/ecdsa`
-- **Keccak/SHA3 hash function** exposed on `Keccak` namespace https://github.com/o1-labs/o1js/pull/1291
-- `Hash` namespace which holds all hash functions https://github.com/o1-labs/o1js/pull/999
-  - `Bytes`, provable type to hold a byte array, which serves as input and output for Keccak variants
-  - `UInt8`, provable type to hold a single byte, which is constrained to be in the 0 to 255 range
-- `Gadgets.rotate32()` for rotation over 32 bit values https://github.com/o1-labs/o1js/pull/1259
-- `Gadgets.leftShift32()` for left shift over 32 bit values https://github.com/o1-labs/o1js/pull/1259
-- `Gadgets.divMod32()` division modulo 2^32 that returns the remainder and quotient of the operation https://github.com/o1-labs/o1js/pull/1259
-- `Gadgets.rangeCheck32()` range check for 32 bit values https://github.com/o1-labs/o1js/pull/1259
-- `Gadgets.addMod32()` addition modulo 2^32 https://github.com/o1-labs/o1js/pull/1259
-- Expose new bitwise gadgets on `UInt32` and `UInt64` https://github.com/o1-labs/o1js/pull/1259
+- **Keccak/SHA3 hash function** exposed on `Keccak` namespace
+  https://github.com/o1-labs/o1js/pull/1291
+- `Hash` namespace which holds all hash functions
+  https://github.com/o1-labs/o1js/pull/999
+  - `Bytes`, provable type to hold a byte array, which serves as input and
+    output for Keccak variants
+  - `UInt8`, provable type to hold a single byte, which is constrained to be in
+    the 0 to 255 range
+- `Gadgets.rotate32()` for rotation over 32 bit values
+  https://github.com/o1-labs/o1js/pull/1259
+- `Gadgets.leftShift32()` for left shift over 32 bit values
+  https://github.com/o1-labs/o1js/pull/1259
+- `Gadgets.divMod32()` division modulo 2^32 that returns the remainder and
+  quotient of the operation https://github.com/o1-labs/o1js/pull/1259
+- `Gadgets.rangeCheck32()` range check for 32 bit values
+  https://github.com/o1-labs/o1js/pull/1259
+- `Gadgets.addMod32()` addition modulo 2^32
+  https://github.com/o1-labs/o1js/pull/1259
+- Expose new bitwise gadgets on `UInt32` and `UInt64`
+  https://github.com/o1-labs/o1js/pull/1259
   - bitwise XOR via `{UInt32, UInt64}.xor()`
   - bitwise NOT via `{UInt32, UInt64}.not()`
   - bitwise ROTATE via `{UInt32, UInt64}.rotate()`
   - bitwise LEFTSHIFT via `{UInt32, UInt64}.leftShift()`
   - bitwise RIGHTSHIFT via `{UInt32, UInt64}.rightShift()`
   - bitwise AND via `{UInt32, UInt64}.and()`
-- Example for using actions to store a map data structure https://github.com/o1-labs/o1js/pull/1300
-- `Provable.constraintSystem()` and `{ZkProgram,SmartContract}.analyzeMethods()` return a `summary()` method to return a summary of the constraints used by a method https://github.com/o1-labs/o1js/pull/1007
-- `assert()` asserts that a given statement is true https://github.com/o1-labs/o1js/pull/1285
+- Example for using actions to store a map data structure
+  https://github.com/o1-labs/o1js/pull/1300
+- `Provable.constraintSystem()` and `{ZkProgram,SmartContract}.analyzeMethods()`
+  return a `summary()` method to return a summary of the constraints used by a
+  method https://github.com/o1-labs/o1js/pull/1007
+- `assert()` asserts that a given statement is true
+  https://github.com/o1-labs/o1js/pull/1285
 
 ### Fixed
 
-- Fix stack overflows when calling provable methods with large inputs https://github.com/o1-labs/o1js/pull/1334
-- Fix `Local.setProofsEnabled()` which would not get picked up by `deploy()` https://github.com/o1-labs/o1js/pull/1330
-- Remove usage of private class fields in core types like `Field`, for better type compatibility between different o1js versions https://github.com/o1-labs/o1js/pull/1319
+- Fix stack overflows when calling provable methods with large inputs
+  https://github.com/o1-labs/o1js/pull/1334
+- Fix `Local.setProofsEnabled()` which would not get picked up by `deploy()`
+  https://github.com/o1-labs/o1js/pull/1330
+- Remove usage of private class fields in core types like `Field`, for better
+  type compatibility between different o1js versions
+  https://github.com/o1-labs/o1js/pull/1319
 
 ## [0.15.0](https://github.com/o1-labs/o1js/compare/1ad7333e9e...7acf19d0d)
 
 ### Breaking changes
 
-- `ZkProgram.compile()` now returns the verification key and its hash, to be consistent with `SmartContract.compile()` https://github.com/o1-labs/o1js/pull/1292 [@rpanic](https://github.com/rpanic)
+- `ZkProgram.compile()` now returns the verification key and its hash, to be
+  consistent with `SmartContract.compile()`
+  https://github.com/o1-labs/o1js/pull/1292 [@rpanic](https://github.com/rpanic)
 
 ### Added
 
-- **Foreign field arithmetic** exposed through the `createForeignField()` class factory https://github.com/o1-labs/snarkyjs/pull/985
-- `Crypto` namespace which exposes elliptic curve and finite field arithmetic on bigints, as well as example curve parameters https://github.com/o1-labs/o1js/pull/1240
-- `Gadgets.ForeignField.assertMul()` for efficiently constraining products of sums in non-native arithmetic https://github.com/o1-labs/o1js/pull/1262
-- `Unconstrained` for safely maintaining unconstrained values in provable code https://github.com/o1-labs/o1js/pull/1262
-- `Gadgets.rangeCheck8()` to assert that a value fits in 8 bits https://github.com/o1-labs/o1js/pull/1288
+- **Foreign field arithmetic** exposed through the `createForeignField()` class
+  factory https://github.com/o1-labs/snarkyjs/pull/985
+- `Crypto` namespace which exposes elliptic curve and finite field arithmetic on
+  bigints, as well as example curve parameters
+  https://github.com/o1-labs/o1js/pull/1240
+- `Gadgets.ForeignField.assertMul()` for efficiently constraining products of
+  sums in non-native arithmetic https://github.com/o1-labs/o1js/pull/1262
+- `Unconstrained` for safely maintaining unconstrained values in provable code
+  https://github.com/o1-labs/o1js/pull/1262
+- `Gadgets.rangeCheck8()` to assert that a value fits in 8 bits
+  https://github.com/o1-labs/o1js/pull/1288
 
 ### Changed
 
-- Change precondition APIs to use "require" instead of "assert" as the verb, to distinguish them from provable assertions. [@LuffySama-Dev](https://github.com/LuffySama-Dev)
-  - `this.x.getAndAssertEquals()` is now `this.x.getAndRequireEquals()` https://github.com/o1-labs/o1js/pull/1263
-  - `this.x.assertEquals(x)` is now `this.x.requireEquals(x)` https://github.com/o1-labs/o1js/pull/1263
-  - `this.account.x.getAndAssertEquals(x)` is now `this.account.x.requireEquals(x)` https://github.com/o1-labs/o1js/pull/1265
-  - `this.account.x.assertBetween()` is now `this.account.x.requireBetween()` https://github.com/o1-labs/o1js/pull/1265
-  - `this.network.x.getAndAssertEquals()` is now `this.network.x.getAndRequireEquals()` https://github.com/o1-labs/o1js/pull/1265
-- `Provable.constraintSystem()` and `{ZkProgram,SmartContract}.analyzeMethods()` return a `print()` method for pretty-printing the constraint system https://github.com/o1-labs/o1js/pull/1240
+- Change precondition APIs to use "require" instead of "assert" as the verb, to
+  distinguish them from provable assertions.
+  [@LuffySama-Dev](https://github.com/LuffySama-Dev)
+  - `this.x.getAndAssertEquals()` is now `this.x.getAndRequireEquals()`
+    https://github.com/o1-labs/o1js/pull/1263
+  - `this.x.assertEquals(x)` is now `this.x.requireEquals(x)`
+    https://github.com/o1-labs/o1js/pull/1263
+  - `this.account.x.getAndAssertEquals(x)` is now
+    `this.account.x.requireEquals(x)` https://github.com/o1-labs/o1js/pull/1265
+  - `this.account.x.assertBetween()` is now `this.account.x.requireBetween()`
+    https://github.com/o1-labs/o1js/pull/1265
+  - `this.network.x.getAndAssertEquals()` is now
+    `this.network.x.getAndRequireEquals()`
+    https://github.com/o1-labs/o1js/pull/1265
+- `Provable.constraintSystem()` and `{ZkProgram,SmartContract}.analyzeMethods()`
+  return a `print()` method for pretty-printing the constraint system
+  https://github.com/o1-labs/o1js/pull/1240
 
 ### Fixed
 
-- Fix missing recursive verification of proofs in smart contracts https://github.com/o1-labs/o1js/pull/1302
+- Fix missing recursive verification of proofs in smart contracts
+  https://github.com/o1-labs/o1js/pull/1302
 
 ## [0.14.2](https://github.com/o1-labs/o1js/compare/26363465d...1ad7333e9e)
 
 ### Breaking changes
 
-- Change return signature of `ZkProgram.analyzeMethods()` to be a keyed object https://github.com/o1-labs/o1js/pull/1223
+- Change return signature of `ZkProgram.analyzeMethods()` to be a keyed object
+  https://github.com/o1-labs/o1js/pull/1223
 
 ### Added
 
 - Provable non-native field arithmetic:
-  - `Gadgets.ForeignField.{add, sub, sumchain}()` for addition and subtraction https://github.com/o1-labs/o1js/pull/1220
-  - `Gadgets.ForeignField.{mul, inv, div}()` for multiplication and division https://github.com/o1-labs/o1js/pull/1223
-- Comprehensive internal testing of constraint system layouts generated by new gadgets https://github.com/o1-labs/o1js/pull/1241 https://github.com/o1-labs/o1js/pull/1220
+  - `Gadgets.ForeignField.{add, sub, sumchain}()` for addition and subtraction
+    https://github.com/o1-labs/o1js/pull/1220
+  - `Gadgets.ForeignField.{mul, inv, div}()` for multiplication and division
+    https://github.com/o1-labs/o1js/pull/1223
+- Comprehensive internal testing of constraint system layouts generated by new
+  gadgets https://github.com/o1-labs/o1js/pull/1241
+  https://github.com/o1-labs/o1js/pull/1220
 
 ### Changed
 
-- `Lightnet` namespace API updates with added `listAcquiredKeyPairs()` method https://github.com/o1-labs/o1js/pull/1256
-- Expose raw provable methods of a `ZkProgram` on `zkProgram.rawMethods` https://github.com/o1-labs/o1js/pull/1241
-- Reduce number of constraints needed by `rotate()`, `leftShift()` and, `rightShift()` gadgets https://github.com/o1-labs/o1js/pull/1201
+- `Lightnet` namespace API updates with added `listAcquiredKeyPairs()` method
+  https://github.com/o1-labs/o1js/pull/1256
+- Expose raw provable methods of a `ZkProgram` on `zkProgram.rawMethods`
+  https://github.com/o1-labs/o1js/pull/1241
+- Reduce number of constraints needed by `rotate()`, `leftShift()` and,
+  `rightShift()` gadgets https://github.com/o1-labs/o1js/pull/1201
 
 ### Fixed
 
-- Add a parameter to `checkZkappTransaction` for block length to check for transaction inclusion. This fixes a case where `Transaction.wait()` only checked the latest block, which led to an error once the transaction was included in a block that was not the latest. https://github.com/o1-labs/o1js/pull/1239
+- Add a parameter to `checkZkappTransaction` for block length to check for
+  transaction inclusion. This fixes a case where `Transaction.wait()` only
+  checked the latest block, which led to an error once the transaction was
+  included in a block that was not the latest.
+  https://github.com/o1-labs/o1js/pull/1239
 
 ## [0.14.1](https://github.com/o1-labs/o1js/compare/e8e7510e1...26363465d)
 
 ### Added
 
-- `Gadgets.not()`, new provable method to support bitwise not. https://github.com/o1-labs/o1js/pull/1198
-- `Gadgets.leftShift() / Gadgets.rightShift()`, new provable methods to support bitwise shifting. https://github.com/o1-labs/o1js/pull/1194
-- `Gadgets.and()`, new provable method to support bitwise and. https://github.com/o1-labs/o1js/pull/1193
-- `Gadgets.multiRangeCheck()` and `Gadgets.compactMultiRangeCheck()`, two building blocks for non-native arithmetic with bigints of size up to 264 bits. https://github.com/o1-labs/o1js/pull/1216
+- `Gadgets.not()`, new provable method to support bitwise not.
+  https://github.com/o1-labs/o1js/pull/1198
+- `Gadgets.leftShift() / Gadgets.rightShift()`, new provable methods to support
+  bitwise shifting. https://github.com/o1-labs/o1js/pull/1194
+- `Gadgets.and()`, new provable method to support bitwise and.
+  https://github.com/o1-labs/o1js/pull/1193
+- `Gadgets.multiRangeCheck()` and `Gadgets.compactMultiRangeCheck()`, two
+  building blocks for non-native arithmetic with bigints of size up to 264 bits.
+  https://github.com/o1-labs/o1js/pull/1216
 
 ### Fixed
 
-- Removed array reversal of fetched actions, since they are returned in the correct order. https://github.com/o1-labs/o1js/pull/1258
+- Removed array reversal of fetched actions, since they are returned in the
+  correct order. https://github.com/o1-labs/o1js/pull/1258
 
 ## [0.14.0](https://github.com/o1-labs/o1js/compare/045faa7...e8e7510e1)
 
 ### Breaking changes
 
-- Constraint optimizations in Field methods and core crypto changes break all verification keys https://github.com/o1-labs/o1js/pull/1171 https://github.com/o1-labs/o1js/pull/1178
+- Constraint optimizations in Field methods and core crypto changes break all
+  verification keys https://github.com/o1-labs/o1js/pull/1171
+  https://github.com/o1-labs/o1js/pull/1178
 
 ### Changed
 
-- `ZkProgram` has moved out of the `Experimental` namespace and is now available as a top-level import directly. `Experimental.ZkProgram` has been deprecated.
-- `ZkProgram` gets a new input argument `name: string` which is required in the non-experimental API. The name is used to identify a ZkProgram when caching prover keys. https://github.com/o1-labs/o1js/pull/1200
+- `ZkProgram` has moved out of the `Experimental` namespace and is now available
+  as a top-level import directly. `Experimental.ZkProgram` has been deprecated.
+- `ZkProgram` gets a new input argument `name: string` which is required in the
+  non-experimental API. The name is used to identify a ZkProgram when caching
+  prover keys. https://github.com/o1-labs/o1js/pull/1200
 
 ### Added
 
-- `Lightnet` namespace to interact with the account manager provided by the [lightnet Mina network](https://hub.docker.com/r/o1labs/mina-local-network) https://github.com/o1-labs/o1js/pull/1167
-- Internal support for several custom gates (range check, bitwise operations, foreign field operations) and lookup tables https://github.com/o1-labs/o1js/pull/1176
-- `Gadgets.rangeCheck64()`, new provable method to do efficient 64-bit range checks using lookup tables https://github.com/o1-labs/o1js/pull/1181
-- `Gadgets.rotate()`, new provable method to support bitwise rotation for native field elements. https://github.com/o1-labs/o1js/pull/1182
-- `Gadgets.xor()`, new provable method to support bitwise xor for native field elements. https://github.com/o1-labs/o1js/pull/1177
-- `Proof.dummy()` to create dummy proofs https://github.com/o1-labs/o1js/pull/1188
-  - You can use this to write ZkPrograms that handle the base case and the inductive case in the same method.
+- `Lightnet` namespace to interact with the account manager provided by the
+  [lightnet Mina network](https://hub.docker.com/r/o1labs/mina-local-network)
+  https://github.com/o1-labs/o1js/pull/1167
+- Internal support for several custom gates (range check, bitwise operations,
+  foreign field operations) and lookup tables
+  https://github.com/o1-labs/o1js/pull/1176
+- `Gadgets.rangeCheck64()`, new provable method to do efficient 64-bit range
+  checks using lookup tables https://github.com/o1-labs/o1js/pull/1181
+- `Gadgets.rotate()`, new provable method to support bitwise rotation for native
+  field elements. https://github.com/o1-labs/o1js/pull/1182
+- `Gadgets.xor()`, new provable method to support bitwise xor for native field
+  elements. https://github.com/o1-labs/o1js/pull/1177
+- `Proof.dummy()` to create dummy proofs
+  https://github.com/o1-labs/o1js/pull/1188
+  - You can use this to write ZkPrograms that handle the base case and the
+    inductive case in the same method.
 
 ### Changed
 
-- Use cached prover keys in `compile()` when running in Node.js https://github.com/o1-labs/o1js/pull/1187
-  - Caching is configurable by passing a custom `Cache` (new export) to `compile()`
-  - By default, prover keys are stored in an OS-dependent cache directory; `~/.cache/pickles` on Mac and Linux
-- Use cached setup points (SRS and Lagrange bases) when running in Node.js https://github.com/o1-labs/o1js/pull/1197
+- Use cached prover keys in `compile()` when running in Node.js
+  https://github.com/o1-labs/o1js/pull/1187
+  - Caching is configurable by passing a custom `Cache` (new export) to
+    `compile()`
+  - By default, prover keys are stored in an OS-dependent cache directory;
+    `~/.cache/pickles` on Mac and Linux
+- Use cached setup points (SRS and Lagrange bases) when running in Node.js
+  https://github.com/o1-labs/o1js/pull/1197
   - Also, speed up SRS generation by using multiple threads
-  - Together with caching of prover keys, this speeds up compilation time by roughly
+  - Together with caching of prover keys, this speeds up compilation time by
+    roughly
     - **86%** when everything is cached
     - **34%** when nothing is cached
 
@@ -735,53 +1133,70 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ### Breaking changes
 
-- Changes to some verification keys caused by changing the way `Struct` orders object properties. https://github.com/o1-labs/o1js/pull/1124 [@Comdex](https://github.com/Comdex)
-  - To recover existing verification keys and behavior, change the order of properties in your Struct definitions to be alphabetical
+- Changes to some verification keys caused by changing the way `Struct` orders
+  object properties. https://github.com/o1-labs/o1js/pull/1124
+  [@Comdex](https://github.com/Comdex)
+  - To recover existing verification keys and behavior, change the order of
+    properties in your Struct definitions to be alphabetical
   - The `customObjectKeys` option is removed from `Struct`
 
 ### Changed
 
 - Improve prover performance by ~25% https://github.com/o1-labs/o1js/pull/1092
-  - Change internal representation of field elements to be JS bigint instead of Uint8Array
+  - Change internal representation of field elements to be JS bigint instead of
+    Uint8Array
 - Consolidate internal framework for testing equivalence of two implementations
 
 ## [0.13.0](https://github.com/o1-labs/o1js/compare/fbd4b2717...c2f392fe5)
 
 ### Breaking changes
 
-- Changes to verification keys caused by updates to the proof system. This breaks all deployed contracts https://github.com/o1-labs/o1js/pull/1016
+- Changes to verification keys caused by updates to the proof system. This
+  breaks all deployed contracts https://github.com/o1-labs/o1js/pull/1016
 
 ## [0.12.2](https://github.com/o1-labs/o1js/compare/b1d8d5910...fbd4b2717)
 
 ### Changed
 
 - Renamed SnarkyJS to o1js https://github.com/o1-labs/o1js/pull/1104
-- Reduce loading time of the library by 3-4x https://github.com/o1-labs/o1js/pull/1073
-- Improve error when forgetting `transaction.prove()` https://github.com/o1-labs/o1js/pull/1095
+- Reduce loading time of the library by 3-4x
+  https://github.com/o1-labs/o1js/pull/1073
+- Improve error when forgetting `transaction.prove()`
+  https://github.com/o1-labs/o1js/pull/1095
 
 ## [0.12.1](https://github.com/o1-labs/o1js/compare/161b69d602...b1d8d5910)
 
 ### Added
 
-- Added a method `createTestNullifier` to the Nullifier class for testing purposes. It is recommended to use mina-signer to create Nullifiers in production, since it does not leak the private key of the user. The `Nullifier.createTestNullifier` method requires the private key as an input _outside of the users wallet_. https://github.com/o1-labs/o1js/pull/1026
-- Added `field.isEven` to check if a Field element is odd or even. https://github.com/o1-labs/o1js/pull/1026
+- Added a method `createTestNullifier` to the Nullifier class for testing
+  purposes. It is recommended to use mina-signer to create Nullifiers in
+  production, since it does not leak the private key of the user. The
+  `Nullifier.createTestNullifier` method requires the private key as an input
+  _outside of the users wallet_. https://github.com/o1-labs/o1js/pull/1026
+- Added `field.isEven` to check if a Field element is odd or even.
+  https://github.com/o1-labs/o1js/pull/1026
 
 ### Fixed
 
-- Revert verification key hash change from previous release to stay compatible with the current testnet https://github.com/o1-labs/o1js/pull/1032
+- Revert verification key hash change from previous release to stay compatible
+  with the current testnet https://github.com/o1-labs/o1js/pull/1032
 
 ## [0.12.0](https://github.com/o1-labs/o1js/compare/eaa39dca0...161b69d602)
 
 ### Breaking Changes
 
-- Fix the default verification key hash that was generated for AccountUpdates. This change adopts the default mechanism provided by Mina Protocol https://github.com/o1-labs/o1js/pull/1021
-  - Please be aware that this alteration results in a breaking change affecting the verification key of already deployed contracts.
+- Fix the default verification key hash that was generated for AccountUpdates.
+  This change adopts the default mechanism provided by Mina Protocol
+  https://github.com/o1-labs/o1js/pull/1021
+  - Please be aware that this alteration results in a breaking change affecting
+    the verification key of already deployed contracts.
 
 ## [0.11.4](https://github.com/o1-labs/o1js/compare/544489609...eaa39dca0)
 
 ### Fixed
 
-- NodeJS error caused by invalid import https://github.com/o1-labs/o1js/issues/1012
+- NodeJS error caused by invalid import
+  https://github.com/o1-labs/o1js/issues/1012
 
 ## [0.11.3](https://github.com/o1-labs/o1js/compare/2d2af219c...544489609)
 
@@ -799,279 +1214,453 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ### Breaking changes
 
-- `Group` operations now generate a different set of constraints. This breaks deployed contracts, because the circuit changed. https://github.com/o1-labs/o1js/pull/967
+- `Group` operations now generate a different set of constraints. This breaks
+  deployed contracts, because the circuit changed.
+  https://github.com/o1-labs/o1js/pull/967
 
 ### Added
 
-- Implemented `Nullifier` as a new primitive https://github.com/o1-labs/o1js/pull/882
-  - mina-signer can now be used to generate a Nullifier, which can be consumed by zkApps using the newly added Nullifier Struct
+- Implemented `Nullifier` as a new primitive
+  https://github.com/o1-labs/o1js/pull/882
+  - mina-signer can now be used to generate a Nullifier, which can be consumed
+    by zkApps using the newly added Nullifier Struct
 
 ### Changed
 
-- Improve error message `Can't evaluate prover code outside an as_prover block` https://github.com/o1-labs/o1js/pull/998
+- Improve error message `Can't evaluate prover code outside an as_prover block`
+  https://github.com/o1-labs/o1js/pull/998
 
 ### Fixed
 
-- Fix unsupported use of `window` when running o1js in workers https://github.com/o1-labs/o1js/pull/1002
+- Fix unsupported use of `window` when running o1js in workers
+  https://github.com/o1-labs/o1js/pull/1002
 
 ## [0.11.0](https://github.com/o1-labs/o1js/compare/a632313a...3fbd9678e)
 
 ### Breaking changes
 
-- Rewrite of `Provable.if()` causes breaking changes to all deployed contracts https://github.com/o1-labs/o1js/pull/889
-- Remove all deprecated methods and properties on `Field` https://github.com/o1-labs/o1js/pull/902
-- The `Field(x)` constructor and other Field methods no longer accept a `boolean` as input. Instead, you can now pass in a `bigint` to all Field methods. https://github.com/o1-labs/o1js/pull/902
-- Remove redundant `signFeePayer()` method https://github.com/o1-labs/o1js/pull/935
+- Rewrite of `Provable.if()` causes breaking changes to all deployed contracts
+  https://github.com/o1-labs/o1js/pull/889
+- Remove all deprecated methods and properties on `Field`
+  https://github.com/o1-labs/o1js/pull/902
+- The `Field(x)` constructor and other Field methods no longer accept a
+  `boolean` as input. Instead, you can now pass in a `bigint` to all Field
+  methods. https://github.com/o1-labs/o1js/pull/902
+- Remove redundant `signFeePayer()` method
+  https://github.com/o1-labs/o1js/pull/935
 
 ### Added
 
-- Add `field.assertNotEquals()` to assert that a field element does not equal some value https://github.com/o1-labs/o1js/pull/902
+- Add `field.assertNotEquals()` to assert that a field element does not equal
+  some value https://github.com/o1-labs/o1js/pull/902
   - More efficient than `field.equals(x).assertFalse()`
-- Add `scalar.toConstant()`, `scalar.toBigInt()`, `Scalar.from()`, `privateKey.toBigInt()`, `PrivateKey.fromBigInt()` https://github.com/o1-labs/o1js/pull/935
-- `Poseidon.hashToGroup` enables hashing to a group https://github.com/o1-labs/o1js/pull/887
+- Add `scalar.toConstant()`, `scalar.toBigInt()`, `Scalar.from()`,
+  `privateKey.toBigInt()`, `PrivateKey.fromBigInt()`
+  https://github.com/o1-labs/o1js/pull/935
+- `Poseidon.hashToGroup` enables hashing to a group
+  https://github.com/o1-labs/o1js/pull/887
 
 ### Changed
 
 - **Make stack traces more readable** https://github.com/o1-labs/o1js/pull/890
-  - Stack traces thrown from o1js are cleaned up by filtering out unnecessary lines and other noisy details
-- Remove optional `zkappKey` argument in `smartContract.init()`, and instead assert that `provedState` is false when `init()` is called https://github.com/o1-labs/o1js/pull/908
-- Improve assertion error messages on `Field` methods https://github.com/o1-labs/o1js/issues/743 https://github.com/o1-labs/o1js/pull/902
-- Publicly expose the internal details of the `Field` type https://github.com/o1-labs/o1js/pull/902
+  - Stack traces thrown from o1js are cleaned up by filtering out unnecessary
+    lines and other noisy details
+- Remove optional `zkappKey` argument in `smartContract.init()`, and instead
+  assert that `provedState` is false when `init()` is called
+  https://github.com/o1-labs/o1js/pull/908
+- Improve assertion error messages on `Field` methods
+  https://github.com/o1-labs/o1js/issues/743
+  https://github.com/o1-labs/o1js/pull/902
+- Publicly expose the internal details of the `Field` type
+  https://github.com/o1-labs/o1js/pull/902
 
 ### Deprecated
 
-- Utility methods on `Circuit` are deprecated in favor of the same methods on `Provable` https://github.com/o1-labs/o1js/pull/889
-  - `Circuit.if()`, `Circuit.witness()`, `Circuit.log()` and others replaced by `Provable.if()`, `Provable.witness()`, `Provable.log()`
+- Utility methods on `Circuit` are deprecated in favor of the same methods on
+  `Provable` https://github.com/o1-labs/o1js/pull/889
+  - `Circuit.if()`, `Circuit.witness()`, `Circuit.log()` and others replaced by
+    `Provable.if()`, `Provable.witness()`, `Provable.log()`
   - Under the hood, some of these methods were rewritten in TypeScript
 - Deprecate `field.isZero()` https://github.com/o1-labs/o1js/pull/902
 
 ### Fixed
 
-- Fix running o1js in Node.js on Windows https://github.com/o1-labs/o1js-bindings/pull/19 [@wizicer](https://github.com/wizicer)
-- Fix error reporting from GraphQL requests https://github.com/o1-labs/o1js/pull/919
-- Resolved an `Out of Memory error` experienced on iOS devices (iPhones and iPads) during the initialization of the WASM memory https://github.com/o1-labs/o1js-bindings/pull/26
-- Fix `field.greaterThan()` and other comparison methods outside provable code https://github.com/o1-labs/o1js/issues/858 https://github.com/o1-labs/o1js/pull/902
-- Fix `field.assertBool()` https://github.com/o1-labs/o1js/issues/469 https://github.com/o1-labs/o1js/pull/902
-- Fix `Field(bigint)` where `bigint` is larger than the field modulus https://github.com/o1-labs/o1js/issues/432 https://github.com/o1-labs/o1js/pull/902
+- Fix running o1js in Node.js on Windows
+  https://github.com/o1-labs/o1js-bindings/pull/19
+  [@wizicer](https://github.com/wizicer)
+- Fix error reporting from GraphQL requests
+  https://github.com/o1-labs/o1js/pull/919
+- Resolved an `Out of Memory error` experienced on iOS devices (iPhones and
+  iPads) during the initialization of the WASM memory
+  https://github.com/o1-labs/o1js-bindings/pull/26
+- Fix `field.greaterThan()` and other comparison methods outside provable code
+  https://github.com/o1-labs/o1js/issues/858
+  https://github.com/o1-labs/o1js/pull/902
+- Fix `field.assertBool()` https://github.com/o1-labs/o1js/issues/469
+  https://github.com/o1-labs/o1js/pull/902
+- Fix `Field(bigint)` where `bigint` is larger than the field modulus
+  https://github.com/o1-labs/o1js/issues/432
+  https://github.com/o1-labs/o1js/pull/902
   - The new behaviour is to use the modular residual of the input
-- No longer fail on missing signature in `tx.send()`. This fixes the flow of deploying a zkApp from a UI via a wallet https://github.com/o1-labs/o1js/pull/931 [@marekyggdrasil](https://github.com/marekyggdrasil)
+- No longer fail on missing signature in `tx.send()`. This fixes the flow of
+  deploying a zkApp from a UI via a wallet
+  https://github.com/o1-labs/o1js/pull/931
+  [@marekyggdrasil](https://github.com/marekyggdrasil)
 
 ## [0.10.1](https://github.com/o1-labs/o1js/compare/bcc666f2...a632313a)
 
 ### Changed
 
-- Allow ZkPrograms to return their public output https://github.com/o1-labs/o1js/pull/874 https://github.com/o1-labs/o1js/pull/876
-  - new option `ZkProgram({ publicOutput?: Provable<any>, ... })`; `publicOutput` has to match the _return type_ of all ZkProgram methods.
-  - the `publicInput` option becomes optional; if not provided, methods no longer expect the public input as first argument
-  - full usage example: https://github.com/o1-labs/o1js/blob/f95cf2903e97292df9e703b74ee1fc3825df826d/src/examples/program.ts
+- Allow ZkPrograms to return their public output
+  https://github.com/o1-labs/o1js/pull/874
+  https://github.com/o1-labs/o1js/pull/876
+  - new option `ZkProgram({ publicOutput?: Provable<any>, ... })`;
+    `publicOutput` has to match the _return type_ of all ZkProgram methods.
+  - the `publicInput` option becomes optional; if not provided, methods no
+    longer expect the public input as first argument
+  - full usage example:
+    https://github.com/o1-labs/o1js/blob/f95cf2903e97292df9e703b74ee1fc3825df826d/src/examples/program.ts
 
 ## [0.10.0](https://github.com/o1-labs/o1js/compare/97e393ed...bcc666f2)
 
 ### Breaking Changes
 
-- All references to `actionsHash` are renamed to `actionState` to better mirror what is used in Mina protocol APIs https://github.com/o1-labs/o1js/pull/833
-  - This change affects function parameters and returned object keys throughout the API
-- No longer make `MayUseToken.InheritFromParent` the default `mayUseToken` value on the caller if one zkApp method calls another one; this removes the need to manually override `mayUseToken` in several known cases https://github.com/o1-labs/o1js/pull/863
-  - Causes a breaking change to the verification key of deployed contracts that use zkApp composability
+- All references to `actionsHash` are renamed to `actionState` to better mirror
+  what is used in Mina protocol APIs https://github.com/o1-labs/o1js/pull/833
+  - This change affects function parameters and returned object keys throughout
+    the API
+- No longer make `MayUseToken.InheritFromParent` the default `mayUseToken` value
+  on the caller if one zkApp method calls another one; this removes the need to
+  manually override `mayUseToken` in several known cases
+  https://github.com/o1-labs/o1js/pull/863
+  - Causes a breaking change to the verification key of deployed contracts that
+    use zkApp composability
 
 ### Added
 
-- `this.state.getAndAssertEquals()` as a shortcut for `let x = this.state.get(); this.state.assertEquals(x);` https://github.com/o1-labs/o1js/pull/863
-  - also added `.getAndAssertEquals()` on `this.account` and `this.network` fields
-- Support for fallback endpoints when making network requests, allowing users to provide an array of endpoints for GraphQL network requests. https://github.com/o1-labs/o1js/pull/871
-  - Endpoints are fetched two at a time, and the result returned from the faster response
-- `reducer.forEach(actions, ...)` as a shortcut for `reducer.reduce()` when you don't need a `state` https://github.com/o1-labs/o1js/pull/863
-- New export `TokenId` which supersedes `Token.Id`; `TokenId.deriveId()` replaces `Token.Id.getId()` https://github.com/o1-labs/o1js/pull/863
-- Add `Permissions.allImpossible()` for the set of permissions where nothing is allowed (more convenient than `Permissions.default()` when you want to make most actions impossible) https://github.com/o1-labs/o1js/pull/863
+- `this.state.getAndAssertEquals()` as a shortcut for
+  `let x = this.state.get(); this.state.assertEquals(x);`
+  https://github.com/o1-labs/o1js/pull/863
+  - also added `.getAndAssertEquals()` on `this.account` and `this.network`
+    fields
+- Support for fallback endpoints when making network requests, allowing users to
+  provide an array of endpoints for GraphQL network requests.
+  https://github.com/o1-labs/o1js/pull/871
+  - Endpoints are fetched two at a time, and the result returned from the faster
+    response
+- `reducer.forEach(actions, ...)` as a shortcut for `reducer.reduce()` when you
+  don't need a `state` https://github.com/o1-labs/o1js/pull/863
+- New export `TokenId` which supersedes `Token.Id`; `TokenId.deriveId()`
+  replaces `Token.Id.getId()` https://github.com/o1-labs/o1js/pull/863
+- Add `Permissions.allImpossible()` for the set of permissions where nothing is
+  allowed (more convenient than `Permissions.default()` when you want to make
+  most actions impossible) https://github.com/o1-labs/o1js/pull/863
 
 ### Changed
 
-- **Massive improvement of memory consumption**, thanks to a refactor of o1js' worker usage https://github.com/o1-labs/o1js/pull/872
-  - Memory reduced by up to 10x; see [the PR](https://github.com/o1-labs/o1js/pull/872) for details
-  - Side effect: `Circuit` API becomes async, for example `MyCircuit.prove(...)` becomes `await MyCircuit.prove(...)`
-- Token APIs `this.token.{send,burn,mint}()` now accept an `AccountUpdate` or `SmartContract` as from / to input https://github.com/o1-labs/o1js/pull/863
-- Improve `Transaction.toPretty()` output by adding account update labels in most methods that create account updates https://github.com/o1-labs/o1js/pull/863
-- Raises the limit of actions/events per transaction from 16 to 100, providing users with the ability to submit a larger number of events/actions in a single transaction. https://github.com/o1-labs/o1js/pull/883.
+- **Massive improvement of memory consumption**, thanks to a refactor of o1js'
+  worker usage https://github.com/o1-labs/o1js/pull/872
+  - Memory reduced by up to 10x; see
+    [the PR](https://github.com/o1-labs/o1js/pull/872) for details
+  - Side effect: `Circuit` API becomes async, for example `MyCircuit.prove(...)`
+    becomes `await MyCircuit.prove(...)`
+- Token APIs `this.token.{send,burn,mint}()` now accept an `AccountUpdate` or
+  `SmartContract` as from / to input https://github.com/o1-labs/o1js/pull/863
+- Improve `Transaction.toPretty()` output by adding account update labels in
+  most methods that create account updates
+  https://github.com/o1-labs/o1js/pull/863
+- Raises the limit of actions/events per transaction from 16 to 100, providing
+  users with the ability to submit a larger number of events/actions in a single
+  transaction. https://github.com/o1-labs/o1js/pull/883.
 
 ### Deprecated
 
-- Deprecate both `shutdown()` and `await isReady`, which are no longer needed https://github.com/o1-labs/o1js/pull/872
+- Deprecate both `shutdown()` and `await isReady`, which are no longer needed
+  https://github.com/o1-labs/o1js/pull/872
 
 ### Fixed
 
-- `SmartContract.deploy()` now throws an error when no verification key is found https://github.com/o1-labs/o1js/pull/885
-  - The old, confusing behaviour was to silently not update the verification key (but still update some permissions to "proof", breaking the zkApp)
+- `SmartContract.deploy()` now throws an error when no verification key is found
+  https://github.com/o1-labs/o1js/pull/885
+  - The old, confusing behaviour was to silently not update the verification key
+    (but still update some permissions to "proof", breaking the zkApp)
 
 ## [0.9.8](https://github.com/o1-labs/o1js/compare/1a984089...97e393ed)
 
 ### Fixed
 
-- Fix fetching the `access` permission on accounts https://github.com/o1-labs/o1js/pull/851
-- Fix `fetchActions` https://github.com/o1-labs/o1js/pull/844 https://github.com/o1-labs/o1js/pull/854 [@Comdex](https://github.com/Comdex)
-- Updated `Mina.TransactionId.isSuccess` to accurately verify zkApp transaction status after using `Mina.TransactionId.wait()`. https://github.com/o1-labs/o1js/pull/826
-  - This change ensures that the function correctly checks for transaction completion and provides the expected result.
+- Fix fetching the `access` permission on accounts
+  https://github.com/o1-labs/o1js/pull/851
+- Fix `fetchActions` https://github.com/o1-labs/o1js/pull/844
+  https://github.com/o1-labs/o1js/pull/854 [@Comdex](https://github.com/Comdex)
+- Updated `Mina.TransactionId.isSuccess` to accurately verify zkApp transaction
+  status after using `Mina.TransactionId.wait()`.
+  https://github.com/o1-labs/o1js/pull/826
+  - This change ensures that the function correctly checks for transaction
+    completion and provides the expected result.
 
 ## [0.9.7](https://github.com/o1-labs/o1js/compare/0b7a9ad...1a984089)
 
 ### Added
 
-- `smartContract.fetchActions()` and `Mina.fetchActions()`, asynchronous methods to fetch actions directly from an archive node https://github.com/o1-labs/o1js/pull/843 [@Comdex](https://github.com/Comdex)
+- `smartContract.fetchActions()` and `Mina.fetchActions()`, asynchronous methods
+  to fetch actions directly from an archive node
+  https://github.com/o1-labs/o1js/pull/843 [@Comdex](https://github.com/Comdex)
 
 ### Changed
 
-- `Circuit.runAndCheck()` now uses `snarky` to create a constraint system and witnesses, and check constraints. It closely matches behavior during proving and can be used to test provable code without having to create an expensive proof https://github.com/o1-labs/o1js/pull/840
+- `Circuit.runAndCheck()` now uses `snarky` to create a constraint system and
+  witnesses, and check constraints. It closely matches behavior during proving
+  and can be used to test provable code without having to create an expensive
+  proof https://github.com/o1-labs/o1js/pull/840
 
 ### Fixed
 
-- Fixes two issues that were temporarily reintroduced in the 0.9.6 release https://github.com/o1-labs/o1js/issues/799 https://github.com/o1-labs/o1js/issues/530
+- Fixes two issues that were temporarily reintroduced in the 0.9.6 release
+  https://github.com/o1-labs/o1js/issues/799
+  https://github.com/o1-labs/o1js/issues/530
 
 ## [0.9.6](https://github.com/o1-labs/o1js/compare/21de489...0b7a9ad)
 
 ### Breaking changes
 
-- Circuits changed due to an internal rename of "sequence events" to "actions" which included a change to some hash prefixes; this breaks all deployed contracts.
-- Temporarily reintroduces 2 known issues as a result of reverting a fix necessary for network redeployment:
+- Circuits changed due to an internal rename of "sequence events" to "actions"
+  which included a change to some hash prefixes; this breaks all deployed
+  contracts.
+- Temporarily reintroduces 2 known issues as a result of reverting a fix
+  necessary for network redeployment:
   - https://github.com/o1-labs/o1js/issues/799
   - https://github.com/o1-labs/o1js/issues/530
-  - Please note that we plan to address these issues in a future release. In the meantime, to work around this breaking change, you can try calling `fetchAccount` for each account involved in a transaction before executing the `Mina.transaction` block.
-- Improve number of constraints needed for Merkle tree hashing https://github.com/o1-labs/o1js/pull/820
-  - This breaks deployed zkApps which use `MerkleWitness.calculateRoot()`, because the circuit is changed
-  - You can make your existing contracts compatible again by switching to `MerkleWitness.calculateRootSlow()`, which has the old circuit
-- Renamed function parameters: The `getAction` function now accepts a new object structure for its parameters. https://github.com/o1-labs/o1js/pull/828
-  - The previous object keys, `fromActionHash` and `endActionHash`, have been replaced by `fromActionState` and `endActionState`.
+  - Please note that we plan to address these issues in a future release. In the
+    meantime, to work around this breaking change, you can try calling
+    `fetchAccount` for each account involved in a transaction before executing
+    the `Mina.transaction` block.
+- Improve number of constraints needed for Merkle tree hashing
+  https://github.com/o1-labs/o1js/pull/820
+  - This breaks deployed zkApps which use `MerkleWitness.calculateRoot()`,
+    because the circuit is changed
+  - You can make your existing contracts compatible again by switching to
+    `MerkleWitness.calculateRootSlow()`, which has the old circuit
+- Renamed function parameters: The `getAction` function now accepts a new object
+  structure for its parameters. https://github.com/o1-labs/o1js/pull/828
+  - The previous object keys, `fromActionHash` and `endActionHash`, have been
+    replaced by `fromActionState` and `endActionState`.
 
 ### Added
 
-- `zkProgram.analyzeMethods()` to obtain metadata about a ZkProgram's methods https://github.com/o1-labs/o1js/pull/829 [@maht0rz](https://github.com/maht0rz)
+- `zkProgram.analyzeMethods()` to obtain metadata about a ZkProgram's methods
+  https://github.com/o1-labs/o1js/pull/829
+  [@maht0rz](https://github.com/maht0rz)
 
 ### Fixed
 
 - Improved Event Handling in o1js https://github.com/o1-labs/o1js/pull/825
-  - Updated the internal event type to better handle events emitted in different zkApp transactions and when multiple zkApp transactions are present within a block.
-  - The internal event type now includes event data and transaction information as separate objects, allowing for more accurate information about each event and its associated transaction.
-- Removed multiple best tip blocks when fetching action data https://github.com/o1-labs/o1js/pull/817
-  - Implemented a temporary fix that filters out multiple best tip blocks, if they exist, while fetching actions. This fix will be removed once the related issue in the Archive-Node-API repository (https://github.com/o1-labs/Archive-Node-API/issues/7) is resolved.
-- New `fromActionState` and `endActionState` parameters for fetchActions function in o1js https://github.com/o1-labs/o1js/pull/828
+  - Updated the internal event type to better handle events emitted in different
+    zkApp transactions and when multiple zkApp transactions are present within a
+    block.
+  - The internal event type now includes event data and transaction information
+    as separate objects, allowing for more accurate information about each event
+    and its associated transaction.
+- Removed multiple best tip blocks when fetching action data
+  https://github.com/o1-labs/o1js/pull/817
+  - Implemented a temporary fix that filters out multiple best tip blocks, if
+    they exist, while fetching actions. This fix will be removed once the
+    related issue in the Archive-Node-API repository
+    (https://github.com/o1-labs/Archive-Node-API/issues/7) is resolved.
+- New `fromActionState` and `endActionState` parameters for fetchActions
+  function in o1js https://github.com/o1-labs/o1js/pull/828
   - Allows fetching only necessary actions to compute the latest actions state
   - Eliminates the need to retrieve the entire actions history of a zkApp
-  - Utilizes `actionStateTwo` field returned by Archive Node API as a safe starting point for deriving the most recent action hash
+  - Utilizes `actionStateTwo` field returned by Archive Node API as a safe
+    starting point for deriving the most recent action hash
 
 ## [0.9.5](https://github.com/o1-labs/o1js/compare/21de489...4573252d)
 
-- Update the zkApp verification key from within one of its own methods, via proof https://github.com/o1-labs/o1js/pull/812
+- Update the zkApp verification key from within one of its own methods, via
+  proof https://github.com/o1-labs/o1js/pull/812
 
 ### Breaking changes
 
-- Change type of verification key returned by `SmartContract.compile()` to match `VerificationKey` https://github.com/o1-labs/o1js/pull/812
+- Change type of verification key returned by `SmartContract.compile()` to match
+  `VerificationKey` https://github.com/o1-labs/o1js/pull/812
 
 ### Fixed
 
-- Failing `Mina.transaction` on Berkeley because of unsatisfied constraints caused by dummy data before we fetched account state https://github.com/o1-labs/o1js/pull/807
-  - Previously, you could work around this by calling `fetchAccount()` for every account involved in a transaction. This is not necessary anymore.
-- Update the zkApp verification key from within one of its own methods, via proof https://github.com/o1-labs/o1js/pull/812
+- Failing `Mina.transaction` on Berkeley because of unsatisfied constraints
+  caused by dummy data before we fetched account state
+  https://github.com/o1-labs/o1js/pull/807
+  - Previously, you could work around this by calling `fetchAccount()` for every
+    account involved in a transaction. This is not necessary anymore.
+- Update the zkApp verification key from within one of its own methods, via
+  proof https://github.com/o1-labs/o1js/pull/812
 
 ## [0.9.4](https://github.com/o1-labs/o1js/compare/9acec55...21de489)
 
 ### Fixed
 
-- `getActions` to handle multiple actions with multiple Account Updates https://github.com/o1-labs/o1js/pull/801
+- `getActions` to handle multiple actions with multiple Account Updates
+  https://github.com/o1-labs/o1js/pull/801
 
 ## [0.9.3](https://github.com/o1-labs/o1js/compare/1abdfb70...9acec55)
 
 ### Added
 
-- Use `fetchEvents()` to fetch events for a specified zkApp from a GraphQL endpoint that implements [this schema](https://github.com/o1-labs/Archive-Node-API/blob/efebc9fd3cfc028f536ae2125e0d2676e2b86cd2/src/schema.ts#L1). `Mina.Network` accepts an additional endpoint which points to a GraphQL server. https://github.com/o1-labs/o1js/pull/749
+- Use `fetchEvents()` to fetch events for a specified zkApp from a GraphQL
+  endpoint that implements
+  [this schema](https://github.com/o1-labs/Archive-Node-API/blob/efebc9fd3cfc028f536ae2125e0d2676e2b86cd2/src/schema.ts#L1).
+  `Mina.Network` accepts an additional endpoint which points to a GraphQL
+  server. https://github.com/o1-labs/o1js/pull/749
   - Use the `mina` property for the Mina node.
   - Use `archive` for the archive node.
-- Use `getActions` to fetch actions for a specified zkApp from a GraphQL endpoint GraphQL endpoint that implements the same schema as `fetchEvents`. https://github.com/o1-labs/o1js/pull/788
+- Use `getActions` to fetch actions for a specified zkApp from a GraphQL
+  endpoint GraphQL endpoint that implements the same schema as `fetchEvents`.
+  https://github.com/o1-labs/o1js/pull/788
 
 ### Fixed
 
-- Added the missing export of `Mina.TransactionId` https://github.com/o1-labs/o1js/pull/785
-- Added an option to specify `tokenId` as `Field` in `fetchAccount()` https://github.com/o1-labs/o1js/pull/787 [@rpanic](https://github.com/rpanic)
+- Added the missing export of `Mina.TransactionId`
+  https://github.com/o1-labs/o1js/pull/785
+- Added an option to specify `tokenId` as `Field` in `fetchAccount()`
+  https://github.com/o1-labs/o1js/pull/787 [@rpanic](https://github.com/rpanic)
 
 ## [0.9.2](https://github.com/o1-labs/o1js/compare/9c44b9c2...1abdfb70)
 
 ### Added
 
-- `this.network.timestamp` is added back and is implemented on top of `this.network.globalSlotSinceGenesis` https://github.com/o1-labs/o1js/pull/755
+- `this.network.timestamp` is added back and is implemented on top of
+  `this.network.globalSlotSinceGenesis` https://github.com/o1-labs/o1js/pull/755
 
 ### Changed
 
-- On-chain value `globalSlot` is replaced by the clearer `currentSlot` https://github.com/o1-labs/o1js/pull/755
-  - `currentSlot` refers to the slot at which the transaction _will be included in a block_.
-  - the only supported method is `currentSlot.assertBetween()` because `currentSlot.get()` is impossible to implement since the value is determined in the future and `currentSlot.assertEquals()` is error-prone
+- On-chain value `globalSlot` is replaced by the clearer `currentSlot`
+  https://github.com/o1-labs/o1js/pull/755
+  - `currentSlot` refers to the slot at which the transaction _will be included
+    in a block_.
+  - the only supported method is `currentSlot.assertBetween()` because
+    `currentSlot.get()` is impossible to implement since the value is determined
+    in the future and `currentSlot.assertEquals()` is error-prone
 
 ### Fixed
 
-- Incorrect counting of limit on events and actions https://github.com/o1-labs/o1js/pull/758
-- Type error when using `Circuit.array` in on-chain state or events https://github.com/o1-labs/o1js/pull/758
-- Bug when using `Circuit.witness` outside the prover https://github.com/o1-labs/o1js/pull/774
+- Incorrect counting of limit on events and actions
+  https://github.com/o1-labs/o1js/pull/758
+- Type error when using `Circuit.array` in on-chain state or events
+  https://github.com/o1-labs/o1js/pull/758
+- Bug when using `Circuit.witness` outside the prover
+  https://github.com/o1-labs/o1js/pull/774
 
 ## [0.9.1](https://github.com/o1-labs/o1js/compare/71b6132b...9c44b9c2)
 
 ### Fixed
 
-- Bug when using `this.<state>.get()` outside a transaction https://github.com/o1-labs/o1js/pull/754
+- Bug when using `this.<state>.get()` outside a transaction
+  https://github.com/o1-labs/o1js/pull/754
 
 ## [0.9.0](https://github.com/o1-labs/o1js/compare/c5a36207...71b6132b)
 
 ### Added
 
-- `Transaction.fromJSON` to recover transaction object from JSON https://github.com/o1-labs/o1js/pull/705
-- New precondition: `provedState`, a boolean which is true if the entire on-chain state of this account was last modified by a proof https://github.com/o1-labs/o1js/pull/741
-  - Same API as all preconditions: `this.account.provedState.assertEquals(Bool(true))`
-  - Can be used to assert that the state wasn't tampered with by the zkApp developer using non-contract logic, for example, before deploying the zkApp
-- New on-chain value `globalSlot`, to make assertions about the current time https://github.com/o1-labs/o1js/pull/649
-  - example: `this.globalSlot.get()`, `this.globalSlot.assertBetween(lower, upper)`
-  - Replaces `network.timestamp`, `network.globalSlotSinceGenesis` and `network.globalSlotSinceHardFork`. https://github.com/o1-labs/o1js/pull/560
+- `Transaction.fromJSON` to recover transaction object from JSON
+  https://github.com/o1-labs/o1js/pull/705
+- New precondition: `provedState`, a boolean which is true if the entire
+  on-chain state of this account was last modified by a proof
+  https://github.com/o1-labs/o1js/pull/741
+  - Same API as all preconditions:
+    `this.account.provedState.assertEquals(Bool(true))`
+  - Can be used to assert that the state wasn't tampered with by the zkApp
+    developer using non-contract logic, for example, before deploying the zkApp
+- New on-chain value `globalSlot`, to make assertions about the current time
+  https://github.com/o1-labs/o1js/pull/649
+  - example: `this.globalSlot.get()`,
+    `this.globalSlot.assertBetween(lower, upper)`
+  - Replaces `network.timestamp`, `network.globalSlotSinceGenesis` and
+    `network.globalSlotSinceHardFork`. https://github.com/o1-labs/o1js/pull/560
 - New permissions:
-  - `access` to control whether account updates for this account can be used at all https://github.com/o1-labs/o1js/pull/500
-  - `setTiming` to control who can update the account's `timing` field https://github.com/o1-labs/o1js/pull/685
-  - Example: `this.permissions.set({ ...Permissions.default(), access: Permissions.proofOrSignature() })`
-- Expose low-level view into the PLONK gates created by a smart contract method https://github.com/o1-labs/o1js/pull/687
+  - `access` to control whether account updates for this account can be used at
+    all https://github.com/o1-labs/o1js/pull/500
+  - `setTiming` to control who can update the account's `timing` field
+    https://github.com/o1-labs/o1js/pull/685
+  - Example:
+    `this.permissions.set({ ...Permissions.default(), access: Permissions.proofOrSignature() })`
+- Expose low-level view into the PLONK gates created by a smart contract method
+  https://github.com/o1-labs/o1js/pull/687
   - `MyContract.analyzeMethods().<method name>.gates`
 
 ### Changed
 
-- BREAKING CHANGE: Modify signature algorithm used by `Signature.{create,verify}` to be compatible with mina-signer https://github.com/o1-labs/o1js/pull/710
-  - Signatures created with mina-signer's `client.signFields()` can now be verified inside a SNARK!
+- BREAKING CHANGE: Modify signature algorithm used by
+  `Signature.{create,verify}` to be compatible with mina-signer
+  https://github.com/o1-labs/o1js/pull/710
+  - Signatures created with mina-signer's `client.signFields()` can now be
+    verified inside a SNARK!
   - Breaks existing deployed smart contracts which use `Signature.verify()`
-- BREAKING CHANGE: Circuits changed due to core protocol and cryptography changes; this breaks all deployed contracts.
-- BREAKING CHANGE: Change structure of `Account` type which is returned by `Mina.getAccount()` https://github.com/o1-labs/o1js/pull/741
+- BREAKING CHANGE: Circuits changed due to core protocol and cryptography
+  changes; this breaks all deployed contracts.
+- BREAKING CHANGE: Change structure of `Account` type which is returned by
+  `Mina.getAccount()` https://github.com/o1-labs/o1js/pull/741
   - for example, `account.appState` -> `account.zkapp.appState`
-  - full new type (exported as `Types.Account`): https://github.com/o1-labs/o1js/blob/0be70cb8ceb423976f348980e9d6238820758cc0/src/provable/gen/transaction.ts#L515
-- Test accounts hard-coded in `LocalBlockchain` now have default permissions, not permissions allowing everything. Fixes some unintuitive behaviour in tests, like requiring no signature when using these accounts to send MINA https://github.com/o1-labs/o1js/issues/638
+  - full new type (exported as `Types.Account`):
+    https://github.com/o1-labs/o1js/blob/0be70cb8ceb423976f348980e9d6238820758cc0/src/provable/gen/transaction.ts#L515
+- Test accounts hard-coded in `LocalBlockchain` now have default permissions,
+  not permissions allowing everything. Fixes some unintuitive behaviour in
+  tests, like requiring no signature when using these accounts to send MINA
+  https://github.com/o1-labs/o1js/issues/638
 
 ### Removed
 
-- Preconditions `timestamp` and `globalSlotSinceHardFork` https://github.com/o1-labs/o1js/pull/560
+- Preconditions `timestamp` and `globalSlotSinceHardFork`
+  https://github.com/o1-labs/o1js/pull/560
   - `timestamp` is expected to come back as a wrapper for the new `globalSlot`
 
 ## [0.8.0](https://github.com/o1-labs/o1js/compare/d880bd6e...c5a36207)
 
 ### Added
 
-- `this.account.<field>.set()` as a unified API to update fields on the account https://github.com/o1-labs/o1js/pull/643
-  - covers `permissions`, `verificationKey`, `zkappUri`, `tokenSymbol`, `delegate`, `votingFor`
+- `this.account.<field>.set()` as a unified API to update fields on the account
+  https://github.com/o1-labs/o1js/pull/643
+  - covers `permissions`, `verificationKey`, `zkappUri`, `tokenSymbol`,
+    `delegate`, `votingFor`
   - exists on `SmartContract.account` and `AccountUpdate.account`
-- `this.sender` to get the public key of the transaction's sender https://github.com/o1-labs/o1js/pull/652
+- `this.sender` to get the public key of the transaction's sender
+  https://github.com/o1-labs/o1js/pull/652
   - To get the sender outside a smart contract, there's now `Mina.sender()`
-- `tx.wait()` is now implemented. It waits for the transactions inclusion in a block https://github.com/o1-labs/o1js/pull/645
-  - `wait()` also now takes an optional `options` parameter to specify the polling interval or maximum attempts. `wait(options?: { maxAttempts?: number; interval?: number }): Promise<void>;`
-- `Circuit.constraintSystemFromKeypair(keypair)` to inspect the circuit at a low level https://github.com/o1-labs/o1js/pull/529
-  - Works with a `keypair` (prover + verifier key) generated with the `Circuit` API
-- `Mina.faucet()` can now be used to programmatically fund an address on the testnet, using the faucet provided by faucet.minaprotocol.com https://github.com/o1-labs/o1js/pull/693
+- `tx.wait()` is now implemented. It waits for the transactions inclusion in a
+  block https://github.com/o1-labs/o1js/pull/645
+  - `wait()` also now takes an optional `options` parameter to specify the
+    polling interval or maximum attempts.
+    `wait(options?: { maxAttempts?: number; interval?: number }): Promise<void>;`
+- `Circuit.constraintSystemFromKeypair(keypair)` to inspect the circuit at a low
+  level https://github.com/o1-labs/o1js/pull/529
+  - Works with a `keypair` (prover + verifier key) generated with the `Circuit`
+    API
+- `Mina.faucet()` can now be used to programmatically fund an address on the
+  testnet, using the faucet provided by faucet.minaprotocol.com
+  https://github.com/o1-labs/o1js/pull/693
 
 ### Changed
 
-- BREAKING CHANGE: Constraint changes in `sign()`, `requireSignature()` and `createSigned()` on `AccountUpdate` / `SmartContract`. _This means that smart contracts using these methods in their proofs won't be able to create valid proofs against old deployed verification keys._ https://github.com/o1-labs/o1js/pull/637
-- `Mina.transaction` now takes a _public key_ as the fee payer argument (passing in a private key is deprecated) https://github.com/o1-labs/o1js/pull/652
-  - Before: `Mina.transaction(privateKey, ...)`. Now: `Mina.transaction(publicKey, ...)`
-  - `AccountUpdate.fundNewAccount()` now enables funding multiple accounts at once, and deprecates the `initialBalance` argument
-- New option `enforceTransactionLimits` for `LocalBlockchain` (default value: `true`), to disable the enforcement of protocol transaction limits (maximum events, maximum sequence events and enforcing certain layout of `AccountUpdate`s depending on their authorization) https://github.com/o1-labs/o1js/pull/620
-- Change the default `send` permissions (for sending MINA or tokens) that get set when deploying a zkApp, from `signature()` to `proof()` https://github.com/o1-labs/o1js/pull/648
-- Functions for making assertions and comparisons have been renamed to their long form, instead of the initial abbreviation. Old function names have been deprecated https://github.com/o1-labs/o1js/pull/681
+- BREAKING CHANGE: Constraint changes in `sign()`, `requireSignature()` and
+  `createSigned()` on `AccountUpdate` / `SmartContract`. _This means that smart
+  contracts using these methods in their proofs won't be able to create valid
+  proofs against old deployed verification keys._
+  https://github.com/o1-labs/o1js/pull/637
+- `Mina.transaction` now takes a _public key_ as the fee payer argument (passing
+  in a private key is deprecated) https://github.com/o1-labs/o1js/pull/652
+  - Before: `Mina.transaction(privateKey, ...)`. Now:
+    `Mina.transaction(publicKey, ...)`
+  - `AccountUpdate.fundNewAccount()` now enables funding multiple accounts at
+    once, and deprecates the `initialBalance` argument
+- New option `enforceTransactionLimits` for `LocalBlockchain` (default value:
+  `true`), to disable the enforcement of protocol transaction limits (maximum
+  events, maximum sequence events and enforcing certain layout of
+  `AccountUpdate`s depending on their authorization)
+  https://github.com/o1-labs/o1js/pull/620
+- Change the default `send` permissions (for sending MINA or tokens) that get
+  set when deploying a zkApp, from `signature()` to `proof()`
+  https://github.com/o1-labs/o1js/pull/648
+- Functions for making assertions and comparisons have been renamed to their
+  long form, instead of the initial abbreviation. Old function names have been
+  deprecated https://github.com/o1-labs/o1js/pull/681
   - `.lt` -> `.lessThan`
   - `.lte` -> `.lessThanOrEqual`
   - `.gt` -> `.greaterThan`
@@ -1084,31 +1673,43 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ### Deprecated
 
-- `this.setPermissions()` in favor of `this.account.permissions.set()` https://github.com/o1-labs/o1js/pull/643
+- `this.setPermissions()` in favor of `this.account.permissions.set()`
+  https://github.com/o1-labs/o1js/pull/643
   - `this.tokenSymbol.set()` in favor of `this.account.tokenSymbol.set()`
   - `this.setValue()` in favor of `this.account.<field>.set()`
-- `Mina.transaction(privateKey: PrivateKey, ...)` in favor of new signature `Mina.transaction(publicKey: PublicKey, ...)`
-- `AccountUpdate.createSigned(privateKey: PrivateKey)` in favor of new signature `AccountUpdate.createSigned(publicKey: PublicKey)` https://github.com/o1-labs/o1js/pull/637
-- `.lt`, `.lte`, `gt`, `gte`, `.assertLt`, `.assertLte`, `.assertGt`, `.assertGte` have been deprecated. https://github.com/o1-labs/o1js/pull/681
+- `Mina.transaction(privateKey: PrivateKey, ...)` in favor of new signature
+  `Mina.transaction(publicKey: PublicKey, ...)`
+- `AccountUpdate.createSigned(privateKey: PrivateKey)` in favor of new signature
+  `AccountUpdate.createSigned(publicKey: PublicKey)`
+  https://github.com/o1-labs/o1js/pull/637
+- `.lt`, `.lte`, `gt`, `gte`, `.assertLt`, `.assertLte`, `.assertGt`,
+  `.assertGte` have been deprecated. https://github.com/o1-labs/o1js/pull/681
 
 ### Fixed
 
-- Fixed Apple silicon performance issue https://github.com/o1-labs/o1js/issues/491
-- Type inference for Structs with instance methods https://github.com/o1-labs/o1js/pull/567
+- Fixed Apple silicon performance issue
+  https://github.com/o1-labs/o1js/issues/491
+- Type inference for Structs with instance methods
+  https://github.com/o1-labs/o1js/pull/567
   - also fixes `Struct.fromJSON`
-- `SmartContract.fetchEvents` fixed when multiple event types existed https://github.com/o1-labs/o1js/issues/627
-- Error when using reduce with a `Struct` as state type https://github.com/o1-labs/o1js/pull/689
-- Fix use of stale cached accounts in `Mina.transaction` https://github.com/o1-labs/o1js/issues/430
+- `SmartContract.fetchEvents` fixed when multiple event types existed
+  https://github.com/o1-labs/o1js/issues/627
+- Error when using reduce with a `Struct` as state type
+  https://github.com/o1-labs/o1js/pull/689
+- Fix use of stale cached accounts in `Mina.transaction`
+  https://github.com/o1-labs/o1js/issues/430
 
 ## [0.7.3](https://github.com/o1-labs/o1js/compare/5f20f496...d880bd6e)
 
 ### Fixed
 
-- Bug in `deploy()` when initializing a contract that already exists https://github.com/o1-labs/o1js/pull/588
+- Bug in `deploy()` when initializing a contract that already exists
+  https://github.com/o1-labs/o1js/pull/588
 
 ### Deprecated
 
-- `Mina.BerkeleyQANet` in favor of the clearer-named `Mina.Network` https://github.com/o1-labs/o1js/pull/588
+- `Mina.BerkeleyQANet` in favor of the clearer-named `Mina.Network`
+  https://github.com/o1-labs/o1js/pull/588
 
 ## [0.7.2](https://github.com/o1-labs/o1js/compare/705f58d3...5f20f496)
 
@@ -1119,65 +1720,110 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ### Fixed
 
-- Bug in `Circuit.log` printing account updates https://github.com/o1-labs/o1js/pull/578
+- Bug in `Circuit.log` printing account updates
+  https://github.com/o1-labs/o1js/pull/578
 
 ## [0.7.1](https://github.com/o1-labs/o1js/compare/f0837188...705f58d3)
 
 ### Fixed
 
-- Testnet-incompatible signatures in v0.7.0 https://github.com/o1-labs/o1js/pull/565
+- Testnet-incompatible signatures in v0.7.0
+  https://github.com/o1-labs/o1js/pull/565
 
 ## [0.7.0](https://github.com/o1-labs/o1js/compare/f0837188...9a94231c)
 
 ### Added
 
-- Added an optional string parameter to certain `assert` methods https://github.com/o1-labs/o1js/pull/470
-- `Struct`, a new primitive for declaring composite, SNARK-compatible types https://github.com/o1-labs/o1js/pull/416
-  - With this, we also added a way to include auxiliary, non-field element data in composite types
-  - Added `VerificationKey`, which is a `Struct` with auxiliary data, to pass verification keys to a `@method`
-  - BREAKING CHANGE: Change names related to circuit types: `AsFieldsAndAux<T>` -> `Provable<T>`, `AsFieldElement<T>` -> `ProvablePure<T>`, `circuitValue` -> `provable`
-  - BREAKING CHANGE: Change all `ofFields` and `ofBits` methods on circuit types to `fromFields` and `fromBits`
-- New option `proofsEnabled` for `LocalBlockchain` (default value: `true`), to quickly test transaction logic with proofs disabled https://github.com/o1-labs/o1js/pull/462
-  - with `proofsEnabled: true`, proofs now get verified locally https://github.com/o1-labs/o1js/pull/423
-- `SmartContract.approve()` to approve a tree of child account updates https://github.com/o1-labs/o1js/pull/428 https://github.com/o1-labs/o1js/pull/534
-  - AccountUpdates are now valid `@method` arguments, and `approve()` is intended to be used on them when passed to a method
+- Added an optional string parameter to certain `assert` methods
+  https://github.com/o1-labs/o1js/pull/470
+- `Struct`, a new primitive for declaring composite, SNARK-compatible types
+  https://github.com/o1-labs/o1js/pull/416
+  - With this, we also added a way to include auxiliary, non-field element data
+    in composite types
+  - Added `VerificationKey`, which is a `Struct` with auxiliary data, to pass
+    verification keys to a `@method`
+  - BREAKING CHANGE: Change names related to circuit types: `AsFieldsAndAux<T>`
+    -> `Provable<T>`, `AsFieldElement<T>` -> `ProvablePure<T>`, `circuitValue`
+    -> `provable`
+  - BREAKING CHANGE: Change all `ofFields` and `ofBits` methods on circuit types
+    to `fromFields` and `fromBits`
+- New option `proofsEnabled` for `LocalBlockchain` (default value: `true`), to
+  quickly test transaction logic with proofs disabled
+  https://github.com/o1-labs/o1js/pull/462
+  - with `proofsEnabled: true`, proofs now get verified locally
+    https://github.com/o1-labs/o1js/pull/423
+- `SmartContract.approve()` to approve a tree of child account updates
+  https://github.com/o1-labs/o1js/pull/428
+  https://github.com/o1-labs/o1js/pull/534
+  - AccountUpdates are now valid `@method` arguments, and `approve()` is
+    intended to be used on them when passed to a method
   - Also replaces `Experimental.accountUpdateFromCallback()`
-- `Circuit.log()` to easily log Fields and other provable types inside a method, with the same API as `console.log()` https://github.com/o1-labs/o1js/pull/484
-- `SmartContract.init()` is a new method on the base `SmartContract` that will be called only during the first deploy (not if you re-deploy later to upgrade the contract) https://github.com/o1-labs/o1js/pull/543
-  - Overriding `init()` is the new recommended way to add custom state initialization logic.
-- `transaction.toPretty()` and `accountUpdate.toPretty()` for debugging transactions by printing only the pieces that differ from default account updates https://github.com/o1-labs/o1js/pull/428
-- `AccountUpdate.attachToTransaction()` for explicitly adding an account update to the current transaction. This replaces some previous behaviour where an account update got attached implicitly https://github.com/o1-labs/o1js/pull/484
-- `SmartContract.requireSignature()` and `AccountUpdate.requireSignature()` as a simpler, better-named replacement for `.sign()` https://github.com/o1-labs/o1js/pull/558
+- `Circuit.log()` to easily log Fields and other provable types inside a method,
+  with the same API as `console.log()` https://github.com/o1-labs/o1js/pull/484
+- `SmartContract.init()` is a new method on the base `SmartContract` that will
+  be called only during the first deploy (not if you re-deploy later to upgrade
+  the contract) https://github.com/o1-labs/o1js/pull/543
+  - Overriding `init()` is the new recommended way to add custom state
+    initialization logic.
+- `transaction.toPretty()` and `accountUpdate.toPretty()` for debugging
+  transactions by printing only the pieces that differ from default account
+  updates https://github.com/o1-labs/o1js/pull/428
+- `AccountUpdate.attachToTransaction()` for explicitly adding an account update
+  to the current transaction. This replaces some previous behaviour where an
+  account update got attached implicitly
+  https://github.com/o1-labs/o1js/pull/484
+- `SmartContract.requireSignature()` and `AccountUpdate.requireSignature()` as a
+  simpler, better-named replacement for `.sign()`
+  https://github.com/o1-labs/o1js/pull/558
 
 ### Changed
 
-- BREAKING CHANGE: `tx.send()` is now asynchronous: old: `send(): TransactionId` new: `send(): Promise<TransactionId>` and `tx.send()` now directly waits for the network response, as opposed to `tx.send().wait()` https://github.com/o1-labs/o1js/pull/423
+- BREAKING CHANGE: `tx.send()` is now asynchronous: old: `send(): TransactionId`
+  new: `send(): Promise<TransactionId>` and `tx.send()` now directly waits for
+  the network response, as opposed to `tx.send().wait()`
+  https://github.com/o1-labs/o1js/pull/423
 - Sending transactions to `LocalBlockchain` now involves
-- `Circuit.witness` can now be called outside circuits, where it will just directly return the callback result https://github.com/o1-labs/o1js/pull/484
-- The `FeePayerSpec`, which is used to specify properties of the transaction via `Mina.transaction()`, now has another optional parameter to specify the nonce manually. `Mina.transaction({ feePayerKey: feePayer, nonce: 1 }, () => {})` https://github.com/o1-labs/o1js/pull/497
-- BREAKING CHANGE: Static methods of type `.fromString()`, `.fromNumber()` and `.fromBigInt()` on `Field`, `UInt64`, `UInt32` and `Int64` are no longer supported https://github.com/o1-labs/o1js/pull/519
-  - use `Field(number | string | bigint)` and `UInt64.from(number | string | bigint)`
-- Move several features out of 'experimental' https://github.com/o1-labs/o1js/pull/555
+- `Circuit.witness` can now be called outside circuits, where it will just
+  directly return the callback result https://github.com/o1-labs/o1js/pull/484
+- The `FeePayerSpec`, which is used to specify properties of the transaction via
+  `Mina.transaction()`, now has another optional parameter to specify the nonce
+  manually. `Mina.transaction({ feePayerKey: feePayer, nonce: 1 }, () => {})`
+  https://github.com/o1-labs/o1js/pull/497
+- BREAKING CHANGE: Static methods of type `.fromString()`, `.fromNumber()` and
+  `.fromBigInt()` on `Field`, `UInt64`, `UInt32` and `Int64` are no longer
+  supported https://github.com/o1-labs/o1js/pull/519
+  - use `Field(number | string | bigint)` and
+    `UInt64.from(number | string | bigint)`
+- Move several features out of 'experimental'
+  https://github.com/o1-labs/o1js/pull/555
   - `Reducer` replaces `Experimental.Reducer`
-  - `MerkleTree` and `MerkleWitness` replace `Experimental.{MerkleTree,MerkleWitness}`
+  - `MerkleTree` and `MerkleWitness` replace
+    `Experimental.{MerkleTree,MerkleWitness}`
   - In a `SmartContract`, `this.token` replaces `this.experimental.token`
 
 ### Deprecated
 
-- `CircuitValue` deprecated in favor of `Struct` https://github.com/o1-labs/o1js/pull/416
-- Static props `Field.zero`, `Field.one`, `Field.minusOne` deprecated in favor of `Field(number)` https://github.com/o1-labs/o1js/pull/524
-- `SmartContract.sign()` and `AccountUpdate.sign()` in favor of `.requireSignature()` https://github.com/o1-labs/o1js/pull/558
+- `CircuitValue` deprecated in favor of `Struct`
+  https://github.com/o1-labs/o1js/pull/416
+- Static props `Field.zero`, `Field.one`, `Field.minusOne` deprecated in favor
+  of `Field(number)` https://github.com/o1-labs/o1js/pull/524
+- `SmartContract.sign()` and `AccountUpdate.sign()` in favor of
+  `.requireSignature()` https://github.com/o1-labs/o1js/pull/558
 
 ### Fixed
 
-- Uint comparisons and division fixed inside the prover https://github.com/o1-labs/o1js/pull/503
-- Callback arguments are properly passed into method invocations https://github.com/o1-labs/o1js/pull/516
-- Removed internal type `JSONValue` from public interfaces https://github.com/o1-labs/o1js/pull/536
+- Uint comparisons and division fixed inside the prover
+  https://github.com/o1-labs/o1js/pull/503
+- Callback arguments are properly passed into method invocations
+  https://github.com/o1-labs/o1js/pull/516
+- Removed internal type `JSONValue` from public interfaces
+  https://github.com/o1-labs/o1js/pull/536
 - Returning values from a zkApp https://github.com/o1-labs/o1js/pull/461
 
 ### Fixed
 
-- Callback arguments are properly passed into method invocations https://github.com/o1-labs/o1js/pull/516
+- Callback arguments are properly passed into method invocations
+  https://github.com/o1-labs/o1js/pull/516
 
 ## [0.6.1](https://github.com/o1-labs/o1js/compare/ba688523...f0837188)
 
@@ -1189,15 +1835,23 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ### Added
 
-- `reducer.getActions` partially implemented for local testing https://github.com/o1-labs/o1js/pull/327
-- `gte` and `assertGte` methods on `UInt32`, `UInt64` https://github.com/o1-labs/o1js/pull/349
-- Return sent transaction `hash` for `RemoteBlockchain` https://github.com/o1-labs/o1js/pull/399
+- `reducer.getActions` partially implemented for local testing
+  https://github.com/o1-labs/o1js/pull/327
+- `gte` and `assertGte` methods on `UInt32`, `UInt64`
+  https://github.com/o1-labs/o1js/pull/349
+- Return sent transaction `hash` for `RemoteBlockchain`
+  https://github.com/o1-labs/o1js/pull/399
 
 ### Changed
 
-- BREAKING CHANGE: Rename the `Party` class to `AccountUpdate`. Also, rename other occurrences of "party" to "account update". https://github.com/o1-labs/o1js/pull/393
-- BREAKING CHANGE: Don't require the account address as input to `SmartContract.compile()`, `SmartContract.digest()` and `SmartContract.analyzeMethods()` https://github.com/o1-labs/o1js/pull/406
-  - This works because the address / public key is now a variable in the method circuit; it used to be a constant
+- BREAKING CHANGE: Rename the `Party` class to `AccountUpdate`. Also, rename
+  other occurrences of "party" to "account update".
+  https://github.com/o1-labs/o1js/pull/393
+- BREAKING CHANGE: Don't require the account address as input to
+  `SmartContract.compile()`, `SmartContract.digest()` and
+  `SmartContract.analyzeMethods()` https://github.com/o1-labs/o1js/pull/406
+  - This works because the address / public key is now a variable in the method
+    circuit; it used to be a constant
 - BREAKING CHANGE: Move `ZkProgram` to `Experimental.ZkProgram`
 
 ## [0.5.4](https://github.com/o1-labs/o1js/compare/3461333...f2ad423)
@@ -1210,14 +1864,17 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ### Fixed
 
-- Infinite loop when compiling in web version https://github.com/o1-labs/o1js/issues/379, by [@maht0rz](https://github.com/maht0rz)
+- Infinite loop when compiling in web version
+  https://github.com/o1-labs/o1js/issues/379, by
+  [@maht0rz](https://github.com/maht0rz)
 
 ## [0.5.2](https://github.com/o1-labs/o1js/compare/55c8ea0...4f0dd40)
 
 ### Fixed
 
 - Crash of the web version introduced in 0.5.0
-- Issue with `Experimental.MerkleWitness` https://github.com/o1-labs/o1js/pull/368
+- Issue with `Experimental.MerkleWitness`
+  https://github.com/o1-labs/o1js/pull/368
 
 ## [0.5.1](https://github.com/o1-labs/o1js/compare/e0192f7...55c8ea0)
 
@@ -1229,65 +1886,128 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ### Added
 
-- **Recursive proofs**. RFC: https://github.com/o1-labs/o1js/issues/89, PRs: https://github.com/o1-labs/o1js/pull/245 https://github.com/o1-labs/o1js/pull/250 https://github.com/o1-labs/o1js/pull/261
-  - Enable smart contract methods to take previous proofs as arguments, and verify them in the circuit
-  - Add `ZkProgram`, a new primitive which represents a collection of circuits that produce instances of the same proof. So, it's a more general version of `SmartContract`, without any of the Mina-related API.
-    `ZkProgram` is suitable for rollup-type systems and offchain usage of Pickles + Kimchi.
-- **zkApp composability** -- calling other zkApps from inside zkApps. RFC: https://github.com/o1-labs/o1js/issues/303, PRs: https://github.com/o1-labs/o1js/pull/285, https://github.com/o1-labs/o1js/pull/296, https://github.com/o1-labs/o1js/pull/294, https://github.com/o1-labs/o1js/pull/297
-- **Events** support via `SmartContract.events`, `this.emitEvent`. RFC: https://github.com/o1-labs/o1js/issues/248, PR: https://github.com/o1-labs/o1js/pull/272
-  - `fetchEvents` partially implemented for local testing: https://github.com/o1-labs/o1js/pull/323
-- **Payments**: `this.send({ to, amount })` as an easier API for sending Mina from smart contracts https://github.com/o1-labs/o1js/pull/325
-  - `Party.send()` to transfer Mina between any accounts, for example, from users to smart contracts
-- `SmartContract.digest()` to quickly compute a hash of the contract's circuit. This is [used by the zkApp CLI](https://github.com/o1-labs/zkapp-cli/pull/233) to figure out whether `compile` should be re-run or a cached verification key can be used. https://github.com/o1-labs/o1js/pull/268
-- `Circuit.constraintSystem()` for creating a circuit from a function, counting the number of constraints and computing a digest of the circuit https://github.com/o1-labs/o1js/pull/279
-- `this.account.isNew` to assert that an account did not (or did) exist before the transaction https://github.com/MinaProtocol/mina/pull/11524
-- `LocalBlockchain.setTimestamp` and other setters for network state, to test network preconditions locally https://github.com/o1-labs/o1js/pull/329
-- **Experimental APIs** are now collected under the `Experimental` import, or on `this.experimental` in a smart contract.
-- Custom tokens (_experimental_), via `this.token`. RFC: https://github.com/o1-labs/o1js/issues/233, PR: https://github.com/o1-labs/o1js/pull/273,
-- Actions / sequence events support (_experimental_), via `Experimental.Reducer`. RFC: https://github.com/o1-labs/o1js/issues/265, PR: https://github.com/o1-labs/o1js/pull/274
-- Merkle tree implementation (_experimental_) via `Experimental.MerkleTree` https://github.com/o1-labs/o1js/pull/343
+- **Recursive proofs**. RFC: https://github.com/o1-labs/o1js/issues/89, PRs:
+  https://github.com/o1-labs/o1js/pull/245
+  https://github.com/o1-labs/o1js/pull/250
+  https://github.com/o1-labs/o1js/pull/261
+  - Enable smart contract methods to take previous proofs as arguments, and
+    verify them in the circuit
+  - Add `ZkProgram`, a new primitive which represents a collection of circuits
+    that produce instances of the same proof. So, it's a more general version of
+    `SmartContract`, without any of the Mina-related API. `ZkProgram` is
+    suitable for rollup-type systems and offchain usage of Pickles + Kimchi.
+- **zkApp composability** -- calling other zkApps from inside zkApps. RFC:
+  https://github.com/o1-labs/o1js/issues/303, PRs:
+  https://github.com/o1-labs/o1js/pull/285,
+  https://github.com/o1-labs/o1js/pull/296,
+  https://github.com/o1-labs/o1js/pull/294,
+  https://github.com/o1-labs/o1js/pull/297
+- **Events** support via `SmartContract.events`, `this.emitEvent`. RFC:
+  https://github.com/o1-labs/o1js/issues/248, PR:
+  https://github.com/o1-labs/o1js/pull/272
+  - `fetchEvents` partially implemented for local testing:
+    https://github.com/o1-labs/o1js/pull/323
+- **Payments**: `this.send({ to, amount })` as an easier API for sending Mina
+  from smart contracts https://github.com/o1-labs/o1js/pull/325
+  - `Party.send()` to transfer Mina between any accounts, for example, from
+    users to smart contracts
+- `SmartContract.digest()` to quickly compute a hash of the contract's circuit.
+  This is [used by the zkApp CLI](https://github.com/o1-labs/zkapp-cli/pull/233)
+  to figure out whether `compile` should be re-run or a cached verification key
+  can be used. https://github.com/o1-labs/o1js/pull/268
+- `Circuit.constraintSystem()` for creating a circuit from a function, counting
+  the number of constraints and computing a digest of the circuit
+  https://github.com/o1-labs/o1js/pull/279
+- `this.account.isNew` to assert that an account did not (or did) exist before
+  the transaction https://github.com/MinaProtocol/mina/pull/11524
+- `LocalBlockchain.setTimestamp` and other setters for network state, to test
+  network preconditions locally https://github.com/o1-labs/o1js/pull/329
+- **Experimental APIs** are now collected under the `Experimental` import, or on
+  `this.experimental` in a smart contract.
+- Custom tokens (_experimental_), via `this.token`. RFC:
+  https://github.com/o1-labs/o1js/issues/233, PR:
+  https://github.com/o1-labs/o1js/pull/273,
+- Actions / sequence events support (_experimental_), via
+  `Experimental.Reducer`. RFC: https://github.com/o1-labs/o1js/issues/265, PR:
+  https://github.com/o1-labs/o1js/pull/274
+- Merkle tree implementation (_experimental_) via `Experimental.MerkleTree`
+  https://github.com/o1-labs/o1js/pull/343
 
 ### Changed
 
-- BREAKING CHANGE: Make on-chain state consistent with other preconditions - throw an error when state is not explicitly constrained https://github.com/o1-labs/o1js/pull/267
-- `CircuitValue` improvements https://github.com/o1-labs/o1js/pull/269, https://github.com/o1-labs/o1js/pull/306, https://github.com/o1-labs/o1js/pull/341
-  - Added a base constructor, so overriding the constructor on classes that extend `CircuitValue` is now _optional_. When overriding, the base constructor can be called without arguments, as previously: `super()`. When not overriding, the expected arguments are all the `@prop`s on the class, in the order they were defined in: `new MyCircuitValue(prop1, prop2)`.
-  - `CircuitValue.fromObject({ prop1, prop2 })` is a new, better-typed alternative for using the base constructor.
-  - Fixed: the overridden constructor is now free to have any argument structure -- previously, arguments had to be the props in their declared order. I.e., the behaviour that's now used by the base constructor used to be forced on all constructors, which is no longer the case.
+- BREAKING CHANGE: Make on-chain state consistent with other preconditions -
+  throw an error when state is not explicitly constrained
+  https://github.com/o1-labs/o1js/pull/267
+- `CircuitValue` improvements https://github.com/o1-labs/o1js/pull/269,
+  https://github.com/o1-labs/o1js/pull/306,
+  https://github.com/o1-labs/o1js/pull/341
+  - Added a base constructor, so overriding the constructor on classes that
+    extend `CircuitValue` is now _optional_. When overriding, the base
+    constructor can be called without arguments, as previously: `super()`. When
+    not overriding, the expected arguments are all the `@prop`s on the class, in
+    the order they were defined in: `new MyCircuitValue(prop1, prop2)`.
+  - `CircuitValue.fromObject({ prop1, prop2 })` is a new, better-typed
+    alternative for using the base constructor.
+  - Fixed: the overridden constructor is now free to have any argument structure
+    -- previously, arguments had to be the props in their declared order. I.e.,
+    the behaviour that's now used by the base constructor used to be forced on
+    all constructors, which is no longer the case.
 - `Mina.transaction` improvements
-  - Support zkApp proofs when there are other account updates in the same transaction block https://github.com/o1-labs/o1js/pull/280
-  - Support multiple independent zkApp proofs in one transaction block https://github.com/o1-labs/o1js/pull/296
-- Add previously unimplemented preconditions, like `this.network.timestamp` https://github.com/o1-labs/o1js/pull/324 https://github.com/MinaProtocol/mina/pull/11577
-- Improve error messages thrown from Wasm, by making Rust's `panic` log to the JS console https://github.com/MinaProtocol/mina/pull/11644
-- Not user-facing, but essential: Smart contracts fully constrain the account updates they create, inside the circuit https://github.com/o1-labs/o1js/pull/278
+  - Support zkApp proofs when there are other account updates in the same
+    transaction block https://github.com/o1-labs/o1js/pull/280
+  - Support multiple independent zkApp proofs in one transaction block
+    https://github.com/o1-labs/o1js/pull/296
+- Add previously unimplemented preconditions, like `this.network.timestamp`
+  https://github.com/o1-labs/o1js/pull/324
+  https://github.com/MinaProtocol/mina/pull/11577
+- Improve error messages thrown from Wasm, by making Rust's `panic` log to the
+  JS console https://github.com/MinaProtocol/mina/pull/11644
+- Not user-facing, but essential: Smart contracts fully constrain the account
+  updates they create, inside the circuit
+  https://github.com/o1-labs/o1js/pull/278
 
 ### Fixed
 
-- Fix comparisons on `UInt32` and `UInt64` (`UInt32.lt`, `UInt32.gt`, etc) https://github.com/o1-labs/o1js/issues/174, https://github.com/o1-labs/o1js/issues/101. PR: https://github.com/o1-labs/o1js/pull/307
+- Fix comparisons on `UInt32` and `UInt64` (`UInt32.lt`, `UInt32.gt`, etc)
+  https://github.com/o1-labs/o1js/issues/174,
+  https://github.com/o1-labs/o1js/issues/101. PR:
+  https://github.com/o1-labs/o1js/pull/307
 
 ## [0.4.3](https://github.com/o1-labs/o1js/compare/e66f08d...2375f08)
 
 ### Added
 
-- Implement the [precondition RFC](https://github.com/o1-labs/o1js/issues/179#issuecomment-1139413831):
-  - new fields `this.account` and `this.network` on both `SmartContract` and `Party`
-  - `this.<account|network>.<property>.get()` to use on-chain values in a circuit, e.g. account balance or block height
-  - `this.<account|network>.<property>.{assertEqual, assertBetween, assertNothing}()` to constrain what values to allow for these
-- `CircuitString`, a snark-compatible string type with methods like `.append()` https://github.com/o1-labs/o1js/pull/155
-- `bool.assertTrue()`, `bool.assertFalse()` as convenient aliases for existing functionality
-- `Ledger.verifyPartyProof` which can check if a proof on a transaction is valid https://github.com/o1-labs/o1js/pull/208
-- Memo field in APIs like `Mina.transaction` to attach arbitrary messages https://github.com/o1-labs/o1js/pull/244
+- Implement the
+  [precondition RFC](https://github.com/o1-labs/o1js/issues/179#issuecomment-1139413831):
+  - new fields `this.account` and `this.network` on both `SmartContract` and
+    `Party`
+  - `this.<account|network>.<property>.get()` to use on-chain values in a
+    circuit, e.g. account balance or block height
+  - `this.<account|network>.<property>.{assertEqual, assertBetween, assertNothing}()`
+    to constrain what values to allow for these
+- `CircuitString`, a snark-compatible string type with methods like `.append()`
+  https://github.com/o1-labs/o1js/pull/155
+- `bool.assertTrue()`, `bool.assertFalse()` as convenient aliases for existing
+  functionality
+- `Ledger.verifyPartyProof` which can check if a proof on a transaction is valid
+  https://github.com/o1-labs/o1js/pull/208
+- Memo field in APIs like `Mina.transaction` to attach arbitrary messages
+  https://github.com/o1-labs/o1js/pull/244
 - This changelog
 
 ### Changed
 
-- Huge snark performance improvements (2-10x) for most zkApps https://github.com/MinaProtocol/mina/pull/11053
-- Performance improvements in node with > 4 CPUs, for all snarks https://github.com/MinaProtocol/mina/pull/11292
-- Substantial reduction of o1js' size https://github.com/MinaProtocol/mina/pull/11166
+- Huge snark performance improvements (2-10x) for most zkApps
+  https://github.com/MinaProtocol/mina/pull/11053
+- Performance improvements in node with > 4 CPUs, for all snarks
+  https://github.com/MinaProtocol/mina/pull/11292
+- Substantial reduction of o1js' size
+  https://github.com/MinaProtocol/mina/pull/11166
 
 ### Removed
 
-- Unused functions `call` and `callUnproved`, which were embryonic versions of what is now the `transaction` API to call smart contract methods
+- Unused functions `call` and `callUnproved`, which were embryonic versions of
+  what is now the `transaction` API to call smart contract methods
 - Some unimplemented fields on `SmartContract`
 
 ### Fixed

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,33 +2,55 @@
 
 Thank you for investing your time in contributing to our project.
 
-We also welcome contributions to [zkApps Developer](https://docs.minaprotocol.com/zkapps) documentation.
+We also welcome contributions to
+[zkApps Developer](https://docs.minaprotocol.com/zkapps) documentation.
 
 There are two ways to contribute:
 
-1. Preferred: Maintain your own package that can be installed from [npm](https://www.npmjs.com/) and used alongside o1js. See [Creating high-quality community packages](#creating-high-quality-community-packages).
-2. Directly contribute to this repo. See [Contributing to o1js](#contributing-to-o1js).
+1. Preferred: Maintain your own package that can be installed from
+   [npm](https://www.npmjs.com/) and used alongside o1js. See
+   [Creating high-quality community packages](#creating-high-quality-community-packages).
+2. Directly contribute to this repo. See
+   [Contributing to o1js](#contributing-to-o1js).
 
-If you maintain your own package, we strongly encourage you to add it to our official list of [community packages](./README.md#community-packages).
+If you maintain your own package, we strongly encourage you to add it to our
+official list of [community packages](./README.md#community-packages).
 
-For information that is helpful for o1js core contributors, see [README-dev](README-dev.md).
+For information that is helpful for o1js core contributors, see
+[README-dev](README-dev.md).
 
 ### Creating high-quality community packages
 
-To ensure consistency within the o1js ecosystem and ease review and use by our team and other o1js devs, we encourage community packages to follow these standards:
+To ensure consistency within the o1js ecosystem and ease review and use by our
+team and other o1js devs, we encourage community packages to follow these
+standards:
 
 - The package is published to [npm](https://www.npmjs.com/).
-  - `npm install <your-package>` works and is all that is needed to use the package.
-  - o1js must be listed as a [peer dependency](https://docs.npmjs.com/cli/v9/configuring-npm/package-json#peerdependencies).
+  - `npm install <your-package>` works and is all that is needed to use the
+    package.
+  - o1js must be listed as a
+    [peer dependency](https://docs.npmjs.com/cli/v9/configuring-npm/package-json#peerdependencies).
   - If applicable, the package must work both on the web and in NodeJS.
-- The package is created using the [zkApp CLI](https://www.npmjs.com/package/zkapp-cli) (recommended).  
-  If you did not create the package using the zkApp CLI, follow these guidelines for code consistency:
-  - Use TypeScript, and export types from `d.ts` files. We suggest that you base your tsconfig on the [tsconfig.json](./tsconfig.json) that o1js uses.
-  - Code must be auto-formatted with [prettier](https://prettier.io/). We encourage you to use [.prettierrc.cjs](./.prettierrc.cjs), the same prettier config as o1js.
+- The package is created using the
+  [zkApp CLI](https://www.npmjs.com/package/zkapp-cli) (recommended). If you did
+  not create the package using the zkApp CLI, follow these guidelines for code
+  consistency:
+  - Use TypeScript, and export types from `d.ts` files. We suggest that you base
+    your tsconfig on the [tsconfig.json](./tsconfig.json) that o1js uses.
+  - Code must be auto-formatted with [prettier](https://prettier.io/). We
+    encourage you to use [.prettierrc.cjs](./.prettierrc.cjs), the same prettier
+    config as o1js.
 - The package includes tests.
-  - If applicable, tests must demonstrate that the package's methods can successfully run as provable code. For example, when the package is used in a SmartContract or ZkProgram that is compiled and proven.
-  - Ideally, your tests are easy to use, modify, and port to other projects by developers in the ecosystem. This is achieved by using Jest (see [jest.config.js](./jest.config.js) for an example config) or by structuring your tests as plain node scripts, like [this example](./src/lib/circuit_value.unit-test.ts).
-- Public API must be documented and [JSDoc](https://jsdoc.app/) comments must be present on exported methods and globals.
+  - If applicable, tests must demonstrate that the package's methods can
+    successfully run as provable code. For example, when the package is used in
+    a SmartContract or ZkProgram that is compiled and proven.
+  - Ideally, your tests are easy to use, modify, and port to other projects by
+    developers in the ecosystem. This is achieved by using Jest (see
+    [jest.config.js](./jest.config.js) for an example config) or by structuring
+    your tests as plain node scripts, like
+    [this example](./src/lib/circuit_value.unit-test.ts).
+- Public API must be documented and [JSDoc](https://jsdoc.app/) comments must be
+  present on exported methods and globals.
 - Include README and LICENSE files.
 - Comments and README must be in English and preferably use American spelling.
 
@@ -36,17 +58,28 @@ To ensure consistency within the o1js ecosystem and ease review and use by our t
 
 The `main` branch contains the development version of the code.
 
-To contribute directly to this project repo, follow these steps to get your changes in the `main` branch as quickly as possible.
+To contribute directly to this project repo, follow these steps to get your
+changes in the `main` branch as quickly as possible.
 
-1. Create a new issue for your proposed changes or use an existing issue if a relevant one exists.
-1. Write a request for comment (RFC) to outline your proposed changes and motivation, like this [example RFC](https://github.com/o1-labs/o1js/issues/233). Describe your objective and why the change is useful, how it works, and so on.
+1. Create a new issue for your proposed changes or use an existing issue if a
+   relevant one exists.
+1. Write a request for comment (RFC) to outline your proposed changes and
+   motivation, like this
+   [example RFC](https://github.com/o1-labs/o1js/issues/233). Describe your
+   objective and why the change is useful, how it works, and so on.
 
-   Note: If you are proposing a smaller change your RFC will be smaller, and that's ok! :)
+   Note: If you are proposing a smaller change your RFC will be smaller, and
+   that's ok! :)
 
-1. One of the codebase maintainers reviews your RFC and works with you until it is approved.
-1. After your RFC proposal is approved, fork the repository and implement your changes.
+1. One of the codebase maintainers reviews your RFC and works with you until it
+   is approved.
+1. After your RFC proposal is approved, fork the repository and implement your
+   changes.
 1. Submit a pull request and wait for code review. :)
 
-Our goal is to include functionality within o1js when the change is likely to be widely useful for developers. For more esoteric functionality, it makes more sense to provide high-quality community packages that can be used alongside o1js.
+Our goal is to include functionality within o1js when the change is likely to be
+widely useful for developers. For more esoteric functionality, it makes more
+sense to provide high-quality community packages that can be used alongside
+o1js.
 
 We appreciate your contribution!

--- a/README-dev.md
+++ b/README-dev.md
@@ -1,13 +1,20 @@
 # o1js README-dev
 
-o1js is a TypeScript framework designed for zk-SNARKs and zkApps on the Mina blockchain.
+o1js is a TypeScript framework designed for zk-SNARKs and zkApps on the Mina
+blockchain.
 
 - [zkApps Overview](https://docs.minaprotocol.com/zkapps)
 - [Mina README](/src/mina/README.md)
 
-For more information on our development process and how to contribute, see [CONTRIBUTING.md](https://github.com/o1-labs/o1js/blob/main/CONTRIBUTING.md). This document is meant to guide you through building o1js from source and understanding the development workflow.
+For more information on our development process and how to contribute, see
+[CONTRIBUTING.md](https://github.com/o1-labs/o1js/blob/main/CONTRIBUTING.md).
+This document is meant to guide you through building o1js from source and
+understanding the development workflow.
 
-It is a manual step to build the [o1js Reference docs](https://docs.minaprotocol.com/zkapps/o1js-reference). See [o1js Reference](https://github.com/o1-labs/docs2/wiki/o1js-Reference) in the docs wiki style guide.
+It is a manual step to build the
+[o1js Reference docs](https://docs.minaprotocol.com/zkapps/o1js-reference). See
+[o1js Reference](https://github.com/o1-labs/docs2/wiki/o1js-Reference) in the
+docs wiki style guide.
 
 ## Prerequisites
 
@@ -16,8 +23,10 @@ Before starting, ensure you have the following tools installed:
 - [Git](https://git-scm.com/)
 - [Node.js and npm](https://nodejs.org/)
 - [gh](https://cli.github.com/) (used to download artifacts)
-- [Dune, ocamlc, opam](https://github.com/ocaml/dune) (only needed when compiling o1js from source)
-- [Cargo, rustup](https://www.rust-lang.org/learn/get-started) (only needed when compiling o1js from source)
+- [Dune, ocamlc, opam](https://github.com/ocaml/dune) (only needed when
+  compiling o1js from source)
+- [Cargo, rustup](https://www.rust-lang.org/learn/get-started) (only needed when
+  compiling o1js from source)
 
 After cloning the repository, you need to fetch the submodules:
 
@@ -35,84 +44,142 @@ gh auth login #gh is used to download the compiled artifacts
 npm run build
 ```
 
-This command downloads the artifacts from github if they are missing and compiles the TypeScript source files, making them ready for use.
-The compiled OCaml and WebAssembly artifacts are cached for each commit where ci is run.These artifacts are stored under `src/bindings/compiled` and `src/bindings/mina-transaction/gen` and contain the artifacts needed for both nodejs and web builds.
-These files only have to be regenerated if there are changes to the OCaml or Rust source files.
+This command downloads the artifacts from github if they are missing and
+compiles the TypeScript source files, making them ready for use. The compiled
+OCaml and WebAssembly artifacts are cached for each commit where ci is run.These
+artifacts are stored under `src/bindings/compiled` and
+`src/bindings/mina-transaction/gen` and contain the artifacts needed for both
+nodejs and web builds. These files only have to be regenerated if there are
+changes to the OCaml or Rust source files.
 
 ### External contributors
 
-Unfortunately you generally won't be able to run `npm run build:bindings-download` on your own commits
-because the artifacts won't have been built for them, so make sure to run it on main before you start making changes.
-In a fresh git repo `npm run build` also works.
+Unfortunately you generally won't be able to run
+`npm run build:bindings-download` on your own commits because the artifacts
+won't have been built for them, so make sure to run it on main before you start
+making changes. In a fresh git repo `npm run build` also works.
 
-Keep in mind that merging a newer version of o1js may include Ocaml and rust changes so you may need to redownload the artifacts.
-When this happens, as long as you aren't making changes to the Ocaml and rust yourself,
-you can run `REV=<commit you just merged> npm run build:bindings-download`, this will download the bindings for the commit you merged which should be the same as the ones you need.
+Keep in mind that merging a newer version of o1js may include Ocaml and rust
+changes so you may need to redownload the artifacts. When this happens, as long
+as you aren't making changes to the Ocaml and rust yourself, you can run
+`REV=<commit you just merged> npm run build:bindings-download`, this will
+download the bindings for the commit you merged which should be the same as the
+ones you need.
 
 ### Internal contributors
 
-If you have an open pr `npm run build:bindings-download` should work on any commit where ci has run or is running.
-If ci is still running it uses `gh run watch` to show you the progress.
+If you have an open pr `npm run build:bindings-download` should work on any
+commit where ci has run or is running. If ci is still running it uses
+`gh run watch` to show you the progress.
 
-If your pr has a merge conflict, in which case CI will not run on each new commit, or you
-just don't have a pr you may can run `npm run build:bindings-remote`.
-This will trigger our self-hosted runner to build the bindings for your commit and download them once it finishes.
+If your pr has a merge conflict, in which case CI will not run on each new
+commit, or you just don't have a pr you may can run
+`npm run build:bindings-remote`. This will trigger our self-hosted runner to
+build the bindings for your commit and download them once it finishes.
 
 ## Building with nix
 
-Much like the mina repo, we use the nix registry to conveniently handle git submodules.
-You can enter the devshell with `./pin.sh` and `nix develop o1js#default` or by using
-direnv with the `.envrc` provided. This devshell provides all the dependencies required for npm scripts including `npm run build:update-bindings`.
+Much like the mina repo, we use the nix registry to conveniently handle git
+submodules. You can enter the devshell with `./pin.sh` and
+`nix develop o1js#default` or by using direnv with the `.envrc` provided. This
+devshell provides all the dependencies required for npm scripts including
+`npm run build:update-bindings`.
 
 ## Building Bindings
 
-To regenerate the OCaml and WebAssembly artifacts, you can do so within the o1js repo. The [bindings](https://github.com/o1-labs/o1js-bindings) and [Mina](https://github.com/MinaProtocol/mina) repos are both submodules of o1js so you can build them from within the o1js repo.
+To regenerate the OCaml and WebAssembly artifacts, you can do so within the o1js
+repo. The [bindings](https://github.com/o1-labs/o1js-bindings) and
+[Mina](https://github.com/MinaProtocol/mina) repos are both submodules of o1js
+so you can build them from within the o1js repo.
 
-o1js depends on OCaml code that is transpiled to JavaScript using [Js_of_ocaml](https://github.com/ocsigen/js_of_ocaml) and Rust code that is transpiled to WebAssembly using [wasm-pack](https://github.com/rustwasm/wasm-pack). These artifacts allow o1js to call into [Pickles](https://github.com/MinaProtocol/mina/blob/develop/src/lib/pickles/README.md), [snarky](https://github.com/o1-labs/snarky), and [Kimchi](https://github.com/o1-labs/proof-systems) to write zk-SNARKs and zkApps.
+o1js depends on OCaml code that is transpiled to JavaScript using
+[Js_of_ocaml](https://github.com/ocsigen/js_of_ocaml) and Rust code that is
+transpiled to WebAssembly using
+[wasm-pack](https://github.com/rustwasm/wasm-pack). These artifacts allow o1js
+to call into
+[Pickles](https://github.com/MinaProtocol/mina/blob/develop/src/lib/pickles/README.md),
+[snarky](https://github.com/o1-labs/snarky), and
+[Kimchi](https://github.com/o1-labs/proof-systems) to write zk-SNARKs and
+zkApps.
 
-The compiled artifacts are stored under `src/bindings/compiled` and are version-controlled to simplify the build process for end-users.
+The compiled artifacts are stored under `src/bindings/compiled` and are
+version-controlled to simplify the build process for end-users.
 
-If you want to rebuild the OCaml and Rust artifacts, you must be able to build the mina repo before building the bindings. See the [Mina Dev Readme](https://github.com/MinaProtocol/mina/blob/develop/README-dev.md) for more information. After you have configured your environment to build mina, you can build the bindings:
+If you want to rebuild the OCaml and Rust artifacts, you must be able to build
+the mina repo before building the bindings. See the
+[Mina Dev Readme](https://github.com/MinaProtocol/mina/blob/develop/README-dev.md)
+for more information. After you have configured your environment to build mina,
+you can build the bindings:
 
 ```sh
 npm run build:update-bindings
 ```
 
-This command builds the OCaml and Rust artifacts and copies them to the `src/bindings/compiled` directory.
+This command builds the OCaml and Rust artifacts and copies them to the
+`src/bindings/compiled` directory.
 
 ### Build Scripts
 
-The root build script which kicks off the build process is under `src/bindings/scripts/update-o1js-bindings.sh`. This script is responsible for building the Node.js and web artifacts for o1js, and places them under `src/bindings/compiled`, to be used by o1js.
+The root build script which kicks off the build process is under
+`src/bindings/scripts/update-o1js-bindings.sh`. This script is responsible for
+building the Node.js and web artifacts for o1js, and places them under
+`src/bindings/compiled`, to be used by o1js.
 
 ### OCaml Bindings
 
-o1js depends on Pickles, snarky, and parts of the Mina transaction logic, all of which are compiled to JavaScript and stored as artifacts to be used by o1js natively. The OCaml bindings are located under `src/bindings`. See the [OCaml Bindings README](https://github.com/o1-labs/o1js-bindings/blob/main/README.md) for more information.
+o1js depends on Pickles, snarky, and parts of the Mina transaction logic, all of
+which are compiled to JavaScript and stored as artifacts to be used by o1js
+natively. The OCaml bindings are located under `src/bindings`. See the
+[OCaml Bindings README](https://github.com/o1-labs/o1js-bindings/blob/main/README.md)
+for more information.
 
-To compile the OCaml code, a build tool called Dune is used. Dune is a build system for OCaml projects, and is used in addition with Js_of_ocaml to compile the OCaml code to JavaScript. The dune file that is responsible for compiling the OCaml code is located under `src/bindings/ocaml/dune`. There are two build targets: `o1js_node` and `o1js_web`, which compile the Mina dependencies as well as link the wasm artifacts to build the Node.js and web artifacts, respectively. The output file is `o1js_node.bc.js`, which is used by o1js.
+To compile the OCaml code, a build tool called Dune is used. Dune is a build
+system for OCaml projects, and is used in addition with Js_of_ocaml to compile
+the OCaml code to JavaScript. The dune file that is responsible for compiling
+the OCaml code is located under `src/bindings/ocaml/dune`. There are two build
+targets: `o1js_node` and `o1js_web`, which compile the Mina dependencies as well
+as link the wasm artifacts to build the Node.js and web artifacts, respectively.
+The output file is `o1js_node.bc.js`, which is used by o1js.
 
 ### WebAssembly Bindings
 
-o1js additionally depends on Kimchi, which is compiled to WebAssembly. Kimchi is located in the Mina repo under `src/mina`. See the [Kimchi README](https://github.com/o1-labs/proof-systems/blob/master/README.md) for more information.
+o1js additionally depends on Kimchi, which is compiled to WebAssembly. Kimchi is
+located in the Mina repo under `src/mina`. See the
+[Kimchi README](https://github.com/o1-labs/proof-systems/blob/master/README.md)
+for more information.
 
-To compile the Wasm code, a combination of Cargo and Dune is used. Both build files are located under `src/mina/src/lib/crypto/kimchi`, where the `wasm` folder contains the Rust code that is compiled to Wasm, and the `js` folder that contains a wrapper around the Wasm code which allows Js_of_ocaml to compile against the Wasm backend.
+To compile the Wasm code, a combination of Cargo and Dune is used. Both build
+files are located under `src/mina/src/lib/crypto/kimchi`, where the `wasm`
+folder contains the Rust code that is compiled to Wasm, and the `js` folder that
+contains a wrapper around the Wasm code which allows Js_of_ocaml to compile
+against the Wasm backend.
 
 For the Wasm build, the output files are:
 
 - `plonk_wasm_bg.wasm`: The compiled WebAssembly binary.
-- `plonk_wasm_bg.wasm.d.ts`: TypeScript definition files describing the types of .wasm or .js files.
+- `plonk_wasm_bg.wasm.d.ts`: TypeScript definition files describing the types of
+  .wasm or .js files.
 - `plonk_wasm.js`: JavaScript file that wraps the Wasm code for use in Node.js.
 - `plonk_wasm.d.ts`: TypeScript definition file for plonk_wasm.js.
 
 ### Generated Constant Types
 
-In addition to building the OCaml and Rust code, the build script also generates TypeScript types for constants used in the Mina protocol. These types are generated from the OCaml source files, and are located under `src/bindings/crypto/constants.ts` and `src/bindings/mina-transaction/gen`. When building the bindings, these constants are auto-generated by Dune. If you wish to add a new constant, you can edit the `src/bindings/ocaml/o1js_constants` file, and then run `npm run build:bindings` to regenerate the TypeScript files.
+In addition to building the OCaml and Rust code, the build script also generates
+TypeScript types for constants used in the Mina protocol. These types are
+generated from the OCaml source files, and are located under
+`src/bindings/crypto/constants.ts` and `src/bindings/mina-transaction/gen`. When
+building the bindings, these constants are auto-generated by Dune. If you wish
+to add a new constant, you can edit the `src/bindings/ocaml/o1js_constants`
+file, and then run `npm run build:bindings` to regenerate the TypeScript files.
 
-o1js uses these types to ensure that the constants used in the protocol are consistent with the OCaml source files.
+o1js uses these types to ensure that the constants used in the protocol are
+consistent with the OCaml source files.
 
 ### Bindings check in ci
 
-If the bindings check fails in CI it will upload a patch you can use to update the bindings without having to rebuild locally.
-This can also be helpful when the bindings don't build identically, as unfortunately often happens.
+If the bindings check fails in CI it will upload a patch you can use to update
+the bindings without having to rebuild locally. This can also be helpful when
+the bindings don't build identically, as unfortunately often happens.
 
 To use this patch:
 
@@ -133,13 +200,20 @@ To use this patch:
 | main               | **Yes**     |
 | develop            | No          |
 
-When you start your work on o1js, please create the feature branch off of one of the above base branches.
-It's encouraged to submit your work-in-progress as a draft PR to raise visibility!
-When working with submodules and various interconnected parts of the stack, ensure you are on the correct branches that are compatible with each other.
+When you start your work on o1js, please create the feature branch off of one of
+the above base branches. It's encouraged to submit your work-in-progress as a
+draft PR to raise visibility! When working with submodules and various
+interconnected parts of the stack, ensure you are on the correct branches that
+are compatible with each other.
 
 **Default to `main` as the base branch**.
 
-Other base branches (currently `develop` only) are used in specific scenarios where you want to adapt o1js to changes in the sibling repos on those other branches. Even then, consider whether it is feasible to land your changes to `main` and merge to `develop` afterwards. Only changes in `main` will ever be released, so anything in other branches has to be backported and reconciled with the `main` branch eventually.
+Other base branches (currently `develop` only) are used in specific scenarios
+where you want to adapt o1js to changes in the sibling repos on those other
+branches. Even then, consider whether it is feasible to land your changes to
+`main` and merge to `develop` afterwards. Only changes in `main` will ever be
+released, so anything in other branches has to be backported and reconciled with
+the `main` branch eventually.
 
 #### Relationship Between Repositories and Branches
 
@@ -150,30 +224,42 @@ Other base branches (currently `develop` only) are used in specific scenarios wh
 
 Where:
 
-- `compatible`: This is the [Mina repository](https://github.com/MinaProtocol/mina) branch. It corresponds to the `main` branch in both o1js and o1js-bindings repositories. This branch is where stable releases and soft-fork features are maintained.
+- `compatible`: This is the
+  [Mina repository](https://github.com/MinaProtocol/mina) branch. It corresponds
+  to the `main` branch in both o1js and o1js-bindings repositories. This branch
+  is where stable releases and soft-fork features are maintained.
 
-- `develop`: This branch is maintained across all three repositories. It is used for ongoing (next hard-fork) development, testing new features and integration work.
+- `develop`: This branch is maintained across all three repositories. It is used
+  for ongoing (next hard-fork) development, testing new features and integration
+  work.
 
 ### Style Guide
 
-This repo uses minimal [oxlint](https://oxc.rs/docs/guide/usage/linter.html) and [prettier](https://prettier.io/docs/) configs to stay tidy. Here are some tips to comply with the style:
+This repo uses minimal [oxlint](https://oxc.rs/docs/guide/usage/linter.html) and
+[prettier](https://prettier.io/docs/) configs to stay tidy. Here are some tips
+to comply with the style:
 
-1. Check for style violations by running the npm commands `npm run lint path/to/file` and `npm run format:check path/to/file`
+1. Check for style violations by running the npm commands
+   `npm run lint path/to/file` and `npm run format:check path/to/file`
 
 - To attempt to fix all style violations in all changed files, you can run:
   - `git diff --cached --name-only --diff-filter=d | grep -E '\.(ts|js)$' | xargs npm run format`
-  - and `git diff --cached --name-only --diff-filter=d | grep -E '\.(ts|js)$' | xargs npm run lint:fix`
+  - and
+    `git diff --cached --name-only --diff-filter=d | grep -E '\.(ts|js)$' | xargs npm run lint:fix`
 
 2. Integrate prettier into your dev environment
 
-- For instance the [VS Code](https://marketplace.visualstudio.com/items?itemName=esbenp.prettier-vscode) plugin allows for format on save
+- For instance the
+  [VS Code](https://marketplace.visualstudio.com/items?itemName=esbenp.prettier-vscode)
+  plugin allows for format on save
 
 3. Enable pre-commit hooks
 
-- There is an opt-in pre-commit hook available that will attempt to fix styling for all diffed files. Enable it by running `git config husky.optin true`
+- There is an opt-in pre-commit hook available that will attempt to fix styling
+  for all diffed files. Enable it by running `git config husky.optin true`
 
-> [!NOTE]
-> You can opt-out of linting in a PR by tagging it with skip-lint, in case the linting script is legitimately blocking an important PR
+> [!NOTE] You can opt-out of linting in a PR by tagging it with skip-lint, in
+> case the linting script is legitimately blocking an important PR
 
 ### Running Tests
 
@@ -184,7 +270,8 @@ npm run test
 npm run test:unit
 ```
 
-In order for the mina-signer tests to run you must also build from inside its subdirectory:
+In order for the mina-signer tests to run you must also build from inside its
+subdirectory:
 
 ```sh
 cd src/mina-signer
@@ -192,7 +279,8 @@ npm run build
 cd ../..
 ```
 
-This runs all the unit tests and provides you with a summary of the test results.
+This runs all the unit tests and provides you with a summary of the test
+results.
 
 Note that you can run individual jest tests via the command:
 
@@ -206,7 +294,8 @@ You can also run integration tests by running:
 npm run test:integration
 ```
 
-Finally, a set of end-to-end tests are run against the browser. These tests are not run by default, but you can run them by running:
+Finally, a set of end-to-end tests are run against the browser. These tests are
+not run by default, but you can run them by running:
 
 ```sh
 npm install
@@ -222,7 +311,8 @@ npm run e2e:show-report
 
 <!-- The test example should stay in sync with a real value set in .github/workflows/build-actions.yml -->
 
-You can execute the CI locally by using [act](https://github.com/nektos/act). First, generate a GitHub token and use:
+You can execute the CI locally by using [act](https://github.com/nektos/act).
+First, generate a GitHub token and use:
 
 ```sh
 act -j Build-And-Test-Server --matrix test_type:"Simple integration tests" -s $GITHUB_TOKEN
@@ -230,15 +320,21 @@ act -j Build-And-Test-Server --matrix test_type:"Simple integration tests" -s $G
 
 ### Releasing
 
-To release a new version of o1js, you must first update the version number in `package.json`. Then, you can create a new pull request to merge your changes into the main branch. After the pull request is merged, a CI job automatically publishes the new version to npm.
+To release a new version of o1js, you must first update the version number in
+`package.json`. Then, you can create a new pull request to merge your changes
+into the main branch. After the pull request is merged, a CI job automatically
+publishes the new version to npm.
 
 ## Testing and Debugging
 
 ### Test zkApps against Lightnet network
 
-Use the lightweight Mina blockchain network (Lightnet) to test on a local blockchain before you test with a live network. To test zkApps against the local blockchain, first spin up Lightnet.
+Use the lightweight Mina blockchain network (Lightnet) to test on a local
+blockchain before you test with a live network. To test zkApps against the local
+blockchain, first spin up Lightnet.
 
-The easiest way is to use [zkApp CLI](https://www.npmjs.com/package/zkapp-cli) sub-commands:
+The easiest way is to use [zkApp CLI](https://www.npmjs.com/package/zkapp-cli)
+sub-commands:
 
 ```shell
 zk lightnet start # start the local network
@@ -250,7 +346,8 @@ zk lightnet stop # stop the local network
 
 Use `zk lightnet --help` for more information.
 
-You can also use the corresponding [Docker image](https://hub.docker.com/r/o1labs/mina-local-network) manually:
+You can also use the corresponding
+[Docker image](https://hub.docker.com/r/o1labs/mina-local-network) manually:
 
 ```shell
 docker run --rm --pull=missing -it \
@@ -265,31 +362,48 @@ docker run --rm --pull=missing -it \
   o1labs/mina-local-network:compatible-latest-lightnet
 ```
 
-See the [Docker Hub repository](https://hub.docker.com/r/o1labs/mina-local-network) for more information.
+See the
+[Docker Hub repository](https://hub.docker.com/r/o1labs/mina-local-network) for
+more information.
 
 Next up, get the Mina blockchain accounts information to be used in your zkApp.
-After the local network is up and running, you can use the [Lightnet](https://github.com/o1-labs/o1js/blob/ec789794b2067addef6b6f9c9a91c6511e07e37c/src/lib/fetch.ts#L1012) `o1js API namespace` to get the accounts information.
-See the corresponding example in [src/examples/zkapps/hello-world/run-live.ts](https://github.com/o1-labs/o1js/blob/ec789794b2067addef6b6f9c9a91c6511e07e37c/src/examples/zkapps/hello-world/run-live.ts).
+After the local network is up and running, you can use the
+[Lightnet](https://github.com/o1-labs/o1js/blob/ec789794b2067addef6b6f9c9a91c6511e07e37c/src/lib/fetch.ts#L1012)
+`o1js API namespace` to get the accounts information. See the corresponding
+example in
+[src/examples/zkapps/hello-world/run-live.ts](https://github.com/o1-labs/o1js/blob/ec789794b2067addef6b6f9c9a91c6511e07e37c/src/examples/zkapps/hello-world/run-live.ts).
 
 ### Profiling o1js
 
-To enhance the development experience and optimize the performance of o1js, use the Chrome Debugger alongside Node.js. This setup is particularly useful when you want to profile the performance of your zkApp or o1js.
+To enhance the development experience and optimize the performance of o1js, use
+the Chrome Debugger alongside Node.js. This setup is particularly useful when
+you want to profile the performance of your zkApp or o1js.
 
 #### Using the `run-debug` script
 
-To facilitate this process, use the provided script named `run-debug`. To use this script, run:
+To facilitate this process, use the provided script named `run-debug`. To use
+this script, run:
 
 ```sh
 ./run-debug <path-to-your-zkapp> --bundle
 ```
 
-This script initializes a Node.js process with the `--inspect-brk` flag that starts the Node.js inspector and breaks before the user script starts (i.e., it pauses execution until a debugger is attached). The `--enable-source-maps` flag ensures that source maps are used to allow easy debugging of o1js code directly.
+This script initializes a Node.js process with the `--inspect-brk` flag that
+starts the Node.js inspector and breaks before the user script starts (i.e., it
+pauses execution until a debugger is attached). The `--enable-source-maps` flag
+ensures that source maps are used to allow easy debugging of o1js code directly.
 
-After the Node.js process is running, open the Chrome browser and navigate to `chrome://inspect` to attach the Chrome Debugger to the Node.js process. You can set breakpoints, inspect variables, and profile the performance of your zkApp or o1js. For more information on using the Chrome Debugger, see the [DevTools documentation](https://developer.chrome.com/docs/devtools/).
+After the Node.js process is running, open the Chrome browser and navigate to
+`chrome://inspect` to attach the Chrome Debugger to the Node.js process. You can
+set breakpoints, inspect variables, and profile the performance of your zkApp or
+o1js. For more information on using the Chrome Debugger, see the
+[DevTools documentation](https://developer.chrome.com/docs/devtools/).
 
 ### Debugging within the SDK
 
-To debug a call into the SDK, you can link your local copy of the SDK with `npm link`. After that, you'll be able to add log statements, set breakpoints, and make code changes. Within the SDK, run:
+To debug a call into the SDK, you can link your local copy of the SDK with
+`npm link`. After that, you'll be able to add log statements, set breakpoints,
+and make code changes. Within the SDK, run:
 
 ```sh
 npm run link
@@ -303,7 +417,11 @@ npm link o1js
 
 #### Logging from OCaml
 
-If you need to debug a call into the OCaml code, the process is a little more complicated. The OCaml is compiled into JavaScript with js_of_ocaml during `npm run build:update-bindings`, so you'll need to add your logs into the OCaml code and rebuild the bindings to see them. Logging from OCaml in a way that will reflect as JS `console.log`s in the compiled code can be done like this:
+If you need to debug a call into the OCaml code, the process is a little more
+complicated. The OCaml is compiled into JavaScript with js_of_ocaml during
+`npm run build:update-bindings`, so you'll need to add your logs into the OCaml
+code and rebuild the bindings to see them. Logging from OCaml in a way that will
+reflect as JS `console.log`s in the compiled code can be done like this:
 
 ```ocaml
 let () = print_endline "This is a log" in

--- a/README-nix.md
+++ b/README-nix.md
@@ -4,14 +4,13 @@
 configuration that can help developers build a project in a reproducible and
 reliable manner, without messing up versions during upgrades.
 
-Much like the `mina` repository, you can use Nix to
-handle the dependencies required across the codebase, including npm scripts.
+Much like the `mina` repository, you can use Nix to handle the dependencies
+required across the codebase, including npm scripts.
 
-> **When should I use Nix?**
-> If you cannot build the codebase locally (due to untrusty package manager,
-> faulty versioning, or unavailable libraries), it is a good idea to try the Nix
-> build instead. This can happen especially if you're using a Mac–and even more
-> likely–with non-Intel chips.
+> **When should I use Nix?** If you cannot build the codebase locally (due to
+> untrusty package manager, faulty versioning, or unavailable libraries), it is
+> a good idea to try the Nix build instead. This can happen especially if you're
+> using a Mac–and even more likely–with non-Intel chips.
 
 ## Installing Nix
 
@@ -22,7 +21,8 @@ sh <(curl -L https://nixos.org/nix/install) --daemon
 ```
 
 If you're unsure about your Nix setup, the assistant will guide you towards a
-clean installation. It will involve backing up your old `/etc/X` and `/etc/X.backup-before-nix` for `X = {bash.bashrc, bashrc, zshrc}`, and finally
+clean installation. It will involve backing up your old `/etc/X` and
+`/etc/X.backup-before-nix` for `X = {bash.bashrc, bashrc, zshrc}`, and finally
 uninstalling and reinstalling Nix from scratch.
 
 > **warning for macOS users**: macOS updates will often break your nix
@@ -43,17 +43,17 @@ new shell and type
 nix-shell -p nix-info --run "nix-info -m"
 ```
 
-That should output some basic information about the configuration parameters for Nix.
+That should output some basic information about the configuration parameters for
+Nix.
 
 ## Enabling Flakes (recommended)
 
-Mina is packaged using [Nix Flakes](https://nixos.wiki/wiki/Flakes),
-which are an experimental feature of Nix. However, compatibility with
-pre-flake Nix is provided. If you wish to contribute the Nix
-expressions in this repository, or want to get some convenience
-features and speed improvements, **it is advisable to enable flakes**. For
-this, you'll want to make sure you're running recent Nix (⩾2.5) and
-have enabled the relevant experimental features, either in
+Mina is packaged using [Nix Flakes](https://nixos.wiki/wiki/Flakes), which are
+an experimental feature of Nix. However, compatibility with pre-flake Nix is
+provided. If you wish to contribute the Nix expressions in this repository, or
+want to get some convenience features and speed improvements, **it is advisable
+to enable flakes**. For this, you'll want to make sure you're running recent Nix
+(⩾2.5) and have enabled the relevant experimental features, either in
 `/etc/nix/nix.conf` or (recommended) in `~/.config/nix/nix.conf` (meaning to add
 `experimental-features = nix-command flakes` in that file):
 
@@ -88,8 +88,9 @@ with all the dependencies required executing `nix develop o1js#default`.
 nix develop o1js#default
 ```
 
-On macos the first time you run this command, you can expect it to take hours (or even a full day) to complete, due to the lack of cached builds.
-Then, you will observe that the current devshell becomes a Nix shell with the right
+On macos the first time you run this command, you can expect it to take hours
+(or even a full day) to complete, due to the lack of cached builds. Then, you
+will observe that the current devshell becomes a Nix shell with the right
 configuration for `o1js` and `mina`.
 
 From within the shell, you can build o1js and update the bindings.
@@ -113,33 +114,42 @@ nix develop mina
 
 ### Storage handling
 
-Using Nix can take up a lot of disk space if not optimized. Every time you run `nix develop {SOMETHING}`, Nix will create new generations taking gigabytes of data instead of replacing the old ones. This can soon become a problem in your hard disk if you don't handle it carefully. Here are a few indications that can help with this.
+Using Nix can take up a lot of disk space if not optimized. Every time you run
+`nix develop {SOMETHING}`, Nix will create new generations taking gigabytes of
+data instead of replacing the old ones. This can soon become a problem in your
+hard disk if you don't handle it carefully. Here are a few indications that can
+help with this.
 
-Nix has a garbage collector that **is not used by default** after every run. Instead, artifacts get accumulated in your disk unless configured otherwise.
-This is why we recomend `auto-optimise-store = true` (you will be prompted to accept this). You can also run `nix-store --optimize` retroactively.
+Nix has a garbage collector that **is not used by default** after every run.
+Instead, artifacts get accumulated in your disk unless configured otherwise.
+This is why we recomend `auto-optimise-store = true` (you will be prompted to
+accept this). You can also run `nix-store --optimize` retroactively.
 
-If you still need to free up space you can run `nix-store --gc`, unfortunately this can slow down futurue nix builds by forcing you to rebuild dependencies.
-This can be mitigated with [direnv](https://github.com/direnv/direnv) and [nix-direnv](https://github.com/nix-community/nix-direnv) which can create garbage collector roots,
-keeping one gc-root to the latest build of the dev shell so that `nix-store --gc` won't remove it.
-You can also create a gc root any time you run `nix build` (until you remove `./result`) so running `nix build o1js#bindings` before `nix-store --gc` may also help.
+If you still need to free up space you can run `nix-store --gc`, unfortunately
+this can slow down futurue nix builds by forcing you to rebuild dependencies.
+This can be mitigated with [direnv](https://github.com/direnv/direnv) and
+[nix-direnv](https://github.com/nix-community/nix-direnv) which can create
+garbage collector roots, keeping one gc-root to the latest build of the dev
+shell so that `nix-store --gc` won't remove it. You can also create a gc root
+any time you run `nix build` (until you remove `./result`) so running
+`nix build o1js#bindings` before `nix-store --gc` may also help.
 
 ### Runtime optimization
 
-We suggest a few settings in `flake.nix`.
-You will be prompted to accept or reject these the first time you use nix in this repo.
-You can also use `--accept-flake-config` to accept all of them.
+We suggest a few settings in `flake.nix`. You will be prompted to accept or
+reject these the first time you use nix in this repo. You can also use
+`--accept-flake-config` to accept all of them.
 
-`max-jobs = auto`
-For some reason the default is `1`.
+`max-jobs = auto` For some reason the default is `1`.
 
-`auto-optimize-store = true;`
-When building slightly different versions of the same repo your nix store can fill up with coppies of the same files.
-This saves space by replacing them with symlinks.
+`auto-optimize-store = true;` When building slightly different versions of the
+same repo your nix store can fill up with coppies of the same files. This saves
+space by replacing them with symlinks.
 
-`substituters = ...`
-`trusted-public-keys = ...`
-These make sure you are using the mina-nix-cache which will save time by downloading any derivations already available.
-Anything built in CI is added to this nix-cache, so it should make a big difference in build times.
+`substituters = ...` `trusted-public-keys = ...` These make sure you are using
+the mina-nix-cache which will save time by downloading any derivations already
+available. Anything built in CI is added to this nix-cache, so it should make a
+big difference in build times.
 
 ## Common Issues
 
@@ -198,7 +208,8 @@ Alternatively, try this change in the `src/mina/flake.nix` file:
 
 ### wasm32-unknown-unknown
 
-The rust compiler and/or Wasm-pack might not be correctly setup in the Nix shell.
+The rust compiler and/or Wasm-pack might not be correctly setup in the Nix
+shell.
 
 ```console
 Error: wasm32-unknown-unknown target not found in sysroot:  "/nix/store/w30zw23kmgks77d870i502a3185hjycv-rust"
@@ -283,8 +294,8 @@ to install it from scratch.
 
 When several clones of the repository are present in the system and both have
 used Nix (or if it has been moved from one location to another), Nix might cache
-an old path, breaking builds. For example, typing `nix develop mina`
-would complain and produce the following error:
+an old path, breaking builds. For example, typing `nix develop mina` would
+complain and produce the following error:
 
 ```console
 error: resolving Git reference 'master': revspec 'master' not found
@@ -298,17 +309,22 @@ Rerun `pin.sh` and `src/mina/nix/pin.sh`.
 
 ### Changes to nix flakes aren't taking effect
 
-On MacOS, nix may ignore changes to files when nix commands are run and reuse the flake cached in its registry. Running commands like `nix develop o1js` and `nix run o1js#update-bindings` will reuse the cached version of the flake. As a result:
+On MacOS, nix may ignore changes to files when nix commands are run and reuse
+the flake cached in its registry. Running commands like `nix develop o1js` and
+`nix run o1js#update-bindings` will reuse the cached version of the flake. As a
+result:
 
 - The devshell could be missing newly added dependencies.
-- Builds executed directly with `nix run` could be generated from old source files.
+- Builds executed directly with `nix run` could be generated from old source
+  files.
 
 #### Fix
 
 There are two ways to ensure Nix recognizes flake changes:
 
 - Rerun `pin.sh` to force an update to the registry, then run your command.
-- Reference the flake by its directory path rather than its registry name. This forces Nix to use the current contents of the directory:
+- Reference the flake by its directory path rather than its registry name. This
+  forces Nix to use the current contents of the directory:
 
 ```bash
 nix develop .'?submodules=1#default'

--- a/README.md
+++ b/README.md
@@ -1,21 +1,27 @@
 # o1js &nbsp; [![npm version](https://img.shields.io/npm/v/o1js.svg?style=flat)](https://www.npmjs.com/package/o1js) [![npm](https://img.shields.io/npm/dm/o1js)](https://www.npmjs.com/package/o1js) [![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg)](https://github.com/o1-labs/o1js/blob/main/CONTRIBUTING.md)
 
-ℹ️ **o1js** is an evolution of [SnarkyJS](https://www.npmjs.com/package/snarkyjs) which saw
-49 updated versions over two years of development with 43,141 downloads.
+ℹ️ **o1js** is an evolution of
+[SnarkyJS](https://www.npmjs.com/package/snarkyjs) which saw 49 updated versions
+over two years of development with 43,141 downloads.
 
-This name change to o1js reflects the evolution of our vision for the premiere toolkit used by developers to build zero knowledge-enabled applications, while paying homage to our technology's recursive proof generation capabilities.
+This name change to o1js reflects the evolution of our vision for the premiere
+toolkit used by developers to build zero knowledge-enabled applications, while
+paying homage to our technology's recursive proof generation capabilities.
 
-Your favorite functionality stays the same and transitioning to o1js is a quick and easy process:
+Your favorite functionality stays the same and transitioning to o1js is a quick
+and easy process:
 
 - To update zkApp-cli, run the following command:
 
   `npm i -g zkapp-cli@latest`
 
-- To remove the now-deprecated SnarkyJS package and install o1js, run the following command:
+- To remove the now-deprecated SnarkyJS package and install o1js, run the
+  following command:
 
   `npm remove snarkyjs && npm install o1js`
 
-- For existing zkApps, make sure to update your imports from `snarkyjs` to `o1js`
+- For existing zkApps, make sure to update your imports from `snarkyjs` to
+  `o1js`
 - No need to redeploy, you are good to go!
 
 ## o1js
@@ -24,39 +30,64 @@ o1js helps developers build apps powered by zero knowledge (zk) cryptography.
 
 The easiest way to write zk programs is using o1js.
 
-o1js is a TypeScript library for [zk-SNARKs](https://minaprotocol.com/blog/what-are-zk-snarks) and zkApps. You can use o1js to write zk smart contracts based on zero-knowledge proofs for the Mina Protocol.
+o1js is a TypeScript library for
+[zk-SNARKs](https://minaprotocol.com/blog/what-are-zk-snarks) and zkApps. You
+can use o1js to write zk smart contracts based on zero-knowledge proofs for the
+Mina Protocol.
 
-o1js is automatically included when you create a project using the [zkApp CLI](https://www.npmjs.com/package/zkapp-cli).
+o1js is automatically included when you create a project using the
+[zkApp CLI](https://www.npmjs.com/package/zkapp-cli).
 
 ## Learn More
 
-- To learn more about developing zkApps, see the [zkApp Developers](https://docs.minaprotocol.com/zkapps) docs.
+- To learn more about developing zkApps, see the
+  [zkApp Developers](https://docs.minaprotocol.com/zkapps) docs.
 
-- For guided steps building and using zkApps, see the [zkApp Developers Tutorials](https://docs.minaprotocol.com/zkapps/tutorials/hello-world).
+- For guided steps building and using zkApps, see the
+  [zkApp Developers Tutorials](https://docs.minaprotocol.com/zkapps/tutorials/hello-world).
 
-- To meet other developers building zkApps with o1js, participate in the [#zkapps-developers](https://discord.com/channels/484437221055922177/915745847692636181) channel on Mina Protocol Discord.
+- To meet other developers building zkApps with o1js, participate in the
+  [#zkapps-developers](https://discord.com/channels/484437221055922177/915745847692636181)
+  channel on Mina Protocol Discord.
 
-- For a list of changes between versions, see the [CHANGELOG](https://github.com/o1-labs/o1js/blob/main/CHANGELOG.md).
+- For a list of changes between versions, see the
+  [CHANGELOG](https://github.com/o1-labs/o1js/blob/main/CHANGELOG.md).
 
-- To stay up to date with o1js, see the [O(1) Labs Blog](https://www.o1labs.org/blog?topics=o1js).
+- To stay up to date with o1js, see the
+  [O(1) Labs Blog](https://www.o1labs.org/blog?topics=o1js).
 
 ## Contributing
 
-o1js is an open source project. We appreciate all community contributions to o1js!
+o1js is an open source project. We appreciate all community contributions to
+o1js!
 
-See the [Contributing guidelines](https://github.com/o1-labs/o1js/blob/main/CONTRIBUTING.md) for ways you can contribute.
+See the
+[Contributing guidelines](https://github.com/o1-labs/o1js/blob/main/CONTRIBUTING.md)
+for ways you can contribute.
 
 ## Development Workflow
 
-For guidance on building o1js from source and understanding the development workflow, see [o1js README-dev](https://github.com/o1-labs/o1js/blob/main/README-dev.md).
+For guidance on building o1js from source and understanding the development
+workflow, see
+[o1js README-dev](https://github.com/o1-labs/o1js/blob/main/README-dev.md).
 
 ## Community Packages
 
-High-quality community packages from open source developers are available for your project.
+High-quality community packages from open source developers are available for
+your project.
 
-- **o1js-elgamal** A partially homomorphic encryption library for o1js based on Elgamal encryption: [GitHub](https://github.com/Trivo25/o1js-elgamal) and [npm](https://www.npmjs.com/package/o1js-elgamal)
-- **o1js-pack** A library for o1js that allows a zkApp developer to pack extra data into a single Field. [GitHub](https://github.com/45930/o1js-pack) and [npm](https://www.npmjs.com/package/o1js-pack)
-- **zk-regex-o1js** A CLI tool for compiling ZK Regex circuits in o1js. [Github](https://github.com/Shigoto-dev19/zk-regex-o1js) and [npm](https://www.npmjs.com/package/zk-regex-o1js)
-- **eddsa-o1js** A library for provable EdDSA and Twisted Edwards Curve operations. [Github](https://github.com/o1-labs-XT/eddsa-o1js) and [npm](https://www.npmjs.com/package/eddsa-o1js)
+- **o1js-elgamal** A partially homomorphic encryption library for o1js based on
+  Elgamal encryption: [GitHub](https://github.com/Trivo25/o1js-elgamal) and
+  [npm](https://www.npmjs.com/package/o1js-elgamal)
+- **o1js-pack** A library for o1js that allows a zkApp developer to pack extra
+  data into a single Field. [GitHub](https://github.com/45930/o1js-pack) and
+  [npm](https://www.npmjs.com/package/o1js-pack)
+- **zk-regex-o1js** A CLI tool for compiling ZK Regex circuits in o1js.
+  [Github](https://github.com/Shigoto-dev19/zk-regex-o1js) and
+  [npm](https://www.npmjs.com/package/zk-regex-o1js)
+- **eddsa-o1js** A library for provable EdDSA and Twisted Edwards Curve
+  operations. [Github](https://github.com/o1-labs-XT/eddsa-o1js) and
+  [npm](https://www.npmjs.com/package/eddsa-o1js)
 
-To include your package, see [Creating high-quality community packages](https://github.com/o1-labs/o1js/blob/main/CONTRIBUTING.md#creating-high-quality-community-packages).
+To include your package, see
+[Creating high-quality community packages](https://github.com/o1-labs/o1js/blob/main/CONTRIBUTING.md#creating-high-quality-community-packages).

--- a/package.json
+++ b/package.json
@@ -62,6 +62,8 @@
     "dump-vks": "npm run build && ./run tests/vk-regression/vk-regression.ts --bundle --dump",
     "format": "prettier --write --ignore-unknown",
     "format:check": "prettier --check --ignore-unknown",
+    "format:md": "prettier --config .prettierrc.md.cjs --write '*.md'",
+    "format:md:check": "prettier --config .prettierrc.md.cjs --check '*.md'",
     "clean": "rimraf ./dist && rimraf ./src/bindings/compiled/_node_bindings",
     "clean-all": "npm run clean && rimraf ./tests/report && rimraf ./tests/test-artifacts",
     "lint": "npx oxlint",


### PR DESCRIPTION
- Add .prettierrc.md.cjs for markdown-specific formatting config
- Add npm scripts for markdown formatting and checking
- Update CI to enforce markdown formatting standards
- Apply 80-character line wrapping to all top-level markdown files