### PR TITLE
only assertAlmostReduced on scalar s in `EddsaSignature.check`

### DIFF
--- a/src/lib/provable/crypto/foreign-ecdsa.ts
+++ b/src/lib/provable/crypto/foreign-ecdsa.ts
@@ -1,19 +1,19 @@
-import { provableFromClass } from '../types/provable-derivers.js';
 import { CurveParams } from '../../../bindings/crypto/elliptic-curve.js';
-import { ProvablePureExtended } from '../types/struct.js';
-import { FlexiblePoint, ForeignCurve, createForeignCurve, toPoint } from './foreign-curve.js';
+import type { Bool } from '../bool.js';
 import { AlmostForeignField } from '../foreign-field.js';
 import { assert } from '../gadgets/common.js';
-import { Field3 } from '../gadgets/foreign-field.js';
 import { Ecdsa } from '../gadgets/elliptic-curve.js';
+import { Field3 } from '../gadgets/foreign-field.js';
 import { l, multiRangeCheck } from '../gadgets/range-check.js';
-import { Keccak } from './keccak.js';
-import { Bytes } from '../wrapped-classes.js';
 import { UInt8 } from '../int.js';
-import type { Bool } from '../bool.js';
+import { provableFromClass } from '../types/provable-derivers.js';
+import { ProvablePureExtended } from '../types/struct.js';
+import { Bytes } from '../wrapped-classes.js';
+import { FlexiblePoint, ForeignCurve, createForeignCurve, toPoint } from './foreign-curve.js';
+import { Keccak } from './keccak.js';
 
 // external API
-export { createEcdsa, EcdsaSignature };
+export { EcdsaSignature, createEcdsa };
 
 type FlexibleSignature =
   | EcdsaSignature
@@ -204,8 +204,8 @@ class EcdsaSignature {
   static check(signature: EcdsaSignature) {
     multiRangeCheck(signature.r.value);
     multiRangeCheck(signature.s.value);
-    // more efficient than the automatic check, which would do this for each scalar separately
-    this.Curve.Scalar.assertAlmostReduced(signature.r, signature.s);
+
+    this.Curve.Scalar.assertAlmostReduced(signature.s);
   }
 
   // dynamic subclassing infra


### PR DESCRIPTION
`check()` was calling `Scalar.assertAlmostReduced(signature.R, signature.s)` which asserts both `r` and `s` against the scalar field modulus. However, `r` is an encoded curve point and not a scalar, its top limb can reach 2^80 due to the sign bit, while the scalar modulus top limb is only ~2^76. this caused `weakBound` inside `assertAlmostReduced` to overflow 88 bits, failing the RangeCheck0 constraint. We now only assert `s` against the scalar modulus. `r` is already covered by the multiRangeCheck on the line above