### PR TITLE
[mesa] compat: increases events and actions limits to match mesa values

### DIFF
--- a/src/lib/mina/v1/constants.ts
+++ b/src/lib/mina/v1/constants.ts
@@ -5,8 +5,8 @@
 // Constants to define the maximum number of segments, events, and actions in a transaction
 export namespace TransactionLimits {
   export const MAX_ZKAPP_SEGMENT_PER_TRANSACTION = 16;
-  export const MAX_ACTION_ELEMENTS = 100 as const;
-  export const MAX_EVENT_ELEMENTS = 100 as const;
+  export const MAX_ACTION_ELEMENTS = 1024 as const;
+  export const MAX_EVENT_ELEMENTS = 1024 as const;
 }
 
 export namespace ZkappConstants {


### PR DESCRIPTION
closes #2637
Bumps 2 numbers

parent: #2647 


Relevant implmentation for mesa: https://github.com/MinaProtocol/mina/pull/17573