### PR TITLE
feat: test cache

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -161,6 +161,7 @@ jobs:
             'Verification Key Regression Check 1',
             'Verification Key Regression Check 2',
             'CommonJS test',
+            'Cache Regression',
           ]
     steps:
       - name: Checkout repository with submodules
@@ -176,6 +177,10 @@ jobs:
           repository: ${{ inputs.target_repo || github.repository }}
           ref: ${{ inputs.target_ref || github.ref }}
           proof_systems_commit: ${{ inputs.proof_systems_commit }}
+      - uses: 'google-github-actions/auth@v3'
+        name: Setup gcloud authentication
+        with:
+          credentials_json: '${{ secrets.GCP_O1JS_CI_BUCKET_SERVICE_ACCOUNT_KEY }}'
       - name: Prepare for tests
         run: touch profiling.md
       - name: Execute tests

--- a/.github/workflows/upload-cache-regressions-artifacts.yml
+++ b/.github/workflows/upload-cache-regressions-artifacts.yml
@@ -1,0 +1,21 @@
+name: Upload Cache Regressions Artifacts
+on:
+  workflow_dispatch:
+
+jobs:
+  upload-artifacts:
+    name: Upload Cache Regressions Artifacts
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout repository with submodules
+      uses: actions/checkout@v4
+      with:
+        submodules: recursive
+    - name: Build
+      uses: ./.github/actions/build
+    - uses: 'google-github-actions/auth@v3'
+      name: Setup gcloud authentication
+      with:
+        credentials_json: '${{ secrets.GCP_O1JS_CI_BUCKET_SERVICE_ACCOUNT_KEY }}'
+    - name: Generate artifacts and upload to GS
+      run: ./scripts/tests/dump-cache-regressions.sh

--- a/npmDepsHash
+++ b/npmDepsHash
@@ -1,1 +1,1 @@
-sha256-x44xLfNO8RQpMnlWFlOk/cvWd7264mWxpbWQaTCaFms=
+sha256-CmWUZ+hMItoWISfwCwRNMkAgLm7E7jhUSxncSG/lkNI=

--- a/package-lock.json
+++ b/package-lock.json
@@ -27,6 +27,7 @@
         "@playwright/test": "^1.48.0",
         "@types/jest": "^27.0.0",
         "@types/libsodium-wrappers-sumo": "^0.7.8",
+        "@types/minimist": "^1.2.5",
         "@types/node": "^18.14.2",
         "esbuild": "^0.25.5",
         "expect": "^29.0.1",
@@ -2560,6 +2561,13 @@
       "dependencies": {
         "@types/libsodium-wrappers": "*"
       }
+    },
+    "node_modules/@types/minimist": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/@types/minimist/-/minimist-1.2.5.tgz",
+      "integrity": "sha512-hov8bUuiLiyFPGyFPE1lwWhmzYbirOXQNNo40+y3zow8aFVTeyn3VWL0VFFfdNddA8S4Vf0Tc062rzyNr7Paag==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/node": {
       "version": "18.18.9",

--- a/package.json
+++ b/package.json
@@ -92,6 +92,7 @@
     "@playwright/test": "^1.48.0",
     "@types/jest": "^27.0.0",
     "@types/libsodium-wrappers-sumo": "^0.7.8",
+    "@types/minimist": "^1.2.5",
     "@types/node": "^18.14.2",
     "esbuild": "^0.25.5",
     "expect": "^29.0.1",

--- a/run-ci-tests.sh
+++ b/run-ci-tests.sh
@@ -49,6 +49,10 @@ case $TEST_TYPE in
   node src/examples/commonjs.cjs
   ;;
 
+"Cache Regression")
+  echo "Cache Regression"
+  ./scripts/tests/check-cache-regressions.sh
+  ;;
 *)
   echo "ERROR: Invalid environment variable, not clear what tests to run! $CI_NODE_INDEX"
   exit 1

--- a/scripts/tests/check-cache-regressions.sh
+++ b/scripts/tests/check-cache-regressions.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+set -Eeuxo pipefail
+
+source ./scripts/lib/ux.sh
+
+# test cache regression packaging and unpackaging primitives here
+./run ./src/tests/cache/simple-regression.ts --bundle --mode dump --tarball ./tests/test-artifacts/cache/simple-regression.tar.gz
+
+./run ./src/tests/cache/simple-regression.ts --bundle --mode check --tarball ./tests/test-artifacts/cache/simple-regression.tar.gz
+
+# This pin is generated in ./dump-cache-regressions.sh
+ARTIFACT_PIN=2025-10-02T13:36:52-04:00
+
+WORKDIR=tests/test-artifacts/cache/
+mkdir -p $WORKDIR
+
+# Download all the artifacts into the workdir
+gcloud storage cp --recursive gs://o1js-ci/tests/cache/fixtures/$ARTIFACT_PIN/ $WORKDIR
+
+WORKDIR=tests/test-artifacts/cache/$ARTIFACT_PIN
+
+# Regression checks
+./run ./src/tests/cache/simple-regression.ts --bundle --mode check --tarball $WORKDIR/simple-regression.tar.gz
+./run ./src/tests/cache/complex-regression.ts --bundle --mode check --tarball $WORKDIR/complex-regression.tar.gz
+
+echo "Artifacts checked successfully!"

--- a/scripts/tests/dump-cache-regressions.sh
+++ b/scripts/tests/dump-cache-regressions.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+set -Eeuxo pipefail
+
+source ./scripts/lib/ux.sh
+
+ARTIFACT_PIN=$(date -Iseconds)
+
+WORKDIR=tests/test-artifacts/cache/$ARTIFACT_PIN/
+mkdir -p $WORKDIR
+
+./run ./src/tests/cache/simple-regression.ts --bundle --mode dump --tarball $WORKDIR/simple-regression.tar.gz
+./run ./src/tests/cache/complex-regression.ts --bundle --keep --mode dump --tarball $WORKDIR/complex-regression.tar.gz
+
+gcloud storage cp --recursive $WORKDIR gs://o1js-ci/tests/cache/fixtures/
+
+echo "Uploaded artifacts to: ($ARTIFACT_PIN)"

--- a/src/tests/cache/basic.unit-test.ts
+++ b/src/tests/cache/basic.unit-test.ts
@@ -1,0 +1,54 @@
+import assert from 'node:assert';
+import { describe, it } from 'node:test';
+import { Cache, CacheHeader } from 'o1js';
+import os from 'os';
+
+function makeFakeHeader(): CacheHeader {
+  return {
+    version: 0,
+    kind: 'lagrange-basis',
+    persistentId: "fake-persistent-id",
+    uniqueId: "fake-unique-id",
+    dataType: "string",
+  }
+}
+
+describe('Expected cache behaviour', () => {
+  it('should throw on read and write with a none cache', () => {
+    const cache = Cache.None
+    const header: CacheHeader = makeFakeHeader();
+    assert.throws(() => cache.read(header), "none cache should throw on read");
+
+
+    const value: Uint8Array = new Uint8Array();
+
+    assert.throws(() => cache.write(header, value), "none cache should throw on write");
+  })
+
+  it('should read and write to a temporary filesystem cache', () => {
+    const tmpdir = os.tmpdir();
+    const cache = Cache.FileSystem(tmpdir, true)
+    const header: CacheHeader = makeFakeHeader();
+
+    const value: Uint8Array = new Uint8Array(
+      [1, 2, 3]
+    )
+
+    cache.write(header, value)
+
+    const readValue = cache.read(header)
+
+    assert.deepEqual(readValue, value, "filesystem cache read should match cache write")
+    assert.deepEqual(readValue, new Uint8Array([1, 2, 3]), "filesystem cache read should match identically constructed data")
+  })
+
+  it('should read and write to the default filesystem cache', () => {
+    const cache = Cache.FileSystemDefault
+    const header: CacheHeader = makeFakeHeader();
+    const value: Uint8Array = new Uint8Array([4, 5, 6])
+    cache.write(header, value)
+    const readValue = cache.read(header)
+    assert.deepEqual(readValue, value, "filesystemDefault cache read should match cache write")
+    assert.deepEqual(readValue, new Uint8Array([4, 5, 6]), "filesystemDefault cache read should match identically constructed data")
+  });
+});

--- a/src/tests/cache/complex-regression.ts
+++ b/src/tests/cache/complex-regression.ts
@@ -1,0 +1,90 @@
+import minimist from "minimist";
+import assert from "node:assert";
+import { Field, Provable, Struct, UInt64, Unconstrained, ZkProgram } from "o1js";
+import { CacheHarness } from "./harness.js";
+
+const { mode, tarball } = minimist(process.argv.slice(2))
+
+const harness = await CacheHarness({ mode, tarball })
+
+const RealProgram = ZkProgram({
+  name: 'real',
+  publicOutput: UInt64,
+  methods: {
+    make: {
+      privateInputs: [UInt64],
+      async method(value: UInt64) {
+        let expected = UInt64.from(35);
+        value.assertEquals(expected);
+        return { publicOutput: value.add(1) };
+      },
+    },
+  },
+});
+
+class RealProof extends RealProgram.Proof { }
+class Nested extends Struct({ inner: RealProof }) { }
+
+const RecursiveProgram = ZkProgram({
+  name: 'recursive',
+  methods: {
+    verifyReal: {
+      privateInputs: [RealProof],
+      async method(proof: RealProof) {
+        proof.verify();
+      },
+    },
+    verifyNested: {
+      privateInputs: [Field, Nested],
+      async method(_unrelated, { inner }: Nested) {
+        inner.verify();
+      },
+    },
+    verifyInternal: {
+      privateInputs: [Unconstrained.withEmpty<RealProof | undefined>(undefined)],
+      async method(fakeProof: Unconstrained<RealProof | undefined>) {
+        // witness either fake proof from input, or real proof
+        let proof = await Provable.witnessAsync(RealProof, async () => {
+          let maybeFakeProof = fakeProof.get();
+          if (maybeFakeProof !== undefined) return maybeFakeProof;
+
+          let { proof } = await RealProgram.make(35);
+          return proof;
+        });
+
+        proof.declare();
+        proof.verify();
+      },
+    },
+  },
+});
+
+const { verificationKey: realVk } = await RealProgram.compile({ cache: harness.cache })
+harness.check(realVk, "realVk");
+const { verificationKey: vk } = await RecursiveProgram.compile({ cache: harness.cache })
+harness.check(vk, "vk");
+const { proof: realProof } = await RealProgram.make(35);
+{
+  const ok = await harness.verify(realProof, "realVk");
+  assert.equal(ok, true, "expected real proof to verify with realVk")
+}
+const { proof: recursiveProof } = await RecursiveProgram.verifyReal(realProof);
+
+{
+  const ok = await harness.verify(recursiveProof, "vk");
+  assert.equal(ok, true, "expected recursive proof to verify with vk");
+}
+
+const { proof: nestedProof } = await RecursiveProgram.verifyNested(0, { inner: realProof })
+{
+  const ok = await harness.verify(nestedProof, "vk");
+  assert.equal(ok, true, "expected nested proof to verify with vk")
+}
+const { proof: internalProof } = await RecursiveProgram.verifyInternal(undefined)
+
+{
+  const ok = await harness.verify(internalProof, "vk");
+  assert.equal(ok, true, "expected internal proof to verify with vk");
+}
+
+await harness.finish()

--- a/src/tests/cache/harness.ts
+++ b/src/tests/cache/harness.ts
@@ -1,0 +1,85 @@
+import { exec as execCallback } from 'child_process';
+import fs from 'fs';
+import assert from 'node:assert';
+import { Cache, ProofBase, VerificationKey, verify as verifyProof } from 'o1js';
+import path from 'path';
+import util from 'util';
+
+const exec = util.promisify(execCallback)
+
+export async function tmpdir(): Promise<string> {
+  const { stdout } = await exec(`mktemp -d`)
+  return stdout.trim()
+}
+
+export async function untar(tarball: string): Promise<string> {
+  const d = await tmpdir()
+  await exec(`tar -xzf ${tarball} -C ${d}`)
+
+  return d
+}
+
+export const allowedModes = ["check", "dump"] as const;
+export type AllowedMode = typeof allowedModes[number]
+export function isAllowedMode(val: string): val is AllowedMode {
+  return (allowedModes as readonly string[]).includes(val)
+}
+
+export async function tar(directory: string, out: string) {
+  const dirPath = path.resolve(directory)
+  const outPath = path.resolve(out);
+  const dirName = path.dirname(outPath);
+  fs.mkdirSync(dirName, { recursive: true })
+  await exec(`tar -czf ${outPath} .`, {
+    cwd: dirPath,
+  })
+}
+
+
+export async function CacheHarness({ mode, tarball }: { mode: string, tarball: string }) {
+  if (!isAllowedMode(mode)) { throw new Error(`mode should be one of ${allowedModes.join(' | ')}`) }
+
+
+  const workingDir = await (async () => {
+    if (mode == "check") {
+      return await untar(tarball);
+    } else {
+      return tmpdir();
+    }
+  })()
+
+  const cacheDir = path.join(workingDir, "cache")
+  const cache = Cache.FileSystem(cacheDir)
+
+  const check = (verificationKey: VerificationKey, label: string) => {
+    if (mode == "check") {
+      const expectedVk = JSON.parse(fs.readFileSync(path.join(workingDir, `${label}.json`), "utf8"));
+      assert.deepEqual(expectedVk.data, verificationKey.data, `expected (${label}) verification keys to remain the same`);
+
+      return
+    }
+
+    if (mode == "dump") {
+      fs.writeFileSync(path.join(workingDir, `${label}.json`), JSON.stringify(verificationKey))
+    }
+  }
+
+  const verify = async <T, U>(proof: ProofBase<T, U>, label: string): Promise<boolean> => {
+    const expectedVk = JSON.parse(fs.readFileSync(path.join(workingDir, `${label}.json`), "utf8"));
+
+    const expectedOk = await verifyProof(proof, expectedVk);
+    return expectedOk
+  }
+
+  const finish = async () => {
+    await tar(workingDir, tarball)
+  }
+
+
+  return {
+    cache,
+    check,
+    verify,
+    finish,
+  }
+}

--- a/src/tests/cache/simple-regression.ts
+++ b/src/tests/cache/simple-regression.ts
@@ -1,0 +1,33 @@
+import minimist from "minimist";
+import assert from "node:assert";
+import { Field, ZkProgram } from "o1js";
+import { CacheHarness } from "./harness.js";
+
+const {
+  mode,
+  tarball,
+} = minimist(process.argv.slice(2))
+
+const harness = await CacheHarness({ mode, tarball })
+
+const SimpleProgram = ZkProgram({
+  name: "simple-program",
+  publicOutput: Field,
+  methods: {
+    baseCase: {
+      privateInputs: [],
+      async method() {
+        return {
+          publicOutput: Field(1),
+        }
+      }
+    }
+  }
+})
+
+const { verificationKey: vk } = await SimpleProgram.compile({ cache: harness.cache });
+const { proof } = await SimpleProgram.baseCase();
+harness.check(vk, "vk");
+const ok = await harness.verify(proof, "vk");
+assert.equal(ok, true, "expected proof to verify");
+await harness.finish()


### PR DESCRIPTION
added tests for the cache

Looks like:
```
o1js [leon/cache-tests] ♞  ./run src/tests/cache/regression.ts
running /Users/leon/github/o1js/dist/node/tests/cache/regression.js
testing: ./src/tests/cache/fixtures/no-cache
verification key: "8967949142774532422581957991016399617286291282656324010799834374481046006813"
testing: ./src/tests/cache/fixtures/previous
verification key: "8967949142774532422581957991016399617286291282656324010799834374481046006813"
```

When you run it


We test: when using a known good state of the cache (fixtures/previous), do you come up with the same verification key as in a previous version, and can you still verify the proof properly with both the new key and the old key.

This is ONLY using `FileSystem` cache at the moment, because we only HAVE filesystemCache at the moment /shrug

closes #2336