### PR TITLE
Update rust version in o1js nix flake to match proof systems

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -103,7 +103,7 @@
           ((pkgs.rustChannelOf
             {
               channel = "nightly";
-              date = "nightly-2024-09-05";
+              date = "2024-09-05";
               sha256 = "sha256-s5nlYcYG9EuO2HK2BU3PkI928DZBKCTJ4U9bz3RX1t4=";
             }).rust.override
             {


### PR DESCRIPTION
Update rust version in o1js nix flake to match proof systems https://github.com/o1-labs/proof-systems/blob/master/Makefile#L33