### PR TITLE
add cjs test + node version matrix

### DIFF
--- a/.github/actions/build-wasm/action.yml
+++ b/.github/actions/build-wasm/action.yml
@@ -2,6 +2,10 @@ name: Build o1js
 description: 'All of the building steps for o1js'
 
 inputs:
+  node_version:
+    description: 'Node.js version to use'
+    required: false
+    default: '20'
   proof_systems_commit:
     description: 'proof_systems commit to use'
     required: false
@@ -23,7 +27,7 @@ runs:
     - name: Setup Node
       uses: actions/setup-node@v4
       with:
-        node-version: '20'
+        node-version: ${{ inputs.node_version }}
 
     - name: use proof_systems_commit if provided
       if: ${{ inputs.proof_systems_commit != '' }}
@@ -58,7 +62,7 @@ runs:
           ~/.npm
           node_modules
           dist
-        key: ${{ runner.OS }}-node-v2-${{ hashFiles('**/package-lock.json') }}-${{ hashFiles('**/*.ts', '**/*.js') }}
+        key: ${{ runner.OS }}-node-${{ inputs.node_version }}-v2-${{ hashFiles('**/package-lock.json') }}-${{ hashFiles('**/*.ts', '**/*.js') }}
     - name: Build examples
       if: ${{ steps.cache.outputs.cache-hit != 'true' }}
       shell: bash
@@ -77,5 +81,4 @@ runs:
       uses: actions/cache@v4
       with:
         path: .
-        key: repo-${{ github.sha }}
-
+        key: repo-${{ github.sha }}-node-${{ inputs.node_version }}

--- a/.github/actions/release-pkg-pr-version/action.yml
+++ b/.github/actions/release-pkg-pr-version/action.yml
@@ -9,7 +9,7 @@ runs:
       uses: actions/cache@v4
       with:
         path: .
-        key: repo-${{ github.sha }}
+        key: repo-${{ github.sha }}-node-20
     - name: Setup Node.JS 20
       uses: actions/setup-node@v4
       with:
@@ -27,4 +27,3 @@ runs:
     - name: Publish o1js and mina-signer on pkg-pr-new
       shell: bash
       run: npx pkg-pr-new publish ./ ./src/mina-signer
-

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -220,6 +220,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
+        node: [20, 22, 24]
         chunk: [1, 2, 3, 4, 5, 6, 7, 8]
     steps:
       - name: Checkout repository with submodules
@@ -234,6 +235,7 @@ jobs:
           repository: ${{ inputs.target_repo || github.repository }}
           ref: ${{ inputs.target_ref || github.ref }}
           proof_systems_commit: ${{ inputs.proof_systems_commit }}
+          node_version: ${{ matrix.node }}
       - name: Count tests
         id: count_tests
         run: |
@@ -244,10 +246,12 @@ jobs:
       - name: Run unit tests
         env:
           TOTAL_TESTS: ${{ steps.count_tests.outputs.test_count }}
+          NODE_VERSION: ${{ matrix.node }}
           CHUNK: ${{ matrix.chunk }}
           CHUNKS: 8
         shell: bash
         run: |
+          echo "Node version: $NODE_VERSION"
           echo "Total tests: $TOTAL_TESTS"
           echo "Current chunk: $CHUNK"
           echo "Total chunks: $CHUNKS"
@@ -282,13 +286,13 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: test-results-${{ matrix.chunk }}
+          name: test-results-node-${{ matrix.node }}-${{ matrix.chunk }}
           path: profiling.md
       - name: Add to job summary
         if: always()
         shell: bash
         run: |
-          echo "### Test Results for Unit Tests Chunk ${{ matrix.chunk }}" >> $GITHUB_STEP_SUMMARY
+          echo "### Test Results for Unit Tests Chunk ${{ matrix.chunk }} (Node ${{ matrix.node }})" >> $GITHUB_STEP_SUMMARY
           cat profiling.md >> $GITHUB_STEP_SUMMARY
 
   Build-And-Test-Server-Unit-Tests:

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -167,6 +167,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
+        node: [20, 22, 24]
         test_type:
           [
             'Simple integration tests',
@@ -194,6 +195,7 @@ jobs:
           repository: ${{ inputs.target_repo || github.repository }}
           ref: ${{ inputs.target_ref || github.ref }}
           proof_systems_commit: ${{ inputs.proof_systems_commit }}
+          node_version: ${{ matrix.node }}
       - uses: 'google-github-actions/auth@v3'
         name: Setup gcloud authentication
         with:
@@ -207,7 +209,7 @@ jobs:
       - name: Add to job summary
         if: always()
         run: |
-          echo "### Test Results for ${{ matrix.test_type }}" >> $GITHUB_STEP_SUMMARY
+          echo "### Test Results for ${{ matrix.test_type }} (Node ${{ matrix.node }})" >> $GITHUB_STEP_SUMMARY
           cat profiling.md >> $GITHUB_STEP_SUMMARY
 
   Run-Unit-Tests:
@@ -300,24 +302,25 @@ jobs:
     needs: [Prepare-Wasm]
     timeout-minutes: 90
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        node: [20, 22, 24]
     steps:
-      - name: Restore repository
-        uses: actions/cache@v4
+      - name: Checkout repository with submodules
+        uses: actions/checkout@v4
         with:
-          path: .
-          key: repo-${{ github.sha }}
+          submodules: recursive
+          repository: ${{ inputs.target_repo || github.repository }}
+          ref: ${{ inputs.target_ref || github.ref }}
 
-      - name: Setup Node.JS ${{ matrix.node }}
-        uses: actions/setup-node@v4
+      - name: build
+        uses: ./.github/actions/build-wasm
         with:
-          node-version: 20
-          # TODO matrixing this requires changing branch protection rules
-
-      - name: Restore npm cache
-        uses: actions/cache@v4
-        with:
-          path: ~/.npm
-          key: ${{ runner.OS }}-node-${{ hashFiles('**/package-lock.json') }}
+          repository: ${{ inputs.target_repo || github.repository }}
+          ref: ${{ inputs.target_ref || github.ref }}
+          proof_systems_commit: ${{ inputs.proof_systems_commit }}
+          node_version: ${{ matrix.node }}
 
       - name: Cache Playwright browsers
         uses: actions/cache@v4

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -99,7 +99,7 @@ jobs:
         with:
           repository: ${{ inputs.target_repo || github.repository }}
           ref: ${{ inputs.target_ref || github.ref }}
-      - name: Setup Node.JS ${{ matrix.node }}
+      - name: Setup Node.JS 20
         uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node }}
@@ -167,7 +167,6 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node: [20, 22, 24]
         test_type:
           [
             'Simple integration tests',
@@ -195,7 +194,6 @@ jobs:
           repository: ${{ inputs.target_repo || github.repository }}
           ref: ${{ inputs.target_ref || github.ref }}
           proof_systems_commit: ${{ inputs.proof_systems_commit }}
-          node_version: ${{ matrix.node }}
       - uses: 'google-github-actions/auth@v3'
         name: Setup gcloud authentication
         with:
@@ -209,7 +207,7 @@ jobs:
       - name: Add to job summary
         if: always()
         run: |
-          echo "### Test Results for ${{ matrix.test_type }} (Node ${{ matrix.node }})" >> $GITHUB_STEP_SUMMARY
+          echo "### Test Results for ${{ matrix.test_type }}" >> $GITHUB_STEP_SUMMARY
           cat profiling.md >> $GITHUB_STEP_SUMMARY
 
   Run-Unit-Tests:
@@ -220,7 +218,6 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node: [20, 22, 24]
         chunk: [1, 2, 3, 4, 5, 6, 7, 8]
     steps:
       - name: Checkout repository with submodules
@@ -235,7 +232,6 @@ jobs:
           repository: ${{ inputs.target_repo || github.repository }}
           ref: ${{ inputs.target_ref || github.ref }}
           proof_systems_commit: ${{ inputs.proof_systems_commit }}
-          node_version: ${{ matrix.node }}
       - name: Count tests
         id: count_tests
         run: |
@@ -246,12 +242,10 @@ jobs:
       - name: Run unit tests
         env:
           TOTAL_TESTS: ${{ steps.count_tests.outputs.test_count }}
-          NODE_VERSION: ${{ matrix.node }}
           CHUNK: ${{ matrix.chunk }}
           CHUNKS: 8
         shell: bash
         run: |
-          echo "Node version: $NODE_VERSION"
           echo "Total tests: $TOTAL_TESTS"
           echo "Current chunk: $CHUNK"
           echo "Total chunks: $CHUNKS"
@@ -286,13 +280,13 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: test-results-node-${{ matrix.node }}-${{ matrix.chunk }}
+          name: test-results-${{ matrix.chunk }}
           path: profiling.md
       - name: Add to job summary
         if: always()
         shell: bash
         run: |
-          echo "### Test Results for Unit Tests Chunk ${{ matrix.chunk }} (Node ${{ matrix.node }})" >> $GITHUB_STEP_SUMMARY
+          echo "### Test Results for Unit Tests Chunk ${{ matrix.chunk }}" >> $GITHUB_STEP_SUMMARY
           cat profiling.md >> $GITHUB_STEP_SUMMARY
 
   Build-And-Test-Server-Unit-Tests:
@@ -306,25 +300,23 @@ jobs:
     needs: [Prepare-Wasm]
     timeout-minutes: 90
     runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        node: [20, 22, 24]
     steps:
-      - name: Checkout repository with submodules
-        uses: actions/checkout@v4
+      - name: Restore repository
+        uses: actions/cache@v4
         with:
-          submodules: recursive
-          repository: ${{ inputs.target_repo || github.repository }}
-          ref: ${{ inputs.target_ref || github.ref }}
+          path: .
+          key: repo-${{ github.sha }}-node-20
 
-      - name: build
-        uses: ./.github/actions/build-wasm
+      - name: Setup Node.JS 20
+        uses: actions/setup-node@v4
         with:
-          repository: ${{ inputs.target_repo || github.repository }}
-          ref: ${{ inputs.target_ref || github.ref }}
-          proof_systems_commit: ${{ inputs.proof_systems_commit }}
-          node_version: ${{ matrix.node }}
+          node-version: 20
+
+      - name: Restore npm cache
+        uses: actions/cache@v4
+        with:
+          path: ~/.npm
+          key: ${{ runner.OS }}-node-20-${{ hashFiles('**/package-lock.json') }}
 
       - name: Cache Playwright browsers
         uses: actions/cache@v4

--- a/.github/workflows/nightly-node-compatibility.yml
+++ b/.github/workflows/nightly-node-compatibility.yml
@@ -1,0 +1,199 @@
+name: Nightly Node Compatibility
+
+on:
+  schedule:
+    - cron: '0 3 * * *'
+  workflow_dispatch:
+    inputs:
+      proof_systems_commit:
+        description: 'proof_systems commit to use'
+        required: false
+        default: ''
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  Server-Compatibility:
+    name: Server Compatibility (Node ${{ matrix.node }}, ${{ matrix.test_type }})
+    timeout-minutes: 210
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        node: [20, 22, 24]
+        test_type:
+          [
+            'Simple integration tests',
+            'Reducer integration tests',
+            'DEX integration tests',
+            'DEX integration test with proofs',
+            'Voting integration tests',
+            'Verification Key Regression Check 1',
+            'Verification Key Regression Check 2',
+            'CommonJS test',
+            'Cache Regression',
+            'Performance Regression',
+          ]
+    steps:
+      - name: Checkout repository with submodules
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: Build
+        uses: ./.github/actions/build-wasm
+        with:
+          proof_systems_commit: ${{ github.event.inputs.proof_systems_commit || '' }}
+          node_version: ${{ matrix.node }}
+
+      - uses: 'google-github-actions/auth@v3'
+        name: Setup gcloud authentication
+        with:
+          credentials_json: '${{ secrets.GCP_O1JS_CI_BUCKET_SERVICE_ACCOUNT_KEY }}'
+
+      - name: Prepare for tests
+        run: touch profiling.md
+
+      - name: Execute tests
+        env:
+          TEST_TYPE: ${{ matrix.test_type }}
+        run: sh run-ci-tests.sh
+
+      - name: Add to job summary
+        if: always()
+        run: |
+          echo "### Test Results for ${{ matrix.test_type }} (Node ${{ matrix.node }})" >> $GITHUB_STEP_SUMMARY
+          cat profiling.md >> $GITHUB_STEP_SUMMARY
+
+  Unit-Test-Compatibility:
+    name: Unit Test Compatibility (Node ${{ matrix.node }}, chunk ${{ matrix.chunk }})
+    timeout-minutes: 210
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        node: [20, 22, 24]
+        chunk: [1, 2, 3, 4, 5, 6, 7, 8]
+    steps:
+      - name: Checkout repository with submodules
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: Build
+        uses: ./.github/actions/build-wasm
+        with:
+          proof_systems_commit: ${{ github.event.inputs.proof_systems_commit || '' }}
+          node_version: ${{ matrix.node }}
+
+      - name: Count tests
+        id: count_tests
+        run: |
+          TEST_COUNT=$(find ./dist/node -name "*.unit-test.js" -not -name "*-napi.unit-test.js" | wc -l)
+          echo "test_count=${TEST_COUNT}" >> $GITHUB_OUTPUT
+          echo "Total test count (excluding napi): ${TEST_COUNT}"
+
+      - name: Run unit tests
+        env:
+          TOTAL_TESTS: ${{ steps.count_tests.outputs.test_count }}
+          CHUNK: ${{ matrix.chunk }}
+          CHUNKS: 8
+        shell: bash
+        run: |
+          echo "Total tests: $TOTAL_TESTS"
+          echo "Current chunk: $CHUNK"
+          echo "Total chunks: $CHUNKS"
+
+          if [ -z "$TOTAL_TESTS" ] || [ "$TOTAL_TESTS" -eq 0 ]; then
+            echo "Error: TOTAL_TESTS is not set or is zero. Exiting."
+            exit 1
+          fi
+
+          start_index=$(( (TOTAL_TESTS * (CHUNK - 1) / CHUNKS) ))
+          end_index=$(( (TOTAL_TESTS * CHUNK / CHUNKS) ))
+
+          echo "Running tests from index $start_index to $end_index"
+
+          shopt -s globstar
+          all_tests=(./dist/node/**/*.unit-test.js)
+          test_files=()
+          for test in "${all_tests[@]}"; do
+            if [[ ! "$test" =~ -napi\.unit-test\.js$ ]]; then
+              test_files+=("$test")
+            fi
+          done
+
+          set -o pipefail
+
+          for ((i=start_index; i<end_index && i<${#test_files[@]}; i++)); do
+              echo "Running test: ${test_files[$i]}"
+              node --enable-source-maps "${test_files[$i]}" | tee -a profiling.md
+          done
+
+      - name: Upload test results
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: nightly-test-results-node-${{ matrix.node }}-${{ matrix.chunk }}
+          path: profiling.md
+
+      - name: Add to job summary
+        if: always()
+        shell: bash
+        run: |
+          echo "### Test Results for Unit Tests Chunk ${{ matrix.chunk }} (Node ${{ matrix.node }})" >> $GITHUB_STEP_SUMMARY
+          cat profiling.md >> $GITHUB_STEP_SUMMARY
+
+  Web-Compatibility:
+    name: Web Compatibility (Node ${{ matrix.node }})
+    timeout-minutes: 90
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        node: [20, 22, 24]
+    steps:
+      - name: Checkout repository with submodules
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: Build
+        uses: ./.github/actions/build-wasm
+        with:
+          proof_systems_commit: ${{ github.event.inputs.proof_systems_commit || '' }}
+          node_version: ${{ matrix.node }}
+
+      - name: Cache Playwright browsers
+        uses: actions/cache@v4
+        id: playwright-cache
+        with:
+          path: ~/.cache/ms-playwright
+          key: ${{ runner.OS }}-playwright-${{ hashFiles('**/package-lock.json') }}
+
+      - name: Install Playwright browsers
+        if: steps.playwright-cache.outputs.cache-hit != 'true'
+        run: npm run e2e:install
+
+      - name: Build o1js and prepare the web server
+        run: |
+          npm run build:web
+          npm run e2e:prepare-server
+
+      - name: Execute E2E tests
+        run: npm run test:e2e
+
+      - name: Upload E2E test artifacts
+        uses: actions/upload-artifact@v4
+        continue-on-error: true
+        if: always()
+        with:
+          if-no-files-found: ignore
+          name: nightly-e2e-tests-report-node-${{ matrix.node }}
+          path: tests/report/
+          retention-days: 30

--- a/.github/workflows/pull_requests.yml
+++ b/.github/workflows/pull_requests.yml
@@ -64,7 +64,7 @@ jobs:
       - name: Setup Node.JS
         uses: actions/setup-node@v4
         with:
-          node-version: 22
+          node-version: 20
 
       - name: Install Dependencies
         run: npm ci

--- a/run-ci-tests.sh
+++ b/run-ci-tests.sh
@@ -46,6 +46,7 @@ case $TEST_TYPE in
   
 "CommonJS test")
   echo "Testing CommonJS version"
+  node tests/commonjs-worker-regression.cjs
   node src/examples/commonjs.cjs
   ;;
 

--- a/tests/commonjs-worker-regression.cjs
+++ b/tests/commonjs-worker-regression.cjs
@@ -1,0 +1,36 @@
+/**
+ * Regression test for the packaged CommonJS worker entrypoint.
+ *
+ * The package's CommonJS export resolves to dist/node/index.cjs. Compiling a
+ * ZkProgram exercises the Node wasm threadpool and verifies that the worker
+ * source starts the backend rather than exiting before rayon is initialized.
+ */
+const { Cache, Field, ZkProgram } = require('o1js');
+
+const resolvedO1js = require.resolve('o1js').replace(/\\/g, '/');
+if (!resolvedO1js.endsWith('/dist/node/index.cjs')) {
+  throw new Error(`Expected CommonJS package entrypoint, got ${resolvedO1js}`);
+}
+
+const CommonJsWorkerRegression = ZkProgram({
+  name: 'commonjs-worker-regression',
+  publicOutput: Field,
+  methods: {
+    baseCase: {
+      privateInputs: [],
+      async method() {
+        return { publicOutput: Field(1) };
+      },
+    },
+  },
+});
+
+main().catch((error) => {
+  console.error(error);
+  process.exit(1);
+});
+
+async function main() {
+  await CommonJsWorkerRegression.compile({ cache: Cache.None, forceRecompile: true });
+  console.log('CommonJS worker regression passed.');
+}

--- a/tests/perf-regression/perf-regression-wasm.json
+++ b/tests/perf-regression/perf-regression-wasm.json
@@ -1,226 +1,226 @@
 {
   "sha256": {
-    "compileTime": 34.211146682999996,
+    "compileTime": 34.253407877,
     "methods": {
       "sha256": {
         "rows": 5036,
         "digest": "c3952f2bd0dbb6b16ed43add7c57c9c5",
-        "proveTime": 20.257220909999997,
-        "verifyTime": 1.8148095600000016
+        "proveTime": 20.767094446999995,
+        "verifyTime": 1.7003484699999971
       }
     }
   },
   "ecdsa": {
-    "compileTime": 153.397639582,
+    "compileTime": 156.816319717,
     "methods": {
       "verifyEcdsa": {
         "rows": 46221,
         "digest": "d0f4f1d987923683410ebeeee0e3cca1",
-        "proveTime": 60.95979367700001,
-        "verifyTime": 1.8624347070000076
+        "proveTime": 63.141063471,
+        "verifyTime": 1.7192522430000245
       }
     }
   },
   "ecdsa-ethers": {
-    "compileTime": 39.120675961,
+    "compileTime": 41.424727762000025,
     "methods": {
       "verifyEthers": {
         "rows": 46248,
         "digest": "2278723f3c48ee7041964ebfc58f9f0f",
-        "proveTime": 59.80421521099994,
-        "verifyTime": 1.949640282999957
+        "proveTime": 62.17287855000002,
+        "verifyTime": 1.7885750049999916
       }
     }
   },
   "blake2b": {
-    "compileTime": 29.806121277,
+    "compileTime": 30.687363915000002,
     "methods": {
       "blake2b": {
         "rows": 3937,
         "digest": "9a34a081e72a974dc8d663e338ba3a58",
-        "proveTime": 20.959544298,
-        "verifyTime": 1.788057316999999
+        "proveTime": 21.492970062,
+        "verifyTime": 1.6991122990000003
       }
     }
   },
   "rsa-verify": {
-    "compileTime": 44.76653764700001,
+    "compileTime": 46.697651792,
     "methods": {
       "verifyRsa65537": {
         "rows": 12401,
         "digest": "5070b93b8bf964733b6f5a696f42ded7",
-        "proveTime": 25.302830891000006,
-        "verifyTime": 1.844899077000009
+        "proveTime": 26.069927907999997,
+        "verifyTime": 1.6756066370000045
       }
     }
   },
   "add": {
-    "compileTime": 121.430121467,
+    "compileTime": 122.923579822,
     "methods": {
       "performAddition": {
         "rows": 2,
         "digest": "6ffe440928a31a555799dcf7005bae82",
-        "proveTime": 30.740081185999994,
-        "verifyTime": 1.8376519520000147
+        "proveTime": 31.537944285999984,
+        "verifyTime": 1.6640973319999757
       }
     }
   },
   "multiply": {
-    "compileTime": 13.969990479999993,
+    "compileTime": 14.192981432000016,
     "methods": {
       "performMultiplication": {
         "rows": 1,
         "digest": "2a840c03f4e37242a8056a4aa536358c",
-        "proveTime": 28.83372576500001,
-        "verifyTime": 2.112310
+        "proveTime": 30.027106950999993,
+        "verifyTime": 1.6793636359999946
       }
     }
   },
   "hash-chain": {
-    "compileTime": 39.580088925,
+    "compileTime": 40.95907037199999,
     "methods": {
       "chain": {
         "rows": 513,
         "digest": "f1e9d1df2bd3da8fdc22a8b5d65ba7bd",
-        "proveTime": 117.87260368599999,
-        "verifyTime": 2.002624982999987
+        "proveTime": 121.04326211700001,
+        "verifyTime": 1.724345763999998
       }
     }
   },
   "bitwise": {
-    "compileTime": 30.056889648000002,
+    "compileTime": 30.66589253,
     "methods": {
       "rot": {
         "rows": 6,
         "digest": "335c4b0ef55af40110fd4f76709e629e",
-        "proveTime": 20.455568205999995,
-        "verifyTime": 1.8412553280000066
+        "proveTime": 20.456444796999996,
+        "verifyTime": 1.7106732279999997
       },
       "xor": {
         "rows": 3,
         "digest": "bf4c612a866451453ba30641230a99d0",
-        "proveTime": 13.647244727000004,
-        "verifyTime": 1.814390443000011
+        "proveTime": 13.797352399000003,
+        "verifyTime": 1.6573909300000087
       },
       "and": {
         "rows": 4,
         "digest": "f1f4f53ae5d5201eb5ef683c1c9e8167",
-        "proveTime": 13.709698655999993,
-        "verifyTime": 1.8071147000000056
+        "proveTime": 13.697736354000007,
+        "verifyTime": 1.6958301460000076
       }
     }
   },
   "childProgram": {
-    "compileTime": 29.582112802,
+    "compileTime": 30.065016642000003,
     "methods": {
       "compute": {
         "rows": 0,
         "digest": "4f5ddea76d29cfcfd8c595f14e31f21b",
-        "proveTime": 13.416166098999994
+        "proveTime": 13.551987775000017
       },
       "assertAndAdd": {
         "rows": 23,
         "digest": "db2a1a1a0b330ba3a2c34a843829edc2",
-        "proveTime": 19.229850519
+        "proveTime": 19.55552143299999
       }
     }
   },
   "mainProgram": {
-    "compileTime": 82.632056088,
+    "compileTime": 84.050462872,
     "methods": {
       "addSideloadedProgram": {
         "rows": 1796,
         "digest": "df4deb332ff01cbf2e7f39f203d9b717",
-        "proveTime": 23.380605911000007
+        "proveTime": 23.684543850000015
       },
       "validateUsingTree": {
         "rows": 914,
         "digest": "bebd1ddc30c2f7e0784b92508492ecbd",
-        "proveTime": 41.88216156400001,
-        "verifyTime": 1.846096534000011
+        "proveTime": 42.35577157800002,
+        "verifyTime": 1.7165110869999918
       }
     }
   },
   "payroll-runtime-table": {
-    "compileTime": 28.617954108,
+    "compileTime": 28.919570639999996,
     "methods": {
       "verifyPayroll": {
         "rows": 202,
         "digest": "677070f76ca9120c9c6129f2f635ac3b",
-        "proveTime": 20.511479069,
-        "verifyTime": 1.8338156819999931
+        "proveTime": 20.970533158999995,
+        "verifyTime": 1.730733116000003
       }
     }
   },
   "small-program": {
-    "compileTime": 15.987386629000001,
+    "compileTime": 16.569615595999995,
     "methods": {
       "poseidonHash": {
         "rows": 13,
         "digest": "ae6e7db1ed4da63e913e6990b385c439",
-        "proveTime": 13.957040643000015
+        "proveTime": 14.197964360999991
       }
     }
   },
   "big-program": {
-    "compileTime": 174.895731627,
+    "compileTime": 182.64007395299998,
     "methods": {
       "combinedHash": {
         "rows": 53069,
         "digest": "91dc95688cf71dea0f2eabf74c4c1de5",
-        "proveTime": 65.502750422,
-        "verifyTime": 1.8482163310000324
+        "proveTime": 67.67871900900002,
+        "verifyTime": 1.7014751749999706
       }
     }
   },
   "Voting_": {
     "digest": "2d12b9235eac7fe8188447969463455160abb01ddd682efdd4147fe28fc8c608",
-    "compileTime": 38.209853993,
+    "compileTime": 38.801446874,
     "methods": {}
   },
   "Membership_": {
     "digest": "2dcddd890f32e12d56469f8e1cf25706d9b7c83f12342ade821aff42f18f53e9",
-    "compileTime": 11.693168089999999,
+    "compileTime": 11.936199853999998,
     "methods": {}
   },
   "HelloWorld": {
     "digest": "309ebdd97930d6c753207d62c84147fe540f62d1623a1251f1d0b4f5f8bd400d",
-    "compileTime": 6.7330193199999995,
+    "compileTime": 6.681887169000001,
     "methods": {}
   },
   "TokenContract": {
     "digest": "37ad5c458b0b9f5a44650d16fe16200b3fafff89af0c3b4d0ad57eda5df05d54",
-    "compileTime": 10.845228322999995,
+    "compileTime": 10.691305764999997,
     "methods": {}
   },
   "Dex": {
     "digest": "fee88991bcc3331978a787642273ee02cbfc738949c6daad38c3bab65a8e81e",
-    "compileTime": 21.480353653000012,
+    "compileTime": 21.428461564,
     "methods": {}
   },
   "Group Primitive": {
     "digest": "Group Primitive",
-    "compileTime": 0.000047248999995645134,
+    "compileTime": 0.00005066399999486748,
     "methods": {}
   },
   "Bitwise Primitive": {
     "digest": "Bitwise Primitive",
-    "compileTime": 0.000008735999988857657,
+    "compileTime": 0.000009577999997418374,
     "methods": {}
   },
   "Hashes": {
     "digest": "Hashes",
-    "compileTime": 0.000006141000005300156,
+    "compileTime": 0.000005970999991404824,
     "methods": {}
   },
   "Basic": {
     "digest": "Basic",
-    "compileTime": 0.000012105000000796282,
+    "compileTime": 0.000012803999998141081,
     "methods": {}
   },
   "Crypto": {
     "digest": "Crypto",
-    "compileTime": 0.000010472000008216128,
+    "compileTime": 0.000007754999998724088,
     "methods": {}
   }
 }


### PR DESCRIPTION
- adds a simple commonjs test
- dumps performance regression tests (minimal changes, most likely due to flakiness)
- adds a nightly CI job that runs our tests with node 20, 22 and 24