### PR TITLE
Include hash in "VerificationKey.toJSON()" method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,11 +17,16 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased](https://github.com/o1-labs/o1js/compare/4e23a60...HEAD)
 
+### Fixed
+
+- Updated `VerificationKey.toJSON()` to include the verification key hash for
+  compliant encoding. https://github.com/o1-labs/o1js/pull/2332
+
 ### Added
 
 - [PR! 1905](https://github.com/o1-labs/o1js/pull/1905) API support for circuit chunking
   - still requires memory optimizations to be fully functional, and
-  - proof-systems version still needs to be updated to include [this commit](https://github.com/o1-labs/proof-systems/pull/3222/commits/8c37c293f8159eed3676964ba47fc5dc0ae6ea1e) 
+  - proof-systems version still needs to be updated to include [this commit](https://github.com/o1-labs/proof-systems/pull/3222/commits/8c37c293f8159eed3676964ba47fc5dc0ae6ea1e)
     - that fixed the zero knowledge rows mismatch across Kimchi WASM bindings
 
 ## [2.5.0](https://github.com/o1-labs/o1js/compare/6ff7f8470a...4e23a60)

--- a/src/lib/proof-system/verification-key.ts
+++ b/src/lib/proof-system/verification-key.ts
@@ -9,8 +9,8 @@ export { VerificationKey };
 
 class VerificationKey extends Struct({
   ...provable({ data: String, hash: Field }),
-  toJSON({ data }: { data: string }) {
-    return data;
+  toJSON({ data, hash }: { data: string; hash: Field }) {
+    return { data, hash: hash.toString() };
   },
 }) {
   static async dummy(): Promise<VerificationKey> {

--- a/src/lib/proof-system/verification-key.unit-test.ts
+++ b/src/lib/proof-system/verification-key.unit-test.ts
@@ -13,10 +13,14 @@ let vkIsValid = await VerificationKey.checkValidity(generated);
 assert(vkIsValid, 'valid verification key is being rejected as invalid');
 
 const invalidVerificationKey = new VerificationKey({
-    data: generated.data,
-    hash: Field.random(),
-  });
-
+  data: generated.data,
+  hash: Field.random(),
+});
 
 let vkIsNotValid = await VerificationKey.checkValidity(invalidVerificationKey);
 assert(vkIsNotValid === false, 'invalid verification key is being accepted as valid');
+
+const jsonVk = VerificationKey.toJSON(generated);
+const decodedVk = VerificationKey.fromJSON(jsonVk);
+let decodedVkIsValid = await VerificationKey.checkValidity(decodedVk);
+assert(decodedVkIsValid === true, 'decoded valid verification key is being rejected as invalid');


### PR DESCRIPTION
This PR fixes https://github.com/o1-labs/o1js/issues/1868 by including the verification key hash to the `VerificationKey.toJSON()` method.