### PR TITLE
Sourcemaps fix: bundle with sourcemaps.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,11 @@ This project adheres to
 
 ## [Unreleased](https://github.com/o1-labs/o1js/compare/045b1ab...HEAD)
 
+### Fixed
+
+- Sourcemaps properly work with the .cjs distribution of `o1js` now.
+  https://github.com/o1-labs/o1js/pull/2285
+
 ## [2.7.0](https://github.com/o1-labs/o1js/compare/6b6d8b9...045b1ab) - 2025-07-23
 
 ### Added

--- a/src/build/build-node.js
+++ b/src/build/build-node.js
@@ -38,6 +38,7 @@ async function buildNode({ production }) {
     plugins: [makeNodeModulesExternal(), makeJsooExternal()],
     dropLabels: ['ESM'],
     minify: false,
+    sourcemap: true,
   });
 }
 

--- a/src/build/build-web.js
+++ b/src/build/build-web.js
@@ -37,6 +37,7 @@ async function buildWeb({ production }) {
     target: 'esnext',
     plugins: [wasmPlugin()],
     allowOverwrite: true,
+    sourcemap: true,
   });
   bindings = await readFile(tmpBindingsPath, 'utf8');
   bindings = rewriteBundledWasmBindings(bindings);
@@ -89,6 +90,7 @@ async function buildWeb({ production }) {
     allowOverwrite: true,
     logLevel: 'error',
     minify,
+    sourcemap: true,
   });
 }
 


### PR DESCRIPTION
I was experiencing issues with minified stack traces.  This fixes it.

Test: build and check dist/node/index.cjs.map and dist/web/index.js.map.  Before this change, these files should not exist.  After, they should.