### PR TITLE
Enable ZkProgram cache in the browser

### DIFF
--- a/src/bindings/js/web/worker-spec.js
+++ b/src/bindings/js/web/worker-spec.js
@@ -165,5 +165,23 @@ function workerSpec(wasm) {
       args: [wasm.WasmFqSrs, undefined /* number */],
       res: undefined /* number, ptr */,
     },
+    // New get_lagrange_basis pointer functions for web compatibility
+    // These fix zkProgram.compile() with cache writing in browsers
+    caml_fp_srs_get_lagrange_basis_ptr: {
+      args: [wasm.WasmFpSrs, undefined /* number */],
+      res: undefined /* number, ptr */,  // Returns pointer for worker communication
+    },
+    caml_fp_srs_get_lagrange_basis_read_from_ptr: {
+      args: [undefined /* number, ptr */],
+      res: undefined /* WasmVector */,  // Returns actual data
+    },
+    caml_fq_srs_get_lagrange_basis_ptr: {
+      args: [wasm.WasmFqSrs, undefined /* number */],
+      res: undefined /* number, ptr */,  // Returns pointer for worker communication
+    },
+    caml_fq_srs_get_lagrange_basis_read_from_ptr: {
+      args: [undefined /* number, ptr */],
+      res: undefined /* WasmVector */,  // Returns actual data
+    },
   };
 }


### PR DESCRIPTION
## Summary

Enables `ZkProgram.compile({ cache })` to work in browsers. Previously, cache writing was disabled in web environments because the underlying lagrange basis functions were not compatible with the web worker API and would cause compilation to hang indefinitely.

## Background

The `ZkProgram.compile({ cache })` functionality was broken in browsers because:
1. Lagrange basis functions returned `WasmVector` types incompatible with web worker transfer
2. These functions were disabled in `worker-spec.js` to prevent hanging
3. Cache writing would fail silently or hang when attempting to compute lagrange basis

## Changes

- Added 4 new pointer-based function registrations to `worker-spec.js`
- Updated `srs.ts` with environment-aware `getLagrangeBasis` function
- Automatically detects Node.js vs Web environments
- Uses pointer functions in browsers, direct functions in Node.js
- Updated TODO comment to reflect fixed functionality

## Testing Status

🚧 **Draft PR** - Testing in progress

- [ ] Build updated WASM bindings
- [ ] Test ZkProgram.compile() in Node.js (should work unchanged) 
- [ ] Test ZkProgram.compile() in browsers (should no longer hang)
- [ ] Validate ZkProgram cache works in the browser
- [ ] Performance validation and memory leak detection

## Related PRs

This is part 3 of 3 for the complete fix:
1. proof-systems#3306 (Rust pointer functions)
2. mina#17615 (submodule reference update)
3. **This PR**: o1js (worker spec + TypeScript integration)

## Files Changed

- `src/bindings/js/web/worker-spec.js` - Register new pointer functions
- `src/bindings/crypto/bindings/srs.ts` - Environment-aware integration

**Commits:**
- Add lagrange basis pointer functions to web worker specification
- Add environment-aware TypeScript integration for lagrange basis