### PR TITLE
Friendlier UX for cache misses

### DIFF
--- a/src/lib/proof-system/cache.ts
+++ b/src/lib/proof-system/cache.ts
@@ -125,7 +125,7 @@ function readCache<T>(
   try {
     let result = cache.read(header);
     if (result === undefined) {
-      if (cache.debug) console.trace(`cache miss: ${header.persistentId}`);
+      if (cache.debug) console.log(`cache miss: ${header.persistentId}`);
       return undefined;
     }
     if (transform === undefined) return result as any as T;
@@ -147,6 +147,15 @@ function writeCache(cache: Cache, header: CacheHeader, value: Uint8Array) {
   }
 }
 
+function isErr(error: unknown, code: string) {
+  return (
+    typeof error === 'object' &&
+    error !== null &&
+    'code' in error &&
+    (error as { code?: unknown }).code === code
+  );
+}
+
 const None: Cache = {
   read() {
     throw Error('not available');
@@ -163,16 +172,28 @@ const FileSystem = (cacheDirectory: string, debug?: boolean): Cache => ({
 
     let headerPath = resolve(cacheDirectory, `${persistentId}.header`);
     let dataPath = resolve(cacheDirectory, persistentId);
+
     // read current uniqueId, return data if it matches
-    let currentId = readFileSync(headerPath, 'utf8');
+    let currentId: string;
+    try {
+      currentId = readFileSync(headerPath, 'utf8');
+    } catch (error) {
+      if (isErr(error, 'ENOENT')) return undefined;
+      throw error;
+    }
     if (currentId !== uniqueId) return undefined;
 
-    if (dataType === 'string') {
-      let string = readFileSync(dataPath, 'utf8');
-      return new TextEncoder().encode(string);
-    } else {
-      let buffer = readFileSync(dataPath);
-      return new Uint8Array(buffer.buffer);
+    try {
+      if (dataType === 'string') {
+        let string = readFileSync(dataPath, 'utf8');
+        return new TextEncoder().encode(string);
+      } else {
+        let buffer = readFileSync(dataPath);
+        return new Uint8Array(buffer.buffer);
+      }
+    } catch (error) {
+      if (isErr(error, 'ENOENT')) return undefined;
+      throw error;
     }
   },
   write({ persistentId, uniqueId, dataType }, data) {


### PR DESCRIPTION
Closes https://github.com/o1-labs/o1js/issues/2778

Before it was

```
Failed to read cache Error: ENOENT: no such file or directory, open '/tmp/o1js/cache/srs-fp-65536.header'
    at readFileSync (node:fs:443:20)
    at Object.read (o1js/src/lib/proof-system/cache.ts:167:21)
    at readCache (o1js/src/lib/proof-system/cache.ts:126:24)
    at create (o1js/src/bindings/crypto/bindings/srs.ts:116:17)
    at _c6H_ (o1js/dist/node/bindings/compiled/node_bindings/o1js_node.bc.cjs:310558:53)
    at caml_call1 (o1js/dist/node/bindings/compiled/node_bindings/o1js_node.bc.cjs:6876:28)
    at load (/workspace_root/src/mina/src/lib/crypto/kimchi_backend/common/dlog_plonk_based_keypair.ml:160:27)
    at caml_call1 (o1js/dist/node/bindings/compiled/node_bindings/o1js_node.bc.cjs:6876:28)
    at compile_with_wrap_main_overrid (/workspace_root/src/mina/src/lib/pickles/compile.ml:649:21)
    at compile_promise (/workspace_root/src/mina/src/lib/pickles/pickles.ml:320:5)
    at caml_call14 (o1js/dist/node/bindings/compiled/node_bindings/o1js_node.bc.cjs:6915:16)
    at Object.pickles_compile (/workspace_root/src/bindings/ocaml/lib/pickles_bindings.ml:658:5)
    at <anonymous> (o1js/src/lib/proof-system/zkprogram.ts:785:26)
    at withThreadPool (o1js/src/lib/proof-system/workers.ts:60:22)
    at async prettifyStacktracePromise (o1js/src/lib/util/errors.ts:129:12)
    at async compileProgram (o1js/src/lib/proof-system/zkprogram.ts:779:51)
    at async Object.compile (o1js/src/lib/proof-system/zkprogram.ts:397:50)
    at async file://o1js/dist/node/examples/zkprogram/program-with-cache.js:19:27 {
  errno: -2,
  code: 'ENOENT',
  syscall: 'open',
  path: '/tmp/o1js/cache/srs-fp-65536.header'
}
Failed to read cache Error: ENOENT: no such file or directory, open '/tmp/o1js/cache/srs-fq-32768.header'
    at readFileSync (node:fs:443:20)
    at Object.read (o1js/src/lib/proof-system/cache.ts:167:21)
    at readCache (o1js/src/lib/proof-system/cache.ts:126:24)
    at Object.create (o1js/src/bindings/crypto/bindings/srs.ts:116:17)
    at caml_fq_srs_create (/workspace_root/src/mina/src/lib/crypto/kimchi_bindings/js/bindings/srs.js:123:12)
    at _c7b_ (o1js/dist/node/bindings/compiled/node_bindings/o1js_node.bc.cjs:310884:53)
    at caml_call1 (o1js/dist/node/bindings/compiled/node_bindings/o1js_node.bc.cjs:6876:28)
    at load (/workspace_root/src/mina/src/lib/crypto/kimchi_backend/common/dlog_plonk_based_keypair.ml:160:27)
    at caml_call1 (o1js/dist/node/bindings/compiled/node_bindings/o1js_node.bc.cjs:6876:28)
    at _it8_ (/workspace_root/src/mina/src/lib/pickles/step_main.ml:393:21)
    at <anonymous> (/workspace_root/src/mina/src/lib/concurrency/promise/js/promise.js:25:37) {
  errno: -2,
  code: 'ENOENT',
  syscall: 'open',
  path: '/tmp/o1js/cache/srs-fq-32768.header'
}
Failed to read cache Error: ENOENT: no such file or directory, open '/tmp/o1js/cache/lagrange-basis-fp-512.header'
    at readFileSync (node:fs:443:20)
    at Object.read (o1js/src/lib/proof-system/cache.ts:167:21)
    at readCache (o1js/src/lib/proof-system/cache.ts:126:24)
    at readCacheLazy (o1js/src/bindings/crypto/bindings/srs.ts:278:10)
    at lagrangeCommitment (o1js/src/bindings/crypto/bindings/srs.ts:163:25)
    at base_and_correction (/workspace_root/src/mina/src/lib/pickles/wrap_verifier.ml:402:13)
    at _iLW_ (/workspace_root/src/mina/src/lib/pickles/wrap_verifier.ml:420:15)
    at caml_call1 (o1js/dist/node/bindings/compiled/node_bindings/o1js_node.bc.cjs:6876:28)
    at with_label (/workspace_root/src/mina/src/lib/snarky/src/base/snark0.ml:1241:15)
    at caml_call2 (o1js/dist/node/bindings/compiled/node_bindings/o1js_node.bc.cjs:6878:28)
    at lagrange_with_correction (/workspace_root/src/mina/src/lib/pickles/wrap_verifier.ml:374:32)
    at non_constant_part (/workspace_root/src/mina/src/lib/pickles/wrap_verifier.ml:885:29)
    at caml_call1 (o1js/dist/node/bindings/compiled/node_bindings/o1js_node.bc.cjs:6876:28)
    at count_map (/Users/querolite/.opam/mina/lib/base/list.ml:387:14)
    at func$4 (/Users/querolite/.opam/mina/lib/base/list.ml:418:16)
    at _iI7_ (/workspace_root/src/mina/src/lib/pickles/wrap_verifier.ml:876:17)
    at caml_call1 (o1js/dist/node/bindings/compiled/node_bindings/o1js_node.bc.cjs:6876:28)
    at with_label (/workspace_root/src/mina/src/lib/snarky/src/base/snark0.ml:1241:15)
    at caml_call2 (o1js/dist/node/bindings/compiled/node_bindings/o1js_node.bc.cjs:6878:28)
    at _iI2_ (/workspace_root/src/mina/src/lib/pickles/wrap_verifier.ml:874:11)
    at caml_call1 (o1js/dist/node/bindings/compiled/node_bindings/o1js_node.bc.cjs:6876:28)
    at with_label (/workspace_root/src/mina/src/lib/snarky/src/base/snark0.ml:1241:15)
    at caml_call2 (o1js/dist/node/bindings/compiled/node_bindings/o1js_node.bc.cjs:6878:28)
    at <anonymous> (/workspace_root/src/mina/src/lib/pickles/wrap_verifier.ml:811:7)
    at caml_call_gen (/builtin/+stdlib.js:32:12)
    at caml_call_gen (/builtin/+stdlib.js:34:12)
    at caml_call14 (o1js/dist/node/bindings/compiled/node_bindings/o1js_node.bc.cjs:6916:16)
    at <anonymous> (/workspace_root/src/mina/src/lib/pickles/wrap_main.ml:496:19)
    at caml_call1 (o1js/dist/node/bindings/compiled/node_bindings/o1js_node.bc.cjs:6876:28)
    at with_label (/workspace_root/src/mina/src/lib/snarky/src/base/snark0.ml:1241:15)
    at caml_call2 (o1js/dist/node/bindings/compiled/node_bindings/o1js_node.bc.cjs:6878:28)
    at <anonymous> (/workspace_root/src/mina/src/lib/pickles/wrap_main.ml:493:13)
    at caml_call1 (o1js/dist/node/bindings/compiled/node_bindings/o1js_node.bc.cjs:6876:28)
    at with_label (/workspace_root/src/mina/src/lib/snarky/src/base/snark0.ml:1241:15)
    at caml_call2 (o1js/dist/node/bindings/compiled/node_bindings/o1js_node.bc.cjs:6878:28)
    at step_domains (/workspace_root/src/mina/src/lib/pickles/wrap_main.ml:167:20)
    at <anonymous> (/workspace_root/src/mina/src/lib/concurrency/promise/js/promise.js:27:16)
    at caml_call_gen (/builtin/+stdlib.js:28:22)
    at caml_call1 (o1js/dist/node/bindings/compiled/node_bindings/o1js_node.bc.cjs:6876:34)
    at main (/workspace_root/src/mina/src/lib/pickles/compile.ml:673:38)
    at caml_call_gen (/builtin/+stdlib.js:32:12)
    at <anonymous> (/builtin/+stdlib.js:42:14)
    at caml_call_gen (/builtin/+stdlib.js:28:22)
    at caml_call1 (o1js/dist/node/bindings/compiled/node_bindings/o1js_node.bc.cjs:6876:34)
    at mark_active (/workspace_root/src/mina/src/lib/snarky/src/base/snark0.ml:1154:19)
    at _kI9_ (/workspace_root/src/mina/src/lib/snarky/src/base/snark0.ml:1275:52)
    at caml_call_gen (/builtin/+stdlib.js:32:12)
    at <anonymous> (/builtin/+stdlib.js:42:14)
    at caml_call_gen (/builtin/+stdlib.js:28:22)
    at caml_call1 (o1js/dist/node/bindings/compiled/node_bindings/o1js_node.bc.cjs:6876:34)
    at as_stateful (/workspace_root/src/mina/src/lib/snarky/src/base/snark0.ml:743:15)
    at caml_call2 (o1js/dist/node/bindings/compiled/node_bindings/o1js_node.bc.cjs:6878:28)
    at _kWF_ (/workspace_root/src/mina/src/lib/snarky/src/base/runners.ml:253:55)
    at caml_call2 (o1js/dist/node/bindings/compiled/node_bindings/o1js_node.bc.cjs:6878:28)
    at run_computation (/workspace_root/src/mina/src/lib/snarky/src/base/runners.ml:225:33)
    at caml_call1 (o1js/dist/node/bindings/compiled/node_bindings/o1js_node.bc.cjs:6876:28)
    at constraint_system (/workspace_root/src/mina/src/lib/snarky/src/base/runners.ml:253:9)
    at caml_call4 (o1js/dist/node/bindings/compiled/node_bindings/o1js_node.bc.cjs:6882:28)
    at <anonymous> (/workspace_root/src/mina/src/lib/snarky/src/base/snark0.ml:1275:19)
    at caml_call1 (o1js/dist/node/bindings/compiled/node_bindings/o1js_node.bc.cjs:6876:28)
    at finalize_is_running (/workspace_root/src/mina/src/lib/snarky/src/base/snark0.ml:1260:15)
    at constraint_system (/workspace_root/src/mina/src/lib/snarky/src/base/snark0.ml:1274:7)
    at caml_call3 (o1js/dist/node/bindings/compiled/node_bindings/o1js_node.bc.cjs:6880:28)
    at _inJ_ (/workspace_root/src/mina/src/lib/pickles/compile.ml:675:14)
    at <anonymous> (/workspace_root/src/mina/src/lib/concurrency/promise/js/promise.js:25:37)
    at async <anonymous> (o1js/src/lib/proof-system/zkprogram.ts:795:30)
    at async withThreadPool (o1js/src/lib/proof-system/workers.ts:60:16)
    at async prettifyStacktracePromise (o1js/src/lib/util/errors.ts:129:12)
    at async compileProgram (o1js/src/lib/proof-system/zkprogram.ts:779:51)
    at async Object.compile (o1js/src/lib/proof-system/zkprogram.ts:397:50)
    at async file://o1js/dist/node/examples/zkprogram/program-with-cache.js:19:27 {
  errno: -2,
  code: 'ENOENT',
  syscall: 'open',
  path: '/tmp/o1js/cache/lagrange-basis-fp-512.header'
}
```

Now it is

```
cache miss: step-vk-example-with-output-basecase
cache miss: step-pk-example-with-output-basecase
cache miss: wrap-vk-example-with-output
cache miss: wrap-pk-example-with-output
```