### PR TITLE
OCaml/dune: reformat correctly + modestly improve bindings/ocaml/dune

### DIFF
--- a/src/bindings/mina-transaction/gen/v2/dune
+++ b/src/bindings/mina-transaction/gen/v2/dune
@@ -1,6 +1,5 @@
 (rule
- (targets
-  js-layout.ts)
+ (targets js-layout.ts)
  (mode promote)
  (enabled_if
   (<> %{env:NO_JS_BUILD=0} 1))

--- a/src/bindings/ocaml/dune
+++ b/src/bindings/ocaml/dune
@@ -1,15 +1,16 @@
 (executable
- (name o1js_types)
- (public_name o1js-types)
- (package o1js_bindings)
- (modules o1js_types)
- (link_flags (-linkall))
- (modes native)
- (libraries mina_base fields_derivers.zkapps yojson)
+ (flags :standard -w +a)
  (instrumentation
   (backend bisect_ppx))
+ (libraries fields_derivers.zkapps mina_base yojson)
+ (link_flags (-linkall))
+ (modes native)
+ (modules o1js_types)
+ (name o1js_types)
+ (package o1js_bindings)
  (preprocess
-  (pps ppx_version)))
+  (pps ppx_version))
+ (public_name o1js-types))
 
 (rule
  (targets jsLayout.json)
@@ -19,26 +20,27 @@
    (run %{exe:./o1js_types.exe}))))
 
 (executable
- (name o1js_constants)
- (public_name o1js-constants)
- (package o1js_bindings)
- (modules o1js_constants)
- (link_flags (-linkall))
- (modes native)
- (libraries
-  mina_base
-  core_kernel
-  base
-  sponge
-  hash_prefixes
-  mina_signature_kind
-  base58_check
-  pickles
-  random_oracle
-  random_oracle.permutation.ocaml
-  yojson
-  protocol_version)
+ (flags :standard -w +a)
  (instrumentation
   (backend bisect_ppx))
+ (libraries
+  base
+  base58_check
+  core_kernel
+  hash_prefixes
+  mina_base
+  mina_signature_kind
+  pickles
+  protocol_version
+  random_oracle
+  random_oracle.permutation.ocaml
+  sponge
+  yojson)
+ (link_flags (-linkall))
+ (name o1js_constants)
+ (modes native)
+ (modules o1js_constants)
+ (package o1js_bindings)
  (preprocess
-  (pps ppx_version)))
+  (pps ppx_version))
+ (public_name o1js-constants))

--- a/src/bindings/ocaml/jsoo_exports/dune
+++ b/src/bindings/ocaml/jsoo_exports/dune
@@ -7,23 +7,27 @@
  (enabled_if
   (= %{env:PREBUILT_KIMCHI_BINDINGS_JS_NODE_JS=n} n))
  (targets node_js_plonk_wasm.js node_js_plonk_wasm_bg.wasm)
- (deps (:d1 ../../../mina/src/lib/crypto/kimchi_bindings/js/node_js/plonk_wasm.js) (:d2 ../../../mina/src/lib/crypto/kimchi_bindings/js/node_js/plonk_wasm_bg.wasm) )
+ (deps
+  (:d1 ../../../mina/src/lib/crypto/kimchi_bindings/js/node_js/plonk_wasm.js)
+  (:d2
+   ../../../mina/src/lib/crypto/kimchi_bindings/js/node_js/plonk_wasm_bg.wasm))
  (action
   (progn
    (run cp %{d1} node_js_plonk_wasm.js)
-   (run cp %{d2} node_js_plonk_wasm_bg.wasm)
-   )))
+   (run cp %{d2} node_js_plonk_wasm_bg.wasm))))
 
 (rule
  (enabled_if
   (= %{env:PREBUILT_KIMCHI_BINDINGS_JS_WEB=n} n))
  (targets web_plonk_wasm.js web_plonk_wasm_bg.wasm)
- (deps (:d1 ../../../mina/src/lib/crypto/kimchi_bindings/js/web/plonk_wasm.js) (:d2 ../../../mina/src/lib/crypto/kimchi_bindings/js/web/plonk_wasm_bg.wasm) )
+ (deps
+  (:d1 ../../../mina/src/lib/crypto/kimchi_bindings/js/web/plonk_wasm.js)
+  (:d2
+   ../../../mina/src/lib/crypto/kimchi_bindings/js/web/plonk_wasm_bg.wasm))
  (action
   (progn
    (run cp %{d1} web_plonk_wasm.js)
-   (run cp %{d2} web_plonk_wasm_bg.wasm)
-   )))
+   (run cp %{d2} web_plonk_wasm_bg.wasm))))
 
 (rule
  (enabled_if
@@ -31,9 +35,14 @@
  (targets node_js_plonk_wasm.js node_js_plonk_wasm_bg.wasm)
  (action
   (progn
-   (run cp %{env:PREBUILT_KIMCHI_BINDINGS_JS_NODE_JS=n}/plonk_wasm.js node_js_plonk_wasm.js)
-   (run cp %{env:PREBUILT_KIMCHI_BINDINGS_JS_NODE_JS=n}/plonk_wasm_bg.wasm node_js_plonk_wasm_bg.wasm)
-   )))
+   (run
+    cp
+    %{env:PREBUILT_KIMCHI_BINDINGS_JS_NODE_JS=n}/plonk_wasm.js
+    node_js_plonk_wasm.js)
+   (run
+    cp
+    %{env:PREBUILT_KIMCHI_BINDINGS_JS_NODE_JS=n}/plonk_wasm_bg.wasm
+    node_js_plonk_wasm_bg.wasm))))
 
 (rule
  (enabled_if
@@ -41,9 +50,14 @@
  (targets web_plonk_wasm.js web_plonk_wasm_bg.wasm)
  (action
   (progn
-   (run cp %{env:PREBUILT_KIMCHI_BINDINGS_JS_WEB=n}/plonk_wasm.js web_plonk_wasm.js)
-   (run cp %{env:PREBUILT_KIMCHI_BINDINGS_JS_WEB=n}/plonk_wasm_bg.wasm web_plonk_wasm_bg.wasm)
-   )))
+   (run
+    cp
+    %{env:PREBUILT_KIMCHI_BINDINGS_JS_WEB=n}/plonk_wasm.js
+    web_plonk_wasm.js)
+   (run
+    cp
+    %{env:PREBUILT_KIMCHI_BINDINGS_JS_WEB=n}/plonk_wasm_bg.wasm
+    web_plonk_wasm_bg.wasm))))
 
 (executable
  (name o1js_node)

--- a/src/bindings/ocaml/lib/local_ledger.ml
+++ b/src/bindings/ocaml/lib/local_ledger.ml
@@ -144,8 +144,7 @@ let check_account_update_signatures zkapp_command =
     Zkapp_command.Transaction_commitment.create_complete tx_commitment
       ~memo_hash:(Mina_base.Signed_command_memo.hash memo)
       ~fee_payer_hash:
-        (Zkapp_command.Digest.Account_update.create
-           ~signature_kind
+        (Zkapp_command.Digest.Account_update.create ~signature_kind
            (Account_update.of_fee_payer fee_payer) )
   in
   let key_to_string = Signature_lib.Public_key.Compressed.to_base58_check in

--- a/src/bindings/ocaml/lib/pickles_bindings.ml
+++ b/src/bindings/ocaml/lib/pickles_bindings.ml
@@ -617,7 +617,7 @@ let pickles_compile (choices : pickles_rule_js array)
       < publicInputSize : int Js.prop
       ; publicOutputSize : int Js.prop
       ; storable : Cache.js_storable Js.optdef_prop
-      ; overrideWrapDomain : int Js.optdef_prop 
+      ; overrideWrapDomain : int Js.optdef_prop
       ; numChunks : int Js.optdef_prop
       ; lazyMode : bool Js.optdef_prop >
       Js.t ) =
@@ -638,9 +638,7 @@ let pickles_compile (choices : pickles_rule_js array)
     Js.Optdef.to_option config##.overrideWrapDomain
     |> Option.map ~f:Pickles_base.Proofs_verified.of_int_exn
   in
-  let num_chunks =
-    Js.Optdef.get config##.numChunks (fun () -> 1)
-  in
+  let num_chunks = Js.Optdef.get config##.numChunks (fun () -> 1) in
   let lazy_mode = Js.Optdef.get config##.lazyMode (fun () -> false) in
   let (Choices choices) =
     Choices.of_js ~public_input_size ~public_output_size choices

--- a/src/bindings/ocaml/lib/pickles_bindings.mli
+++ b/src/bindings/ocaml/lib/pickles_bindings.mli
@@ -65,7 +65,7 @@ val pickles :
        -> < publicInputSize : int Js.prop
           ; publicOutputSize : int Js.prop
           ; storable : Cache.js_storable Js.optdef_prop
-          ; overrideWrapDomain : int Js.optdef_prop 
+          ; overrideWrapDomain : int Js.optdef_prop
           ; numChunks : int Js.optdef_prop
           ; lazyMode : bool Js.optdef_prop >
           Js.t


### PR DESCRIPTION
Running `dune fmt --auto-promote` to reformat files Caml modules and dune files, and reorgazing the fields in the stanza of the dune file for readability.