### PR TITLE
Format transaction layout definitions to clear the diff

### DIFF
--- a/src/bindings/scripts/build-o1js-node-artifacts.sh
+++ b/src/bindings/scripts/build-o1js-node-artifacts.sh
@@ -74,6 +74,12 @@ run_cmd dune b src/bindings/mina-transaction/gen/v1/js-layout.ts \
   src/bindings/crypto/constants.ts
 ok "TypeScript definitions built"
 
+info "Formatting generated transaction layout definitions..."
+run_cmd npx prettier --write \
+  src/bindings/crypto/constants.ts \
+  src/bindings/mina-transaction/gen/**/*.ts
+ok "TypeScript definitions formatted"
+
 info "Cleaning up Mina config files..."
 run_cmd rm -rf "src/config"
 run_cmd rm "src/config.mlh"


### PR DESCRIPTION
This PR adds one command run to the artifacts build of o1js to run prettier after the transaction layout definitions have been generated. The goal is to remove them from source control when simple white-space changes occur, so we don't have to take care of them manually before committing.