### PR TITLE
chore: formatting zkprogram.ts, and organizing imports

### DIFF
--- a/.prettierrc.cjs
+++ b/.prettierrc.cjs
@@ -13,4 +13,5 @@ module.exports = {
       },
     },
   ],
+  plugins: [require.resolve('prettier-plugin-organize-imports')],
 };

--- a/npmDepsHash
+++ b/npmDepsHash
@@ -1,1 +1,1 @@
-sha256-hvRlb/ZgfEnSW+OJG4UibamdL5UzygQQthMpUqh2W0w=
+sha256-ww0EdkEWiciR6XLTu2/lfqtDMbvIDBLj+gyPH+lpLTE=

--- a/package-lock.json
+++ b/package-lock.json
@@ -41,6 +41,7 @@
         "oxlint": "^1.0.0",
         "pkg-pr-new": "^0.0.9",
         "prettier": "^3.6.2",
+        "prettier-plugin-organize-imports": "^4.3.0",
         "replace-in-file": "^6.3.5",
         "rimraf": "^3.0.2",
         "ts-jest": "^28.0.8",
@@ -5888,6 +5889,23 @@
       },
       "funding": {
         "url": "https://github.com/prettier/prettier?sponsor=1"
+      }
+    },
+    "node_modules/prettier-plugin-organize-imports": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/prettier-plugin-organize-imports/-/prettier-plugin-organize-imports-4.3.0.tgz",
+      "integrity": "sha512-FxFz0qFhyBsGdIsb697f/EkvHzi5SZOhWAjxcx2dLt+Q532bAlhswcXGYB1yzjZ69kW8UoadFBw7TyNwlq96Iw==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "prettier": ">=2.0",
+        "typescript": ">=2.9",
+        "vue-tsc": "^2.1.0 || 3"
+      },
+      "peerDependenciesMeta": {
+        "vue-tsc": {
+          "optional": true
+        }
       }
     },
     "node_modules/pretty-format": {

--- a/package.json
+++ b/package.json
@@ -106,6 +106,7 @@
     "oxlint": "^1.0.0",
     "pkg-pr-new": "^0.0.9",
     "prettier": "^3.6.2",
+    "prettier-plugin-organize-imports": "^4.3.0",
     "replace-in-file": "^6.3.5",
     "rimraf": "^3.0.2",
     "ts-jest": "^28.0.8",

--- a/src/lib/proof-system/zkprogram.ts
+++ b/src/lib/proof-system/zkprogram.ts
@@ -1,66 +1,67 @@
-import { EmptyUndefined, EmptyVoid } from '../../bindings/lib/generic.js';
 import {
   Base64ProofString,
   Base64VerificationKeyString,
+  Gate,
+  Pickles,
   Snarky,
   initializeBindings,
   withThreadPool,
 } from '../../bindings.js';
-import { Pickles, Gate } from '../../bindings.js';
-import { Field } from '../provable/wrapped.js';
-import { FlexibleProvable, InferProvable, ProvablePureExtended } from '../provable/types/struct.js';
-import { InferProvableType } from '../provable/types/provable-derivers.js';
-import { Provable } from '../provable/provable.js';
-import { assert, prettifyStacktracePromise } from '../util/errors.js';
+import { setSrsCache, unsetSrsCache } from '../../bindings/crypto/bindings/srs.js';
+import { prefixes } from '../../bindings/crypto/constants.js';
+import { prefixToField } from '../../bindings/lib/binable.js';
+import { EmptyUndefined, EmptyVoid } from '../../bindings/lib/generic.js';
+import { From, InferValue } from '../../bindings/lib/provable-generic.js';
+import { MlArray, MlBool, MlPair, MlResult } from '../ml/base.js';
+import { MlFieldArray, MlFieldConstArray } from '../ml/fields.js';
+import { FieldConst, FieldVar } from '../provable/core/fieldvar.js';
 import { ConstraintSystemSummary, snarkContext } from '../provable/core/provable-context.js';
 import { hashConstant } from '../provable/crypto/poseidon.js';
-import { MlArray, MlBool, MlResult, MlPair } from '../ml/base.js';
-import { MlFieldArray, MlFieldConstArray } from '../ml/fields.js';
-import { FieldVar, FieldConst } from '../provable/core/fieldvar.js';
-import { Cache, readCache, writeCache } from './cache.js';
-import { decodeProverKey, encodeProverKey, parseHeader } from './prover-keys.js';
-import { setSrsCache, unsetSrsCache } from '../../bindings/crypto/bindings/srs.js';
+import { Provable } from '../provable/provable.js';
+import { InferProvableType } from '../provable/types/provable-derivers.js';
 import { ProvableType, ToProvable } from '../provable/types/provable-intf.js';
-import { prefixToField } from '../../bindings/lib/binable.js';
-import { prefixes } from '../../bindings/crypto/constants.js';
-import { Subclass, Tuple, Get } from '../util/types.js';
+import { FlexibleProvable, InferProvable, ProvablePureExtended } from '../provable/types/struct.js';
+import { emptyWitness } from '../provable/types/util.js';
+import { Field } from '../provable/wrapped.js';
+import { mapObject, mapToObject, zip } from '../util/arrays.js';
+import { assert, prettifyStacktracePromise } from '../util/errors.js';
+import { Get, Subclass, Tuple } from '../util/types.js';
+import { Cache, readCache, writeCache } from './cache.js';
+import { featureFlagsFromGates, featureFlagsToMlOption } from './feature-flags.js';
 import {
-  dummyProof,
   DynamicProof,
-  extractProofs,
-  extractProofTypes,
   Proof,
   ProofBase,
   ProofClass,
   ProofValue,
+  dummyProof,
+  extractProofTypes,
+  extractProofs,
 } from './proof.js';
-import { featureFlagsFromGates, featureFlagsToMlOption } from './feature-flags.js';
-import { emptyWitness } from '../provable/types/util.js';
-import { From, InferValue } from '../../bindings/lib/provable-generic.js';
-import { DeclaredProof, ZkProgramContext } from './zkprogram-context.js';
-import { mapObject, mapToObject, zip } from '../util/arrays.js';
+import { decodeProverKey, encodeProverKey, parseHeader } from './prover-keys.js';
 import { VerificationKey } from './verification-key.js';
+import { DeclaredProof, ZkProgramContext } from './zkprogram-context.js';
 
 // public API
-export { SelfProof, JsonProof, ZkProgram, verify, Empty, Undefined, Void, Method };
+export { Empty, JsonProof, Method, SelfProof, Undefined, Void, ZkProgram, verify };
 
 // internal API
 export {
   CompiledTag,
-  sortMethodArguments,
   MethodInterface,
   MethodReturnType,
-  picklesRuleFromFunction,
-  compileProgram,
-  analyzeMethod,
-  Prover,
-  dummyBase64Proof,
-  computeMaxProofsVerified,
-  RegularProver,
-  TupleToInstances,
   PrivateInput,
   Proof,
+  Prover,
+  RegularProver,
+  TupleToInstances,
+  analyzeMethod,
+  compileProgram,
+  computeMaxProofsVerified,
+  dummyBase64Proof,
   inCircuitVkHash,
+  picklesRuleFromFunction,
+  sortMethodArguments,
 };
 
 type Undefined = undefined;
@@ -225,7 +226,7 @@ type InferMethodType<Config extends ConfigBaseType> = {
  */
 function ZkProgram<
   Config extends ConfigBaseType,
-  _ extends unknown = unknown // weird hack that makes methods infer correctly when their inputs are not annotated
+  _ extends unknown = unknown, // weird hack that makes methods infer correctly when their inputs are not annotated
 >(
   config: Config & {
     name: string;
@@ -603,7 +604,7 @@ type ZkProgram<
         auxiliaryOutput?: ProvableType;
       };
     };
-  }
+  },
 > = ReturnType<typeof ZkProgram<Config>>;
 
 /**
@@ -1059,7 +1060,7 @@ function toFieldAndAuxConsts<T>(type: Provable<T>, value: T) {
 
 ZkProgram.Proof = function <
   PublicInputType extends FlexibleProvable<any>,
-  PublicOutputType extends FlexibleProvable<any>
+  PublicOutputType extends FlexibleProvable<any>,
 >(program: {
   name: string;
   publicInputType: PublicInputType;
@@ -1111,11 +1112,12 @@ function Prover<ProverData>() {
 
 // helper types
 
-type Infer<T> = T extends Subclass<typeof ProofBase>
-  ? InstanceType<T>
-  : T extends ProvableType
-  ? InferProvableType<T>
-  : never;
+type Infer<T> =
+  T extends Subclass<typeof ProofBase>
+    ? InstanceType<T>
+    : T extends ProvableType
+      ? InferProvableType<T>
+      : never;
 
 type TupleToInstances<T> = {
   [I in keyof T]: Infer<T[I]>;
@@ -1133,13 +1135,13 @@ type MethodReturnType<PublicOutput, AuxiliaryOutput> = PublicOutput extends void
         auxiliaryOutput: AuxiliaryOutput;
       }
   : AuxiliaryOutput extends undefined
-  ? {
-      publicOutput: PublicOutput;
-    }
-  : {
-      publicOutput: PublicOutput;
-      auxiliaryOutput: AuxiliaryOutput;
-    };
+    ? {
+        publicOutput: PublicOutput;
+      }
+    : {
+        publicOutput: PublicOutput;
+        auxiliaryOutput: AuxiliaryOutput;
+      };
 
 type Method<
   PublicInput,
@@ -1147,7 +1149,7 @@ type Method<
   MethodSignature extends {
     privateInputs: Tuple<PrivateInput>;
     auxiliaryOutput?: ProvableType;
-  }
+  },
 > = PublicInput extends undefined
   ? {
       method(
@@ -1176,7 +1178,7 @@ type RegularProver<
   PublicInputType,
   PublicOutput,
   Args extends Tuple<PrivateInput>,
-  AuxiliaryOutput
+  AuxiliaryOutput,
 > = (
   publicInput: From<PublicInputType>,
   ...args: TupleFrom<Args>
@@ -1190,7 +1192,7 @@ type Prover<
   PublicInputType,
   PublicOutput,
   Args extends Tuple<PrivateInput>,
-  AuxiliaryOutput
+  AuxiliaryOutput,
 > = PublicInput extends undefined
   ? (...args: TupleFrom<Args>) => Promise<{
       proof: Proof<PublicInput, PublicOutput>;
@@ -1210,8 +1212,8 @@ type ProvableOrVoid<A> = A extends undefined ? typeof Void : ToProvable<A>;
 type InferProvableOrUndefined<A> = A extends undefined
   ? undefined
   : A extends ProvableType
-  ? InferProvable<A>
-  : InferProvable<A> | undefined;
+    ? InferProvable<A>
+    : InferProvable<A> | undefined;
 type InferProvableOrVoid<A> = A extends undefined ? void : InferProvable<A>;
 
 type UnwrapPromise<P> = P extends Promise<infer T> ? T : never;


### PR DESCRIPTION
I wanted to change `zkprogram.ts`, but my formatting really destroys the entire file (as you can probably see here)

We should do a pass across the entire repo at some point, but right now I want to format this file.

Also, I added `organize-imports` for another level of standardization (and also, my local config kinda explodes the imports when I "format" the file, so we should probably have this anyways).

Remember to set your default formatter in `vscode` to `prettier`, otherwise you get a lot of other errors :yikes:

Our CI only checks changed files afaict, so this will be a slow migration across the board for our files, but preferable to a large format blowout