### PR TITLE
`mina-signer` new release v3.1.0

### DIFF
--- a/src/mina-signer/CHANGELOG.md
+++ b/src/mina-signer/CHANGELOG.md
@@ -1,0 +1,25 @@
+# Changelog
+
+All notable changes to this project are documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
+This project adheres to
+[Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+<!--
+  Possible subsections:
+    _Added_ for new features.
+    _Changed_ for changes in existing functionality.
+    _Deprecated_ for soon-to-be removed features.
+    _Removed_ for now removed features.
+    _Fixed_ for any bug fixes.
+    _Security_ in case of vulnerabilities.
+ -->
+
+## [Unreleased](https://github.com/o1-labs/o1js/compare/f54dd40...HEAD)
+
+## [3.0.8](https://github.com/o1-labs/o1js/compare/e3e758b...f54dd40) - 2025-09-09
+
+### Added
+
+- Allow signing zkApp command without fee payer private key https://github.com/o1-labs/o1js/pull/2417

--- a/src/mina-signer/CHANGELOG.md
+++ b/src/mina-signer/CHANGELOG.md
@@ -22,4 +22,5 @@ This project adheres to
 
 ### Added
 
-- Allow signing zkApp command without fee payer private key https://github.com/o1-labs/o1js/pull/2417
+- Allow signing zkApp command without fee payer private key
+  https://github.com/o1-labs/o1js/pull/2417

--- a/src/mina-signer/CHANGELOG.md
+++ b/src/mina-signer/CHANGELOG.md
@@ -18,7 +18,7 @@ This project adheres to
 
 ## [Unreleased](https://github.com/o1-labs/o1js/compare/f54dd40...HEAD)
 
-## [3.0.8](https://github.com/o1-labs/o1js/compare/e3e758b...f54dd40) - 2025-09-09
+## [3.1.0](https://github.com/o1-labs/o1js/compare/e3e758b...f54dd40) - 2025-09-09
 
 ### Added
 

--- a/src/mina-signer/package-lock.json
+++ b/src/mina-signer/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "mina-signer",
-  "version": "3.0.8",
+  "version": "3.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "mina-signer",
-      "version": "3.0.8",
+      "version": "3.1.0",
       "license": "Apache-2.0",
       "dependencies": {
         "blakejs": "^1.2.1",

--- a/src/mina-signer/package-lock.json
+++ b/src/mina-signer/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "mina-signer",
-  "version": "3.0.7",
+  "version": "3.0.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "mina-signer",
-      "version": "3.0.7",
+      "version": "3.0.8",
       "license": "Apache-2.0",
       "dependencies": {
         "blakejs": "^1.2.1",

--- a/src/mina-signer/package.json
+++ b/src/mina-signer/package.json
@@ -1,7 +1,7 @@
 {
   "name": "mina-signer",
   "description": "Node API for signing transactions on various networks for Mina Protocol",
-  "version": "3.0.8",
+  "version": "3.1.0",
   "type": "module",
   "scripts": {
     "build": "tsc -p ../../tsconfig.mina-signer.json",

--- a/src/mina-signer/package.json
+++ b/src/mina-signer/package.json
@@ -1,7 +1,7 @@
 {
   "name": "mina-signer",
   "description": "Node API for signing transactions on various networks for Mina Protocol",
-  "version": "3.0.7",
+  "version": "3.0.8",
   "type": "module",
   "scripts": {
     "build": "tsc -p ../../tsconfig.mina-signer.json",


### PR DESCRIPTION
This release includes the changes of https://github.com/o1-labs/o1js/pull/2417, unblocking the Zeko team.

I added a (yet) small changelog file so we can start documenting changes to this library.