### PR TITLE
Add a small and big zkprogram example

### DIFF
--- a/src/examples/zkprogram/program-small-big.ts
+++ b/src/examples/zkprogram/program-small-big.ts
@@ -1,4 +1,4 @@
-import { Bytes, UInt8, Field, ZkProgram, Poseidon, Hash, verify } from 'o1js';
+import { Bytes, Field, Hash, Poseidon, UInt8, ZkProgram, verify } from 'o1js';
 
 const SmallProgram = ZkProgram({
   name: 'small-program',


### PR DESCRIPTION
This PR adds a very small and very big `ZkProgram` example designed to be included in the compile and prove time performance regression tests.

Closes https://github.com/o1-labs/o1js/issues/2343.

### Details

- **Small Program:**
  - Accepts a single `Field` as a private input.
  - Computes its `Poseidon` hash.
  - Outputs the resulting digest as the public output.

- **Big Program:**
  - Takes a `PoseidonProof` generated by the small program as its private input.
  - Verifies the proof of the small program.
  - Extracts the Poseidon digest from the proof’s public output.
  - Converts the digest into bytes and feeds it through a chained sequence of hash functions:
    1. `SHA2_256`
    2. `BLAKE2B`
    3. `SHA3_512`
    4. `Keccak256`
  - Outputs the final digest as the public output.

### Preview
```sh
./run src/examples/zkprogram/program-small-big.ts
```

```sh
small program rows:  13
big program rows:  53069 

compile small: 1.445s
compile big: 2:56.479 (m:ss.mmm)
prove small: 19.734s
prove big: 1:20.076 (m:ss.mmm)
verify big: 1.673s
Final Digest:  899424c1ec1af7c449056db47fbdc6da6ac5527edc5100ea39bd258b27fded4c
```
