### PR TITLE
[mesa] compat: transaction limit constants update

### DIFF
--- a/src/bindings/crypto/constants.ts
+++ b/src/bindings/crypto/constants.ts
@@ -501,7 +501,7 @@ let versionBytes = {
   transactionHash: 29,
   signedCommandV1: 19,
 };
-let protocolVersions = { txnVersion: 3 };
+let protocolVersions = { txnVersion: 4 };
 let poseidonParamsKimchiFp = {
   mds: [
     [

--- a/src/bindings/mina-transaction/gen/v1/js-layout.ts
+++ b/src/bindings/mina-transaction/gen/v1/js-layout.ts
@@ -84,7 +84,7 @@ let jsLayout = {
                         optionType: 'flaggedOption',
                         inner: { type: 'Field' },
                       },
-                      staticLength: 8,
+                      staticLength: 32,
                     },
                     delegate: {
                       type: 'option',
@@ -623,7 +623,7 @@ let jsLayout = {
                             optionType: 'flaggedOption',
                             inner: { type: 'Field' },
                           },
-                          staticLength: 8,
+                          staticLength: 32,
                         },
                         actionState: {
                           type: 'option',
@@ -799,7 +799,7 @@ let jsLayout = {
               appState: {
                 type: 'array',
                 inner: { type: 'option', optionType: 'flaggedOption', inner: { type: 'Field' } },
-                staticLength: 8,
+                staticLength: 32,
               },
               delegate: {
                 type: 'option',
@@ -1320,7 +1320,7 @@ let jsLayout = {
                       optionType: 'flaggedOption',
                       inner: { type: 'Field' },
                     },
-                    staticLength: 8,
+                    staticLength: 32,
                   },
                   actionState: {
                     type: 'option',
@@ -1573,7 +1573,7 @@ let jsLayout = {
             'zkappUri',
           ],
           entries: {
-            appState: { type: 'array', inner: { type: 'Field' }, staticLength: 8 },
+            appState: { type: 'array', inner: { type: 'Field' }, staticLength: 32 },
             verificationKey: {
               type: 'option',
               optionType: 'orUndefined',

--- a/src/bindings/mina-transaction/gen/v2/js-layout.ts
+++ b/src/bindings/mina-transaction/gen/v2/js-layout.ts
@@ -130,7 +130,7 @@ const AccountPrecondition: BindingsType.Object<AccountPrecondition> = new Bindin
     receiptChainHash: new BindingsType.Option.Flagged(new BindingsType.Leaf.Field()),
     delegate: new BindingsType.Option.Flagged(new BindingsType.Leaf.PublicKey()),
     state: new BindingsType.Array({
-      staticLength: 8,
+      staticLength: 32,
       inner: new BindingsType.Option.Flagged(new BindingsType.Leaf.Field()),
     }),
     actionState: new BindingsType.Option.Flagged(new BindingsType.Leaf.Field()),
@@ -291,7 +291,7 @@ const ZkappAccount: BindingsType.Object<ZkappAccount> = new BindingsType.Object(
   ],
   entries: {
     appState: new BindingsType.Array({
-      staticLength: 8,
+      staticLength: 32,
       inner: new BindingsType.Leaf.Field(),
     }),
     verificationKey: new BindingsType.Option.OrUndefined<{ data: string; hash: Field }>(
@@ -352,7 +352,7 @@ const AccountUpdateModification: BindingsType.Object<AccountUpdateModification> 
     ],
     entries: {
       appState: new BindingsType.Array({
-        staticLength: 8,
+        staticLength: 32,
         inner: new BindingsType.Option.Flagged(new BindingsType.Leaf.Field()),
       }),
       delegate: new BindingsType.Option.Flagged(new BindingsType.Leaf.PublicKey()),

--- a/src/lib/mina/v1/constants.ts
+++ b/src/lib/mina/v1/constants.ts
@@ -1,29 +1,11 @@
 /**
  * This file contains constants used in the Mina protocol.
- * Originally defined in the mina_compile_config file in the mina repo:
- * https://github.com/MinaProtocol/mina/blob/develop/src/lib/mina_compile_config/mina_compile_config.ml
  */
 
-// Constants used to calculate cost of a transaction
-export namespace TransactionCost {
-  // Defined in https://github.com/MinaProtocol/mina/blob/e8c743488cf0c8f0b7925b7a48a914ca73ed13a1/src/lib/mina_compile_config/mina_compile_config.ml#L67
-  export const PROOF_COST = 10.26 as const;
-
-  // Defined in https://github.com/MinaProtocol/mina/blob/e8c743488cf0c8f0b7925b7a48a914ca73ed13a1/src/lib/mina_compile_config/mina_compile_config.ml#L69
-  export const SIGNED_PAIR_COST = 10.08 as const;
-
-  // Defined in https://github.com/MinaProtocol/mina/blob/e39abf79b7fdf96717eb8a8ee88ec42ba1e2663d/src/lib/mina_compile_config/mina_compile_config.ml#L71
-  export const SIGNED_SINGLE_COST = 9.14 as const;
-
-  // Defined in https://github.com/MinaProtocol/mina/blob/e39abf79b7fdf96717eb8a8ee88ec42ba1e2663d/src/lib/mina_compile_config/mina_compile_config.ml#L73
-  export const COST_LIMIT = 69.45 as const;
-}
-
-// Constants to define the maximum number of events and actions in a transaction
+// Constants to define the maximum number of segments, events, and actions in a transaction
 export namespace TransactionLimits {
-  // Defined in https://github.com/MinaProtocol/mina/blob/e39abf79b7fdf96717eb8a8ee88ec42ba1e2663d/src/lib/mina_compile_config/mina_compile_config.ml#L75
+  export const MAX_ZKAPP_SEGMENT_PER_TRANSACTION = 16;
   export const MAX_ACTION_ELEMENTS = 100 as const;
-  // Defined in https://github.com/MinaProtocol/mina/blob/e39abf79b7fdf96717eb8a8ee88ec42ba1e2663d/src/lib/mina_compile_config/mina_compile_config.ml#L77
   export const MAX_EVENT_ELEMENTS = 100 as const;
 }
 

--- a/src/lib/mina/v1/transaction-validation.ts
+++ b/src/lib/mina/v1/transaction-validation.ts
@@ -1,35 +1,35 @@
 /**
  * This module holds the global Mina instance and its interface.
  */
+import { Types, TypesBigint } from '../../../bindings/mina-transaction/v1/types.js';
+import { verifyAccountUpdateSignature } from '../../../mina-signer/src/sign-zkapp-command.js';
+import type { NetworkId } from '../../../mina-signer/src/types.js';
+import { VerificationKey } from '../../proof-system/verification-key.js';
+import { JsonProof, verify } from '../../proof-system/zkprogram.js';
+import { PublicKey } from '../../provable/crypto/signature.js';
+import { assert } from '../../provable/gadgets/common.js';
+import { UInt32, UInt64 } from '../../provable/int.js';
+import { cloneCircuitValue } from '../../provable/types/struct.js';
+import { Field } from '../../provable/wrapped.js';
 import {
-  ZkappCommand,
-  TokenId,
-  Events,
-  ZkappPublicInput,
   AccountUpdate,
+  Events,
+  TokenId,
+  ZkappCommand,
+  ZkappPublicInput,
   dummySignature,
 } from './account-update.js';
-import { Field } from '../../provable/wrapped.js';
-import { UInt64, UInt32 } from '../../provable/int.js';
-import { PublicKey } from '../../provable/crypto/signature.js';
-import { JsonProof, verify } from '../../proof-system/zkprogram.js';
-import { verifyAccountUpdateSignature } from '../../../mina-signer/src/sign-zkapp-command.js';
-import { TransactionCost, TransactionLimits } from './constants.js';
-import { cloneCircuitValue } from '../../provable/types/struct.js';
-import { assert } from '../../provable/gadgets/common.js';
-import { Types, TypesBigint } from '../../../bindings/mina-transaction/v1/types.js';
-import type { NetworkId } from '../../../mina-signer/src/types.js';
 import type { Account } from './account.js';
+import { TransactionLimits } from './constants.js';
 import type { NetworkValue } from './precondition.js';
-import { VerificationKey } from '../../proof-system/verification-key.js';
 
 export {
-  reportGetAccountError,
   defaultNetworkState,
-  verifyTransactionLimits,
-  getTotalTimeRequired,
-  verifyAccountUpdate,
   filterGroups,
+  getEvents as getTotalTimeRequired,
+  reportGetAccountError,
+  verifyAccountUpdate,
+  verifyTransactionLimits
 };
 
 function reportGetAccountError(publicKey: string, tokenId: string) {
@@ -60,23 +60,18 @@ function defaultNetworkState(): NetworkValue {
 }
 
 function verifyTransactionLimits({ accountUpdates }: ZkappCommand) {
-  let { totalTimeRequired, eventElements, authTypes } = getTotalTimeRequired(accountUpdates);
+  let { eventElements } = getEvents(accountUpdates);
+  const segments = accountUpdates.length;
 
-  let isWithinCostLimit = totalTimeRequired < TransactionCost.COST_LIMIT;
+  let isWithinSegmentLimit = segments <= TransactionLimits.MAX_ZKAPP_SEGMENT_PER_TRANSACTION;
 
   let isWithinEventsLimit = eventElements.events <= TransactionLimits.MAX_EVENT_ELEMENTS;
   let isWithinActionsLimit = eventElements.actions <= TransactionLimits.MAX_ACTION_ELEMENTS;
 
   let error = '';
 
-  if (!isWithinCostLimit) {
-    // TODO: we should add a link to the docs explaining the reasoning behind it once we have such an explainer
-    error += `Error: The transaction is too expensive, try reducing the number of AccountUpdates that are attached to the transaction.
-Each transaction needs to be processed by the snark workers on the network.
-Certain layouts of AccountUpdates require more proving time than others, and therefore are too expensive.
-
-${JSON.stringify(authTypes)}
-\n\n`;
+  if (!isWithinSegmentLimit) {
+    error += `Error: the transaction contains too many segments. Try reducing the number of accountUpdates attached to the transaction. The maximum number of updates per transaction is ${TransactionLimits.MAX_ZKAPP_SEGMENT_PER_TRANSACTION}`;
   }
 
   if (!isWithinEventsLimit) {
@@ -90,7 +85,7 @@ ${JSON.stringify(authTypes)}
   if (error) throw Error('Error during transaction sending:\n\n' + error);
 }
 
-function getTotalTimeRequired(accountUpdates: AccountUpdate[]) {
+function getEvents(accountUpdates: AccountUpdate[]) {
   let eventElements = { events: 0, actions: 0 };
 
   let authKinds = accountUpdates.map((update) => {
@@ -111,21 +106,7 @@ function getTotalTimeRequired(accountUpdates: AccountUpdate[]) {
   });
   let authTypes = filterGroups(authKinds);
 
-  /*
-  np := proof
-  n2 := signedPair
-  n1 := signedSingle
-
-  formula used to calculate how expensive a zkapp transaction is
-
-  10.26*np + 10.08*n2 + 9.14*n1 < 69.45
-  */
-  let totalTimeRequired =
-    TransactionCost.PROOF_COST * authTypes.proof +
-    TransactionCost.SIGNED_PAIR_COST * authTypes.signedPair +
-    TransactionCost.SIGNED_SINGLE_COST * authTypes.signedSingle;
-  // returns totalTimeRequired and additional data used by verifyTransactionLimits
-  return { totalTimeRequired, eventElements, authTypes };
+  return { eventElements, authTypes };
 }
 
 function countEventElements({ data }: Events) {


### PR DESCRIPTION
Bringing constants in our mirrored logic up-to-date with mesa: https://github.com/MinaProtocol/mina/pull/17386/files#diff-e9551c7ce072e32a4b8f325f3f2fb913ecd85d80b3dc6905cab71815fb2f4327

Reference PR above, constants changed similarly here.

closes #2636 