### PR TITLE
Update typedoc comments for smart contract init

### DIFF
--- a/src/lib/mina/v1/zkapp.ts
+++ b/src/lib/mina/v1/zkapp.ts
@@ -706,16 +706,38 @@ super.init();
       }
     });
   }
-  // TODO make this a @method and create a proof during `zk deploy` (+ add mechanism to skip this)
   /**
    * `SmartContract.init()` will be called only when a {@link SmartContract} will be first deployed, not for redeployment.
    * This method can be overridden as follows
-   * ```
+   *
+   * @example
+   * ```ts
    * class MyContract extends SmartContract {
-   *  init() {
+   *  @method async init() {
    *    super.init();
    *    this.account.permissions.set(...);
    *    this.x.set(Field(1));
+   *  }
+   * }
+   * ```
+   *
+   * @note
+   * `init` is specifically called during the smart contract deployment.  It cannot be given parameters for additional customization.
+   * In order to inizialize a smart contract with parameters (dynamic initialization), you should write another method to be called after the deployment.
+   *
+   * @example
+   * ```ts
+   * class MyContract extends SmartContract {
+   *  @method async init() {
+   *   super.init();
+   *   this.account.permissions.set(...);
+   *   this.x.set(Field(1));
+   *  }
+   *
+   *  @method async initializeY(y: Field) {
+   *    this.y.getAndRequireEquals();
+   *    this.y.assertEquals(Field(0)); // ensure y is not set yet
+   *    this.y.set(y);
    *  }
    * }
    * ```


### PR DESCRIPTION
See discussion on [discord](https://discord.com/channels/484437221055922177/915745847692636181/1393849452770361467)

The tutorials in the docs mismatch the API reference.  I tested the tutorial code, an it seems correct, so I think the API reference is the one that's out of date.  This documentation update corrects the confusing usage and offers a second example of initializing values outside of the `init` method.