### PR TITLE
Fix `RuntimeTable` native conversion 

### DIFF
--- a/src/bindings/crypto/native/napi-conversion-proof.ts
+++ b/src/bindings/crypto/native/napi-conversion-proof.ts
@@ -62,7 +62,6 @@ function napiProofConversion(napi: Napi, core: ConversionCores) {
       VecVec: napi.WasmVecVecFp,
       ProverProof: napi.WasmFpProverProof,
       LookupCommitments: napi.WasmFpLookupCommitments,
-      RuntimeTable: napi.WasmFpRuntimeTable,
       RuntimeTableCfg: napi.WasmPastaFpRuntimeTableCfg,
       LookupTable: napi.WasmPastaFpLookupTable,
     }),
@@ -72,7 +71,6 @@ function napiProofConversion(napi: Napi, core: ConversionCores) {
       VecVec: napi.WasmVecVecFq,
       ProverProof: napi.WasmFqProverProof,
       LookupCommitments: napi.WasmFqLookupCommitments,
-      RuntimeTable: napi.WasmFqRuntimeTable,
       RuntimeTableCfg: napi.WasmPastaFqRuntimeTableCfg,
       LookupTable: napi.WasmPastaFqLookupTable,
     }),
@@ -87,7 +85,6 @@ function proofConversionPerField(
     VecVec,
     ProverProof,
     LookupCommitments,
-    RuntimeTable,
     RuntimeTableCfg,
     LookupTable,
   }: NapiProofClasses
@@ -189,7 +186,7 @@ function proofConversionPerField(
   }
 
   function runtimeTableToRust([, id, data]: RuntimeTable): NapiRuntimeTable {
-    return new RuntimeTable(id, core.vectorToRust(data));
+    return { id, data: core.vectorToRust(data) };
   }
 
   function runtimeTableCfgToRust([, id, firstColumn]: RuntimeTableCfg): NapiRuntimeTableCfg {
@@ -447,4 +444,3 @@ function proofConversionPerField(
     },
   };
 }
-

--- a/src/bindings/crypto/native/napi-wrappers.ts
+++ b/src/bindings/crypto/native/napi-wrappers.ts
@@ -12,7 +12,6 @@ import type {
   WasmFpProverCommitments as NapiFpProverCommitments,
   WasmFpProverProof as NapiFpProverProof,
   WasmFpRandomOracles as NapiFpRandomOracles,
-  WasmFpRuntimeTable as NapiFpRuntimeTable,
   WasmFpShifts as NapiFpShifts,
   WasmFpSrs as NapiFpSrs,
   WasmFqDomain as NapiFqDomain,
@@ -27,7 +26,6 @@ import type {
   WasmFqProverCommitments as NapiFqProverCommitments,
   WasmFqProverProof as NapiFqProverProof,
   WasmFqRandomOracles as NapiFqRandomOracles,
-  WasmFqRuntimeTable as NapiFqRuntimeTable,
   WasmFqShifts as NapiFqShifts,
   WasmFqSrs as NapiFqSrs,
   LookupInfo as NapiLookupInfo,
@@ -122,6 +120,16 @@ export type NapiProverProof = {
   prev_challenges_comms: ArrayLike<NapiPolyComm>;
 };
 
+export type NapiFpRuntimeTable = {
+  id: number;
+  data: Uint8Array;
+};
+
+export type NapiFqRuntimeTable = {
+  id: number;
+  data: Uint8Array;
+};
+
 export type NapiRuntimeTable = NapiFpRuntimeTable | NapiFqRuntimeTable;
 export type NapiRuntimeTableCfg = NapiPastaFpRuntimeTableCfg | NapiPastaFqRuntimeTableCfg;
 export type NapiLookupTable = NapiPastaFpLookupTable | NapiPastaFqLookupTable;
@@ -210,7 +218,6 @@ export type NapiProofClasses = {
   VecVec: typeof NapiVecVecFp | typeof NapiVecVecFq;
   ProverProof: typeof NapiFpProverProof | typeof NapiFqProverProof;
   LookupCommitments: typeof NapiFpLookupCommitments | typeof NapiFqLookupCommitments;
-  RuntimeTable: typeof NapiFpRuntimeTable | typeof NapiFqRuntimeTable;
   RuntimeTableCfg: typeof NapiPastaFpRuntimeTableCfg | typeof NapiPastaFqRuntimeTableCfg;
   LookupTable: typeof NapiPastaFpLookupTable | typeof NapiPastaFqLookupTable;
 };


### PR DESCRIPTION
This creates a wrapper as we previously did with other napi types to be able to create objects from o1js.

Closes https://github.com/o1-labs/o1js/issues/2782