### PR TITLE
VK regression checks for native backend

### DIFF
--- a/src/bindings/crypto/bindings/srs.ts
+++ b/src/bindings/crypto/bindings/srs.ts
@@ -1,7 +1,7 @@
 import type { Wasm, RustConversion } from '../bindings.js';
 import { type WasmFpSrs, type WasmFqSrs } from '../../compiled/node_bindings/kimchi_wasm.cjs';
 import { PolyComm } from './kimchi-types.js';
-import { srsCache } from '../cache.js';
+import { srsCache as cache } from '../cache.js';
 import {
   type CacheHeader,
   type Cache,
@@ -26,8 +26,6 @@ function empty(): SrsStore {
 const srsStore = { fp: empty(), fq: empty() };
 
 const CacheReadRegister = new Map<string, boolean>();
-
-let cache: Cache | undefined = srsCache;
 
 const srsVersion = 1;
 

--- a/src/bindings/crypto/native/napi-srs.ts
+++ b/src/bindings/crypto/native/napi-srs.ts
@@ -6,7 +6,7 @@ import {
   type Cache,
   type CacheHeader,
 } from '../../../lib/proof-system/cache.js';
-import { srsCache } from '../cache.js';
+import { srsCache as cache } from '../cache.js';
 import { assert } from '../../../lib/util/errors.js';
 import type { RustConversion } from '../bindings.js';
 import type { Napi, NapiAffine, NapiPolyComm, NapiPolyComms, NapiSrs } from './napi-wrappers.js';
@@ -24,8 +24,6 @@ function empty(): SrsStore {
 const srsStore = { fp: empty(), fq: empty() };
 
 const CacheReadRegister = new Map<string, boolean>();
-
-let cache: Cache | undefined = srsCache;
 
 const srsVersion = 1;
 

--- a/src/bindings/js/node/native-backend.js
+++ b/src/bindings/js/node/native-backend.js
@@ -8,22 +8,22 @@ let wasm;
 try {
   const require_ = createRequire(import.meta.url);
   wasm = require_(slug);
-  wasm.__kimchi_backend = 'native';
+  wasm.__o1js_backend_preference = 'native';
   if (typeof globalThis !== 'undefined') {
-    globalThis.__kimchi_backend = 'native';
+    globalThis.__o1js_backend_preference = 'native';
   }
 } catch (e) {
   throw new Error(
     `Native backend requested but '${slug}' is not installed.\n` +
-      `Install it with: npm install @o1js/native\n` +
-      `Original error: ${e.message}`
+    `Install it with: npm install @o1js/native\n` +
+    `Original error: ${e.message}`
   );
 }
 
 // noop thread pool, napirs uses native os threads
 const withThreadPool = WithThreadPool({
-  initThreadPool: async () => {},
-  exitThreadPool: async () => {},
+  initThreadPool: async () => { },
+  exitThreadPool: async () => { },
 });
 
 export { wasm, withThreadPool };

--- a/src/bindings/js/node/node-backend.js
+++ b/src/bindings/js/node/node-backend.js
@@ -10,9 +10,9 @@ let filename = url !== undefined ? fileURLToPath(url) : __filename;
  * @type {import("../../compiled/node_bindings/kimchi_wasm.cjs")}
  */
 const wasm = wasm_;
-wasm.__kimchi_backend = 'wasm';
+wasm.__o1js_backend_preference = 'wasm';
 if (typeof globalThis !== 'undefined') {
-  globalThis.__kimchi_backend = 'wasm';
+  globalThis.__o1js_backend_preference = 'wasm';
 }
 
 export { wasm, withThreadPool };


### PR DESCRIPTION
This PR extends the checks for the VK regression to check that keys generated with a native backend are not modified with respect to the canonical instance. This implicitly checks that both backends produce the same keys.

Just like before, we do:
```
 npm run regression:dump-vks
 npm run regression:check-vks         
```

Closes https://github.com/o1-labs/o1js/issues/2775