### PR TITLE
Isolate bindings constants and transaction layout build

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
     "build:bindings-all": "./src/bindings/scripts/update-o1js-bindings.sh",
     "build:bindings-remote": "./scripts/build/build-bindings-remote.sh",
     "build:bindings-download": "./src/bindings/scripts/download-bindings.sh",
+    "build:bindings-transaction-layout": "./src/bindings/scripts/build-transaction-layout.sh",
     "check:bindings": "./scripts/build/check-for-bindings.sh",
     "build:wasm": "npm run build:wasm:web && npm run build:wasm:node",
     "build:wasm:web": "./scripts/build/wasm/build-web.sh",

--- a/src/bindings/scripts/build-o1js-node-artifacts.sh
+++ b/src/bindings/scripts/build-o1js-node-artifacts.sh
@@ -34,17 +34,7 @@ ok "Mina config files copied"
 npm run build:wasm:node
 npm run build:jsoo:node
 
-info "Building transaction layout TypeScript definitions..."
-run_cmd dune b src/bindings/mina-transaction/gen/v1/js-layout.ts \
-  src/bindings/mina-transaction/gen/v2/js-layout.ts \
-  src/bindings/crypto/constants.ts
-ok "TypeScript definitions built"
-
-info "Formatting generated transaction layout definitions..."
-run_cmd npx prettier --write \
-  src/bindings/crypto/constants.ts \
-  src/bindings/mina-transaction/gen/**/*.ts
-ok "TypeScript definitions formatted"
+npm run build:bindings-transaction-layout
 
 info "Cleaning up Mina config files..."
 run_cmd rm -rf "src/config"

--- a/src/bindings/scripts/build-transaction-layout.sh
+++ b/src/bindings/scripts/build-transaction-layout.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT_DIR="$(cd "$SCRIPT_DIR/../../.." && pwd)"
+CRYPTO_CONSTANTS="$ROOT_DIR/_build/default/src/bindings/crypto/constants.ts"
+MINA_TRANSACTION_GEN="$ROOT_DIR/_build/default/src/bindings/mina-transaction/gen"
+
+# shared libraries
+source "$ROOT_DIR/scripts/lib/ux.sh"
+
+bold "Cleaning compiled bindings crypto constants"
+if [ -f "$CRYPTO_CONSTANTS" ]; then
+  info "Removing $CRYPTO_CONSTANTS"
+  run_cmd rimraf "$CRYPTO_CONSTANTS"
+  ok "_build/default/src/bindings/crypto/constants.ts removed"
+else
+  warn "_build/default/src/bindings/crypto/constants.ts not found, skipping"
+fi
+
+bold "Cleaning compiled Mina transaction layout TS definitions"
+if [ -d "$MINA_TRANSACTION_GEN" ]; then
+  info "Removing compiled files in $MINA_TRANSACTION_GEN"
+  run_cmd rimraf "$MINA_TRANSACTION_GEN";
+  ok "Mina transaction layout TS definitions removed"
+else
+  warn "Compiled directory not found, skipping"
+fi
+
+info "Building bindings constants & transaction layout TypeScript definitions..."
+run_cmd dune b src/bindings/mina-transaction/gen/v1/js-layout.ts \
+  src/bindings/mina-transaction/gen/v2/js-layout.ts \
+  src/bindings/crypto/constants.ts
+ok "Bindings constants & Mina Transaction Layout TypeScript definitions built"
+
+info "Formatting generated transaction layout definitions..."
+run_cmd npx prettier --write \
+  src/bindings/crypto/constants.ts \
+  src/bindings/mina-transaction/gen/**/*.ts
+ok "TypeScript definitions formatted"


### PR DESCRIPTION
Closes https://github.com/o1-labs/o1js/issues/2374.

Note that this PR also moves formatting "mina-transaction/gen" and "bindings/constants" from the build script to the newly added `build-transaction-layout` script.