### PR TITLE
update GitHub actions in CI workflows

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -48,7 +48,7 @@ jobs:
           docker system prune -af --volumes || true
           df -h
       - name: Checkout repository with submodules
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           submodules: recursive
           repository: ${{ inputs.target_repo || github.repository }}
@@ -69,7 +69,7 @@ jobs:
 
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           repository: ${{ inputs.target_repo || github.repository }}
           ref: ${{ inputs.target_ref || github.ref }}
@@ -132,7 +132,7 @@ jobs:
                       "$AGENT_TOOLSDIRECTORY" || true
           docker system prune -af --volumes || true
           df -h
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           submodules: recursive
           repository: ${{ inputs.target_repo || github.repository }}
@@ -165,7 +165,7 @@ jobs:
           ]
     steps:
       - name: Checkout repository with submodules
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           submodules: recursive
           repository: ${{ inputs.target_repo || github.repository }}
@@ -204,7 +204,7 @@ jobs:
         chunk: [1, 2, 3, 4, 5, 6, 7, 8]
     steps:
       - name: Checkout repository with submodules
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           submodules: recursive
           repository: ${{ inputs.target_repo || github.repository }}
@@ -346,7 +346,7 @@ jobs:
           - /tmp:/root/logs
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           repository: ${{ inputs.target_repo || github.repository }}
           ref: ${{ inputs.target_ref || github.ref }}
@@ -382,7 +382,7 @@ jobs:
           - /tmp:/root/logs
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           repository: ${{ inputs.target_repo || github.repository }}
           ref: ${{ inputs.target_ref || github.ref }}
@@ -418,7 +418,7 @@ jobs:
           - /tmp:/root/logs
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           repository: ${{ inputs.target_repo || github.repository }}
           ref: ${{ inputs.target_ref || github.ref }}

--- a/.github/workflows/pull_requests.yml
+++ b/.github/workflows/pull_requests.yml
@@ -19,7 +19,7 @@ jobs:
     steps:
       - name: Disable smudging
         run: echo "GIT_LFS_SKIP_SMUDGE=1" >> $GITHUB_ENV
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           submodules: recursive
       - uses: nixbuild/nix-quick-install-action@v30

--- a/.github/workflows/push_main.yml
+++ b/.github/workflows/push_main.yml
@@ -23,7 +23,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       - name: Setup Node.JS ${{ matrix.node }}
         uses: actions/setup-node@v4
         with:
@@ -45,7 +45,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0 # Fetch all history for all branches and tags
 
@@ -78,7 +78,7 @@ jobs:
 
     runs-on: [ubuntu-latest]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Setup Node.JS ${{ matrix.node }}
         uses: actions/setup-node@v4
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,7 +20,7 @@ jobs:
 
     steps:
       - name: Check out the repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Set up Node.js
         uses: actions/setup-node@v4

--- a/.github/workflows/remote_bindings.yml
+++ b/.github/workflows/remote_bindings.yml
@@ -8,7 +8,7 @@ jobs:
     name: upload bindings artifact
     runs-on: [sdk-self-hosted-linux-amd64-build-system]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           submodules: recursive
       - name: upload

--- a/.github/workflows/upload-cache-regressions-artifacts.yml
+++ b/.github/workflows/upload-cache-regressions-artifacts.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout repository with submodules
-      uses: actions/checkout@v4
+      uses: actions/checkout@v5
       with:
         submodules: recursive
     - name: Build


### PR DESCRIPTION


Upgrade to actions/checkout@v5 for improved performance and stability.

Reference: https://github.com/actions/checkout/releases/tag/v5.0.0