### PR TITLE
update Transaction.fromJSON to accept serialized JSON string

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ This project adheres to
 
 - Internal o1js and protocol constants, hashes and prefixes are now exported via
   the `Core´ namespace. https://github.com/o1-labs/o1js/pull/2421
+- Support for string type input to `Transaction.fromJSON` https://github.com/o1-labs/o1js/pull/2436
 
 ## [2.9.0](https://github.com/o1-labs/o1js/compare/4b1dccdd...114acff) - 2025-09-02
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,8 @@ This project adheres to
 
 - Internal o1js and protocol constants, hashes and prefixes are now exported via
   the `Core´ namespace. https://github.com/o1-labs/o1js/pull/2421
-- Support for string type input to `Transaction.fromJSON` https://github.com/o1-labs/o1js/pull/2436
+- Support for string type input to `Transaction.fromJSON`
+  https://github.com/o1-labs/o1js/pull/2436
 
 ## [2.9.0](https://github.com/o1-labs/o1js/compare/4b1dccdd...114acff) - 2025-09-02
 

--- a/src/lib/mina/v1/account-update.ts
+++ b/src/lib/mina/v1/account-update.ts
@@ -169,10 +169,7 @@ const False = () => Bool(false);
 type Permission = Types.AuthRequired;
 
 class VerificationKeyPermission {
-  constructor(
-    public auth: Permission,
-    public txnVersion: UInt32
-  ) {}
+  constructor(public auth: Permission, public txnVersion: UInt32) {}
 
   // TODO this class could be made incompatible with a plain object (breaking change)
   // private _ = undefined;
@@ -1766,7 +1763,35 @@ const ZkappCommand = {
       ...transaction.accountUpdates.map((a) => a.toPretty()),
     ];
   },
-  fromJSON(json: Types.Json.ZkappCommand): ZkappCommand {
+  parse(json: string): ZkappCommand {
+    let parsedJson: Types.Json.ZkappCommand;
+    try {
+      parsedJson = JSON.parse(json) as Types.Json.ZkappCommand;
+    } catch (error) {
+      throw new Error(
+        `Failed to parse ZkappCommand from JSON string: ${
+          error instanceof Error ? error.message : 'Invalid JSON'
+        }`
+      );
+    }
+
+    try {
+      return this.fromJSON(parsedJson);
+    } catch (error) {
+      throw new Error(
+        `Failed to construct ZkappCommand from parsed JSON: ${
+          error instanceof Error ? error.message : 'Invalid ZkappCommand structure'
+        }`
+      );
+    }
+  },
+  fromJSON(json: Types.Json.ZkappCommand | string): ZkappCommand {
+    // If it's a string, parse it and return
+    if (typeof json === 'string') {
+      return this.parse(json);
+    }
+
+    // Handle the Types.Json.ZkappCommand case
     let { feePayer } = Types.ZkappCommand.fromJSON({
       feePayer: json.feePayer,
       accountUpdates: [],

--- a/src/lib/mina/v1/transaction.test.ts
+++ b/src/lib/mina/v1/transaction.test.ts
@@ -65,7 +65,7 @@ describe('transactions', () => {
 
     // Serialize to JSON string
     let jsonString = originalTx.toJSON();
-    
+
     // Deserialize using fromJSON with string input
     let deserializedTx = Transaction.fromJSON(jsonString);
 
@@ -80,5 +80,22 @@ describe('transactions', () => {
       originalTx.transaction.accountUpdates.length
     );
     expect(deserializedTx.toJSON()).toEqual(originalTx.toJSON());
+  });
+
+  it('should throw proper error for malformed JSON string input', async () => {
+    // Test invalid JSON syntax
+    expect(() => {
+      Transaction.fromJSON('{"invalid": json}');
+    }).toThrow('Failed to parse ZkappCommand from JSON string:');
+
+    // Test valid JSON but invalid ZkappCommand structure
+    expect(() => {
+      Transaction.fromJSON('{"not": "a", "valid": "zkapp", "command": true}');
+    }).toThrow('Failed to construct ZkappCommand from parsed JSON:');
+
+    // Test completely malformed string
+    expect(() => {
+      Transaction.fromJSON('not json at all');
+    }).toThrow('Failed to parse ZkappCommand from JSON string:');
   });
 });

--- a/src/lib/mina/v1/transaction.test.ts
+++ b/src/lib/mina/v1/transaction.test.ts
@@ -1,4 +1,4 @@
-import { UInt64, SmartContract, Mina, AccountUpdate, method } from 'o1js';
+import { UInt64, SmartContract, Mina, AccountUpdate, method, Transaction } from 'o1js';
 
 class MyContract extends SmartContract {
   @method async shouldMakeCompileThrow() {
@@ -54,5 +54,31 @@ describe('transactions', () => {
     await new_fee.send();
     // check that tx was applied, by checking nonce was incremented
     expect((await new_fee).transaction.feePayer.body.nonce).toEqual(nonce);
+  });
+
+  it('fromJSON should serialize and deserialize transaction correctly', async () => {
+    // Create a transaction
+    let originalTx = await Mina.transaction(feePayer, async () => {
+      contract.requireSignature();
+      AccountUpdate.attachToTransaction(contract.self);
+    });
+
+    // Serialize to JSON string
+    let jsonString = originalTx.toJSON();
+    
+    // Deserialize using fromJSON with string input
+    let deserializedTx = Transaction.fromJSON(jsonString);
+
+    // Verify the deserialized transaction has the same structure
+    expect(deserializedTx.transaction.feePayer.body.publicKey.x).toEqual(
+      originalTx.transaction.feePayer.body.publicKey.x
+    );
+    expect(deserializedTx.transaction.feePayer.body.nonce).toEqual(
+      originalTx.transaction.feePayer.body.nonce
+    );
+    expect(deserializedTx.transaction.accountUpdates.length).toEqual(
+      originalTx.transaction.accountUpdates.length
+    );
+    expect(deserializedTx.toJSON()).toEqual(originalTx.toJSON());
   });
 });

--- a/src/lib/mina/v1/transaction.ts
+++ b/src/lib/mina/v1/transaction.ts
@@ -83,7 +83,26 @@ type TransactionCommon = {
 };
 
 namespace Transaction {
-  export function fromJSON(json: Types.Json.ZkappCommand): Transaction<false, false> {
+  /**
+   * Deserializes a transaction from a JSON object or JSON string representation.
+   * This method accepts both parsed JSON objects and JSON strings, making it flexible for different use cases.
+   *
+   * @param json A JSON object representation of a transaction (Types.Json.ZkappCommand) or a JSON string
+   * @returns A new Transaction instance reconstructed from the JSON input
+   *
+   * @example
+   * ```ts
+   * const originalTx = await Mina.transaction(sender, () => {
+   *   zkapp.someMethod();
+   * });
+   * const serialized = originalTx.toJSON();
+   * const deserializedTx = Transaction.fromJSON(serialized);
+   * ```
+   */
+  export function fromJSON(json: Types.Json.ZkappCommand | string): Transaction<false, false> {
+    if (typeof json === 'string') {
+      json = JSON.parse(json) as Types.Json.ZkappCommand;
+    }
     let transaction = ZkappCommand.fromJSON(json);
     return newTransaction(transaction, activeInstance.proofsEnabled);
   }

--- a/src/lib/mina/v1/transaction.ts
+++ b/src/lib/mina/v1/transaction.ts
@@ -100,9 +100,6 @@ namespace Transaction {
    * ```
    */
   export function fromJSON(json: Types.Json.ZkappCommand | string): Transaction<false, false> {
-    if (typeof json === 'string') {
-      json = JSON.parse(json) as Types.Json.ZkappCommand;
-    }
     let transaction = ZkappCommand.fromJSON(json);
     return newTransaction(transaction, activeInstance.proofsEnabled);
   }


### PR DESCRIPTION
## Summary

`tx.toJSON` returns a stringified JSON object, but `Transaction.fromJSON` does not accept a string input.  This makes is slightly awkward to work with serialized JSON transactions.

### Fix

This PR adds support for string as input to the `Transaction.fromJSON` function by adding a `ZkAppCommand.parse` function for handling string input.