### PR TITLE
feat: added test to check RSA usage of cache

### DIFF
--- a/.config/cspell.json
+++ b/.config/cspell.json
@@ -4,7 +4,19 @@
   // language - current active spelling language
   "language": "en",
   // words - list of words to be always considered correct
-  "words": ["tarides", "nixbuild", "stefanzweifel", "ACMRT", "Oxlint", "rimraf", "jsoo", "Eeuo", "caml", "esbuild"],
+  "words": [
+    "ACMRT",
+    "Iseconds",
+    "nixbuild",
+    "Oxlint",
+    "stefanzweifel",
+    "tarides",
+    "rimraf",
+    "jsoo",
+    "Eeuo",
+    "caml",
+    "esbuild"
+  ],
   // flagWords - list of words to be always considered incorrect
   // This is useful for offensive words and common spelling errors.
   // For example "hte" should be "the"

--- a/scripts/tests/check-cache-regressions.sh
+++ b/scripts/tests/check-cache-regressions.sh
@@ -9,7 +9,7 @@ source ./scripts/lib/ux.sh
 ./run ./src/tests/cache/simple-regression.ts --bundle --mode check --tarball ./tests/test-artifacts/cache/simple-regression.tar.gz
 
 # This pin is generated in ./dump-cache-regressions.sh
-ARTIFACT_PIN=2025-10-02T13:36:52-04:00
+ARTIFACT_PIN=2025-10-14T13:40:45-04:00
 
 WORKDIR=tests/test-artifacts/cache/
 mkdir -p $WORKDIR
@@ -22,5 +22,6 @@ WORKDIR=tests/test-artifacts/cache/$ARTIFACT_PIN
 # Regression checks
 ./run ./src/tests/cache/simple-regression.ts --bundle --mode check --tarball $WORKDIR/simple-regression.tar.gz
 ./run ./src/tests/cache/complex-regression.ts --bundle --mode check --tarball $WORKDIR/complex-regression.tar.gz
+./run ./src/tests/cache/rsa-regression.ts --bundle --keep --mode check --tarball $WORKDIR/rsa-regression.tar.gz
 
 echo "Artifacts checked successfully!"

--- a/scripts/tests/dump-cache-regressions.sh
+++ b/scripts/tests/dump-cache-regressions.sh
@@ -10,6 +10,7 @@ mkdir -p $WORKDIR
 
 ./run ./src/tests/cache/simple-regression.ts --bundle --mode dump --tarball $WORKDIR/simple-regression.tar.gz
 ./run ./src/tests/cache/complex-regression.ts --bundle --keep --mode dump --tarball $WORKDIR/complex-regression.tar.gz
+./run ./src/tests/cache/rsa-regression.ts --bundle --keep --mode dump --tarball $WORKDIR/rsa-regression.tar.gz
 
 gcloud storage cp --recursive $WORKDIR gs://o1js-ci/tests/cache/fixtures/
 

--- a/src/examples/crypto/rsa/program.ts
+++ b/src/examples/crypto/rsa/program.ts
@@ -1,0 +1,16 @@
+import { ZkProgram } from 'o1js';
+import { Bigint2048, rsaVerify65537 } from './rsa.js';
+
+export const rsaZkProgram = ZkProgram({
+  name: 'rsa-verify',
+
+  methods: {
+    verifyRsa65537: {
+      privateInputs: [Bigint2048, Bigint2048, Bigint2048],
+
+      async method(message: Bigint2048, signature: Bigint2048, modulus: Bigint2048) {
+        rsaVerify65537(message, signature, modulus);
+      },
+    },
+  },
+});

--- a/src/examples/crypto/rsa/run.ts
+++ b/src/examples/crypto/rsa/run.ts
@@ -1,21 +1,7 @@
-import { ZkProgram } from 'o1js';
 import { Performance } from '../../../lib/testing/perf-regression.js';
-import { Bigint2048, rsaVerify65537 } from './rsa.js';
+import { rsaZkProgram } from './program.js';
+import { Bigint2048 } from './rsa.js';
 import { generateRsaParams, rsaSign, sha256Bigint } from './utils.js';
-
-let rsaZkProgram = ZkProgram({
-  name: 'rsa-verify',
-
-  methods: {
-    verifyRsa65537: {
-      privateInputs: [Bigint2048, Bigint2048, Bigint2048],
-
-      async method(message: Bigint2048, signature: Bigint2048, modulus: Bigint2048) {
-        rsaVerify65537(message, signature, modulus);
-      },
-    },
-  },
-});
 
 let cs = await rsaZkProgram.analyzeMethods();
 

--- a/src/tests/cache/complex-regression.ts
+++ b/src/tests/cache/complex-regression.ts
@@ -1,11 +1,11 @@
-import minimist from "minimist";
-import assert from "node:assert";
-import { Field, Provable, Struct, UInt64, Unconstrained, ZkProgram } from "o1js";
-import { CacheHarness } from "./harness.js";
+import minimist from 'minimist';
+import assert from 'node:assert';
+import { Field, Provable, Struct, UInt64, Unconstrained, ZkProgram } from 'o1js';
+import { CacheHarness } from './harness.js';
 
-const { mode, tarball } = minimist(process.argv.slice(2))
+const { mode, tarball } = minimist(process.argv.slice(2));
 
-const harness = await CacheHarness({ mode, tarball })
+const harness = await CacheHarness({ mode, tarball });
 
 const RealProgram = ZkProgram({
   name: 'real',
@@ -22,8 +22,8 @@ const RealProgram = ZkProgram({
   },
 });
 
-class RealProof extends RealProgram.Proof { }
-class Nested extends Struct({ inner: RealProof }) { }
+class RealProof extends RealProgram.Proof {}
+class Nested extends Struct({ inner: RealProof }) {}
 
 const RecursiveProgram = ZkProgram({
   name: 'recursive',
@@ -59,32 +59,32 @@ const RecursiveProgram = ZkProgram({
   },
 });
 
-const { verificationKey: realVk } = await RealProgram.compile({ cache: harness.cache })
-harness.check(realVk, "realVk");
-const { verificationKey: vk } = await RecursiveProgram.compile({ cache: harness.cache })
-harness.check(vk, "vk");
+const { verificationKey: realVk } = await RealProgram.compile({ cache: harness.cache });
+harness.check(realVk, 'realVk');
+const { verificationKey: vk } = await RecursiveProgram.compile({ cache: harness.cache });
+harness.check(vk, 'vk');
 const { proof: realProof } = await RealProgram.make(35);
 {
-  const ok = await harness.verify(realProof, "realVk");
-  assert.equal(ok, true, "expected real proof to verify with realVk")
+  const ok = await harness.verify(realProof, 'realVk');
+  assert.equal(ok, true, 'expected real proof to verify with realVk');
 }
 const { proof: recursiveProof } = await RecursiveProgram.verifyReal(realProof);
 
 {
-  const ok = await harness.verify(recursiveProof, "vk");
-  assert.equal(ok, true, "expected recursive proof to verify with vk");
+  const ok = await harness.verify(recursiveProof, 'vk');
+  assert.equal(ok, true, 'expected recursive proof to verify with vk');
 }
 
-const { proof: nestedProof } = await RecursiveProgram.verifyNested(0, { inner: realProof })
+const { proof: nestedProof } = await RecursiveProgram.verifyNested(0, { inner: realProof });
 {
-  const ok = await harness.verify(nestedProof, "vk");
-  assert.equal(ok, true, "expected nested proof to verify with vk")
+  const ok = await harness.verify(nestedProof, 'vk');
+  assert.equal(ok, true, 'expected nested proof to verify with vk');
 }
-const { proof: internalProof } = await RecursiveProgram.verifyInternal(undefined)
+const { proof: internalProof } = await RecursiveProgram.verifyInternal(undefined);
 
 {
-  const ok = await harness.verify(internalProof, "vk");
-  assert.equal(ok, true, "expected internal proof to verify with vk");
+  const ok = await harness.verify(internalProof, 'vk');
+  assert.equal(ok, true, 'expected internal proof to verify with vk');
 }
 
-await harness.finish()
+await harness.finish();

--- a/src/tests/cache/rsa-regression.ts
+++ b/src/tests/cache/rsa-regression.ts
@@ -1,0 +1,24 @@
+import minimist from 'minimist';
+import assert from 'node:assert';
+import { rsaZkProgram } from '../../examples/crypto/rsa/program.js';
+import { Bigint2048 } from '../../examples/crypto/rsa/rsa.js';
+import { generateRsaParams, rsaSign, sha256Bigint } from '../../examples/crypto/rsa/utils.js';
+import { CacheHarness } from './harness.js';
+
+const { mode, tarball } = minimist(process.argv.slice(2));
+
+const harness = await CacheHarness({ mode, tarball });
+
+const { verificationKey: vk } = await rsaZkProgram.compile({ cache: harness.cache });
+harness.check(vk, 'vk');
+
+const input = await sha256Bigint('How are you!');
+const params = generateRsaParams(2048);
+const message = Bigint2048.from(input);
+const signature = Bigint2048.from(rsaSign(input, params.d, params.n));
+const modulus = Bigint2048.from(params.n);
+
+const { proof } = await rsaZkProgram.verifyRsa65537(message, signature, modulus);
+const ok = await harness.verify(proof, 'vk');
+assert.equal(ok, true, 'expected proof to verify');
+await harness.finish();

--- a/src/tests/cache/simple-regression.ts
+++ b/src/tests/cache/simple-regression.ts
@@ -1,17 +1,14 @@
-import minimist from "minimist";
-import assert from "node:assert";
-import { Field, ZkProgram } from "o1js";
-import { CacheHarness } from "./harness.js";
+import minimist from 'minimist';
+import assert from 'node:assert';
+import { Field, ZkProgram } from 'o1js';
+import { CacheHarness } from './harness.js';
 
-const {
-  mode,
-  tarball,
-} = minimist(process.argv.slice(2))
+const { mode, tarball } = minimist(process.argv.slice(2));
 
-const harness = await CacheHarness({ mode, tarball })
+const harness = await CacheHarness({ mode, tarball });
 
 const SimpleProgram = ZkProgram({
-  name: "simple-program",
+  name: 'simple-program',
   publicOutput: Field,
   methods: {
     baseCase: {
@@ -19,15 +16,15 @@ const SimpleProgram = ZkProgram({
       async method() {
         return {
           publicOutput: Field(1),
-        }
-      }
-    }
-  }
-})
+        };
+      },
+    },
+  },
+});
 
 const { verificationKey: vk } = await SimpleProgram.compile({ cache: harness.cache });
 const { proof } = await SimpleProgram.baseCase();
-harness.check(vk, "vk");
-const ok = await harness.verify(proof, "vk");
-assert.equal(ok, true, "expected proof to verify");
-await harness.finish()
+harness.check(vk, 'vk');
+const ok = await harness.verify(proof, 'vk');
+assert.equal(ok, true, 'expected proof to verify');
+await harness.finish();


### PR DESCRIPTION
formatted the old cache regression tests

added a new test: cache/rsa-regression that checks the RSA example so it works with a cache.

updated the cache regression artifact pinned to include RSA examples.

this is the root of a trunk.

children:
#2551