### PR TITLE
Revert "bindings/scripts: remove unused prepare-dune-build.sh"

### DIFF
--- a/src/bindings/scripts/prepare-dune-build.sh
+++ b/src/bindings/scripts/prepare-dune-build.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+
+# use this script before you can run `dune build <something>`
+
+set -e
+
+MINA_PATH="src/mina"
+
+# Copy mina config files, that is necessary for o1js to build
+dune b "${MINA_PATH}"/src/config.mlh && \
+cp "${MINA_PATH}"/src/config.mlh src && \
+cp -r "${MINA_PATH}"/src/config src/config


### PR DESCRIPTION
This reverts commit 9a2c4d7315dabf6e779294e1558cabaa1e587a42.

Pushed on main by mistake.