### PR TITLE
RM Internal tags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,11 @@ This project adheres to
 - Enabled chunking through Native prover enabling x4 larger circuits on Node.js.
   https://github.com/o1-labs/o1js/pull/2843
 
+### Changed
+
+- Removed `@internal` JSDoc tags from public APIs so they appear in generated
+  documentation. https://github.com/o1-labs/o1js/pull/2881
+
 ### Removed
 
 - Removed unused `Cairo*` gates. https://github.com/o1-labs/o1js/pull/2752

--- a/src/lib/mina/v1/account-update.ts
+++ b/src/lib/mina/v1/account-update.ts
@@ -1,87 +1,87 @@
-import { cloneCircuitValue, FlexibleProvable, StructNoJson } from '../../provable/types/struct.js';
-import { provable, provableExtends, provablePure } from '../../provable/types/provable-derivers.js';
-import { memoizationContext, memoizeWitness, Provable } from '../../provable/provable.js';
-import { Field, Bool } from '../../provable/wrapped.js';
 import { Pickles } from '../../../bindings.js';
+import { mocks, prefixes, protocolVersions } from '../../../bindings/crypto/constants.js';
+import { From } from '../../../bindings/lib/provable-generic.js';
 import { jsLayout } from '../../../bindings/mina-transaction/gen/v1/js-layout.js';
-import { Types, toJSONEssential } from '../../../bindings/mina-transaction/v1/types.js';
-import { PrivateKey, PublicKey } from '../../provable/crypto/signature.js';
-import { UInt64, UInt32, Int64 } from '../../provable/int.js';
-import type { SmartContract } from './zkapp.js';
 import {
-  Preconditions,
-  Account,
-  Network,
-  CurrentSlot,
-  preconditions,
-  OrIgnore,
-  ClosedInterval,
-  getAccountPreconditions,
-} from './precondition.js';
-import { dummyBase64Proof, Empty, Prover } from '../../proof-system/zkprogram.js';
-import { Proof } from '../../proof-system/proof.js';
-import { Memo } from '../../../mina-signer/src/memo.js';
-import {
-  Events as BaseEvents,
   Actions as BaseActions,
+  Events as BaseEvents,
   MayUseToken as BaseMayUseToken,
 } from '../../../bindings/mina-transaction/v1/transaction-leaves.js';
-import { TokenId as Base58TokenId } from './base58-encodings.js';
-import { hashWithPrefix, packToFields, Poseidon } from '../../provable/crypto/poseidon.js';
-import { mocks, prefixes, protocolVersions } from '../../../bindings/crypto/constants.js';
+import { Types, toJSONEssential } from '../../../bindings/mina-transaction/v1/types.js';
+import { Memo } from '../../../mina-signer/src/memo.js';
+import {
+  CallForest,
+  accountUpdatesToCallForest,
+  callForestHashGeneric,
+  transactionCommitments,
+} from '../../../mina-signer/src/sign-zkapp-command.js';
 import {
   Signature,
   signFieldElement,
   zkAppBodyPrefix,
 } from '../../../mina-signer/src/signature.js';
 import { MlFieldConstArray } from '../../ml/fields.js';
-import {
-  accountUpdatesToCallForest,
-  CallForest,
-  callForestHashGeneric,
-  transactionCommitments,
-} from '../../../mina-signer/src/sign-zkapp-command.js';
-import { currentTransaction } from './transaction-context.js';
-import { isSmartContract } from './smart-contract-base.js';
-import { activeInstance } from './mina-instance.js';
-import { emptyHash, genericHash, MerkleList, MerkleListBase } from '../../provable/merkle-list.js';
+import { Proof } from '../../proof-system/proof.js';
+import { Empty, Prover, dummyBase64Proof } from '../../proof-system/zkprogram.js';
+import { Poseidon, hashWithPrefix, packToFields } from '../../provable/crypto/poseidon.js';
+import { PrivateKey, PublicKey } from '../../provable/crypto/signature.js';
+import { Int64, UInt32, UInt64 } from '../../provable/int.js';
+import { MerkleList, MerkleListBase, emptyHash, genericHash } from '../../provable/merkle-list.js';
 import { Hashed } from '../../provable/packed.js';
-import { accountUpdateLayout, smartContractContext } from './smart-contract-context.js';
-import { assert } from '../../util/assert.js';
+import { Provable, memoizationContext, memoizeWitness } from '../../provable/provable.js';
 import { RandomId } from '../../provable/types/auxiliary.js';
-import { From } from '../../../bindings/lib/provable-generic.js';
+import { provable, provableExtends, provablePure } from '../../provable/types/provable-derivers.js';
+import { FlexibleProvable, StructNoJson, cloneCircuitValue } from '../../provable/types/struct.js';
+import { Bool, Field } from '../../provable/wrapped.js';
+import { assert } from '../../util/assert.js';
+import { TokenId as Base58TokenId } from './base58-encodings.js';
+import { activeInstance } from './mina-instance.js';
+import {
+  Account,
+  ClosedInterval,
+  CurrentSlot,
+  Network,
+  OrIgnore,
+  Preconditions,
+  getAccountPreconditions,
+  preconditions,
+} from './precondition.js';
+import { isSmartContract } from './smart-contract-base.js';
+import { accountUpdateLayout, smartContractContext } from './smart-contract-context.js';
+import { currentTransaction } from './transaction-context.js';
+import type { SmartContract } from './zkapp.js';
 
 // external API
 export {
   AccountUpdate,
-  Permissions,
-  ZkappPublicInput,
-  TransactionVersion,
   AccountUpdateForest,
   AccountUpdateTree,
+  Permissions,
+  TransactionVersion,
+  ZkappPublicInput,
 };
 // internal API
 export {
-  SetOrKeep,
+  AccountUpdateLayout,
+  AccountUpdateTreeBase,
+  Actions,
+  Authorization,
+  Body,
+  CallForest,
+  Events,
+  FeePayerUnsigned,
+  HashedAccountUpdate,
+  LazyProof,
   Permission,
   Preconditions,
-  Body,
-  Authorization,
-  FeePayerUnsigned,
-  ZkappCommand,
-  addMissingSignatures,
-  addMissingProofs,
-  Events,
-  Actions,
+  SetOrKeep,
   TokenId,
-  CallForest,
-  zkAppProver,
+  ZkappCommand,
+  addMissingProofs,
+  addMissingSignatures,
   dummySignature,
-  LazyProof,
-  AccountUpdateTreeBase,
-  AccountUpdateLayout,
   hashAccountUpdate,
-  HashedAccountUpdate,
+  zkAppProver,
 };
 
 const TransactionVersion = {
@@ -169,7 +169,10 @@ const False = () => Bool(false);
 type Permission = Types.AuthRequired;
 
 class VerificationKeyPermission {
-  constructor(public auth: Permission, public txnVersion: UInt32) {}
+  constructor(
+    public auth: Permission,
+    public txnVersion: UInt32
+  ) {}
 
   // TODO this class could be made incompatible with a plain object (breaking change)
   // private _ = undefined;
@@ -490,8 +493,6 @@ interface Body extends AccountUpdateBody {
   publicKey: PublicKey;
 
   /**
-   * @internal
-   *
    * Specify {@link Update}s to tweakable pieces of the account record backing
    * this address in the ledger.
    */
@@ -517,8 +518,6 @@ interface Body extends AccountUpdateBody {
    */
   events: Events;
   /**
-   * @internal
-   *
    * Recent {@link Action}s emitted from this account.
    * Actions can be collected by archive nodes and used in combination with
    * a {@link Reducer}.

--- a/src/lib/mina/v1/account-update.ts
+++ b/src/lib/mina/v1/account-update.ts
@@ -1,87 +1,87 @@
+import { cloneCircuitValue, FlexibleProvable, StructNoJson } from '../../provable/types/struct.js';
+import { provable, provableExtends, provablePure } from '../../provable/types/provable-derivers.js';
+import { memoizationContext, memoizeWitness, Provable } from '../../provable/provable.js';
+import { Field, Bool } from '../../provable/wrapped.js';
 import { Pickles } from '../../../bindings.js';
-import { mocks, prefixes, protocolVersions } from '../../../bindings/crypto/constants.js';
-import { From } from '../../../bindings/lib/provable-generic.js';
 import { jsLayout } from '../../../bindings/mina-transaction/gen/v1/js-layout.js';
-import {
-  Actions as BaseActions,
-  Events as BaseEvents,
-  MayUseToken as BaseMayUseToken,
-} from '../../../bindings/mina-transaction/v1/transaction-leaves.js';
 import { Types, toJSONEssential } from '../../../bindings/mina-transaction/v1/types.js';
+import { PrivateKey, PublicKey } from '../../provable/crypto/signature.js';
+import { UInt64, UInt32, Int64 } from '../../provable/int.js';
+import type { SmartContract } from './zkapp.js';
+import {
+  Preconditions,
+  Account,
+  Network,
+  CurrentSlot,
+  preconditions,
+  OrIgnore,
+  ClosedInterval,
+  getAccountPreconditions,
+} from './precondition.js';
+import { dummyBase64Proof, Empty, Prover } from '../../proof-system/zkprogram.js';
+import { Proof } from '../../proof-system/proof.js';
 import { Memo } from '../../../mina-signer/src/memo.js';
 import {
-  CallForest,
-  accountUpdatesToCallForest,
-  callForestHashGeneric,
-  transactionCommitments,
-} from '../../../mina-signer/src/sign-zkapp-command.js';
+  Events as BaseEvents,
+  Actions as BaseActions,
+  MayUseToken as BaseMayUseToken,
+} from '../../../bindings/mina-transaction/v1/transaction-leaves.js';
+import { TokenId as Base58TokenId } from './base58-encodings.js';
+import { hashWithPrefix, packToFields, Poseidon } from '../../provable/crypto/poseidon.js';
+import { mocks, prefixes, protocolVersions } from '../../../bindings/crypto/constants.js';
 import {
   Signature,
   signFieldElement,
   zkAppBodyPrefix,
 } from '../../../mina-signer/src/signature.js';
 import { MlFieldConstArray } from '../../ml/fields.js';
-import { Proof } from '../../proof-system/proof.js';
-import { Empty, Prover, dummyBase64Proof } from '../../proof-system/zkprogram.js';
-import { Poseidon, hashWithPrefix, packToFields } from '../../provable/crypto/poseidon.js';
-import { PrivateKey, PublicKey } from '../../provable/crypto/signature.js';
-import { Int64, UInt32, UInt64 } from '../../provable/int.js';
-import { MerkleList, MerkleListBase, emptyHash, genericHash } from '../../provable/merkle-list.js';
-import { Hashed } from '../../provable/packed.js';
-import { Provable, memoizationContext, memoizeWitness } from '../../provable/provable.js';
-import { RandomId } from '../../provable/types/auxiliary.js';
-import { provable, provableExtends, provablePure } from '../../provable/types/provable-derivers.js';
-import { FlexibleProvable, StructNoJson, cloneCircuitValue } from '../../provable/types/struct.js';
-import { Bool, Field } from '../../provable/wrapped.js';
-import { assert } from '../../util/assert.js';
-import { TokenId as Base58TokenId } from './base58-encodings.js';
-import { activeInstance } from './mina-instance.js';
 import {
-  Account,
-  ClosedInterval,
-  CurrentSlot,
-  Network,
-  OrIgnore,
-  Preconditions,
-  getAccountPreconditions,
-  preconditions,
-} from './precondition.js';
-import { isSmartContract } from './smart-contract-base.js';
-import { accountUpdateLayout, smartContractContext } from './smart-contract-context.js';
+  accountUpdatesToCallForest,
+  CallForest,
+  callForestHashGeneric,
+  transactionCommitments,
+} from '../../../mina-signer/src/sign-zkapp-command.js';
 import { currentTransaction } from './transaction-context.js';
-import type { SmartContract } from './zkapp.js';
+import { isSmartContract } from './smart-contract-base.js';
+import { activeInstance } from './mina-instance.js';
+import { emptyHash, genericHash, MerkleList, MerkleListBase } from '../../provable/merkle-list.js';
+import { Hashed } from '../../provable/packed.js';
+import { accountUpdateLayout, smartContractContext } from './smart-contract-context.js';
+import { assert } from '../../util/assert.js';
+import { RandomId } from '../../provable/types/auxiliary.js';
+import { From } from '../../../bindings/lib/provable-generic.js';
 
 // external API
 export {
   AccountUpdate,
+  Permissions,
+  ZkappPublicInput,
+  TransactionVersion,
   AccountUpdateForest,
   AccountUpdateTree,
-  Permissions,
-  TransactionVersion,
-  ZkappPublicInput,
 };
 // internal API
 export {
-  AccountUpdateLayout,
-  AccountUpdateTreeBase,
-  Actions,
-  Authorization,
-  Body,
-  CallForest,
-  Events,
-  FeePayerUnsigned,
-  HashedAccountUpdate,
-  LazyProof,
+  SetOrKeep,
   Permission,
   Preconditions,
-  SetOrKeep,
-  TokenId,
+  Body,
+  Authorization,
+  FeePayerUnsigned,
   ZkappCommand,
-  addMissingProofs,
   addMissingSignatures,
-  dummySignature,
-  hashAccountUpdate,
+  addMissingProofs,
+  Events,
+  Actions,
+  TokenId,
+  CallForest,
   zkAppProver,
+  dummySignature,
+  LazyProof,
+  AccountUpdateTreeBase,
+  AccountUpdateLayout,
+  hashAccountUpdate,
+  HashedAccountUpdate,
 };
 
 const TransactionVersion = {
@@ -169,10 +169,7 @@ const False = () => Bool(false);
 type Permission = Types.AuthRequired;
 
 class VerificationKeyPermission {
-  constructor(
-    public auth: Permission,
-    public txnVersion: UInt32
-  ) {}
+  constructor(public auth: Permission, public txnVersion: UInt32) {}
 
   // TODO this class could be made incompatible with a plain object (breaking change)
   // private _ = undefined;
@@ -493,6 +490,7 @@ interface Body extends AccountUpdateBody {
   publicKey: PublicKey;
 
   /**
+   *
    * Specify {@link Update}s to tweakable pieces of the account record backing
    * this address in the ledger.
    */
@@ -518,6 +516,7 @@ interface Body extends AccountUpdateBody {
    */
   events: Events;
   /**
+   *
    * Recent {@link Action}s emitted from this account.
    * Actions can be collected by archive nodes and used in combination with
    * a {@link Reducer}.

--- a/src/lib/provable/crypto/foreign-curve.ts
+++ b/src/lib/provable/crypto/foreign-curve.ts
@@ -1,23 +1,23 @@
 import {
-  CurveParams,
   CurveAffine,
+  CurveParams,
   createCurveAffine,
 } from '../../../bindings/crypto/elliptic-curve.js';
-import { ProvablePureExtended } from '../types/struct.js';
+import { Bytes } from '../bytes.js';
 import { AlmostForeignField, createForeignField } from '../foreign-field.js';
+import { assert } from '../gadgets/common.js';
 import { EllipticCurve, Point } from '../gadgets/elliptic-curve.js';
 import { Field3 } from '../gadgets/foreign-field.js';
-import { assert } from '../gadgets/common.js';
+import { l2Mask, multiRangeCheck } from '../gadgets/range-check.js';
 import { Provable } from '../provable.js';
 import { provableFromClass } from '../types/provable-derivers.js';
-import { l2Mask, multiRangeCheck } from '../gadgets/range-check.js';
-import { Bytes } from '../bytes.js';
+import { ProvablePureExtended } from '../types/struct.js';
 
 // external API
-export { createForeignCurve, ForeignCurve };
+export { ForeignCurve, createForeignCurve };
 
 // internal API
-export { toPoint, FlexiblePoint, ForeignCurveNotNeeded };
+export { FlexiblePoint, ForeignCurveNotNeeded, toPoint };
 
 type FlexiblePoint = {
   x: AlmostForeignField | Field3 | bigint | number;
@@ -202,7 +202,6 @@ class ForeignCurve {
   }
 
   /**
-   * @internal
    * Checks whether this curve point is constant.
    *
    * See {@link FieldVar} to understand constants vs variables.

--- a/src/lib/provable/crypto/foreign-curve.ts
+++ b/src/lib/provable/crypto/foreign-curve.ts
@@ -1,23 +1,23 @@
 import {
-  CurveAffine,
   CurveParams,
+  CurveAffine,
   createCurveAffine,
 } from '../../../bindings/crypto/elliptic-curve.js';
-import { Bytes } from '../bytes.js';
+import { ProvablePureExtended } from '../types/struct.js';
 import { AlmostForeignField, createForeignField } from '../foreign-field.js';
-import { assert } from '../gadgets/common.js';
 import { EllipticCurve, Point } from '../gadgets/elliptic-curve.js';
 import { Field3 } from '../gadgets/foreign-field.js';
-import { l2Mask, multiRangeCheck } from '../gadgets/range-check.js';
+import { assert } from '../gadgets/common.js';
 import { Provable } from '../provable.js';
 import { provableFromClass } from '../types/provable-derivers.js';
-import { ProvablePureExtended } from '../types/struct.js';
+import { l2Mask, multiRangeCheck } from '../gadgets/range-check.js';
+import { Bytes } from '../bytes.js';
 
 // external API
-export { ForeignCurve, createForeignCurve };
+export { createForeignCurve, ForeignCurve };
 
 // internal API
-export { FlexiblePoint, ForeignCurveNotNeeded, toPoint };
+export { toPoint, FlexiblePoint, ForeignCurveNotNeeded };
 
 type FlexiblePoint = {
   x: AlmostForeignField | Field3 | bigint | number;

--- a/src/lib/provable/foreign-field.ts
+++ b/src/lib/provable/foreign-field.ts
@@ -1,18 +1,18 @@
-import { FiniteField, Fp, createField, mod } from '../../bindings/crypto/finite-field.js';
-import { Tuple, TupleMap, TupleN } from '../util/types.js';
+import { mod, Fp, FiniteField, createField } from '../../bindings/crypto/finite-field.js';
+import { checkBitLength, Field, withMessage } from './field.js';
+import { Provable } from './provable.js';
 import { Bool } from './bool.js';
-import { Field, checkBitLength, withMessage } from './field.js';
+import { Tuple, TupleMap, TupleN } from '../util/types.js';
+import { Gadgets } from './gadgets/gadgets.js';
+import { ForeignField as FF, Field3 } from './gadgets/foreign-field.js';
 import { assert } from './gadgets/common.js';
 import { fieldToField3 } from './gadgets/comparison.js';
-import { ForeignField as FF, Field3 } from './gadgets/foreign-field.js';
-import { Gadgets } from './gadgets/gadgets.js';
-import { l, l3 } from './gadgets/range-check.js';
-import { Provable } from './provable.js';
+import { l3, l } from './gadgets/range-check.js';
 import { ProvablePureExtended } from './types/struct.js';
 
 // external API
 export { createForeignField };
-export type { AlmostForeignField, CanonicalForeignField, ForeignField, UnreducedForeignField };
+export type { ForeignField, UnreducedForeignField, AlmostForeignField, CanonicalForeignField };
 
 class ForeignField {
   static _Bigint: FiniteField | undefined = undefined;
@@ -720,7 +720,7 @@ type Constructor<T> = new (...args: any[]) => T;
 function provable<
   F extends ForeignField & {
     type: 'Unreduced' | 'AlmostReduced' | 'FullyReduced';
-  },
+  }
 >(
   Class: Constructor<F> & { check(x: ForeignField): void }
 ): ProvablePureExtended<F, bigint, string> {

--- a/src/lib/provable/foreign-field.ts
+++ b/src/lib/provable/foreign-field.ts
@@ -1,18 +1,18 @@
-import { mod, Fp, FiniteField, createField } from '../../bindings/crypto/finite-field.js';
-import { checkBitLength, Field, withMessage } from './field.js';
-import { Provable } from './provable.js';
-import { Bool } from './bool.js';
+import { FiniteField, Fp, createField, mod } from '../../bindings/crypto/finite-field.js';
 import { Tuple, TupleMap, TupleN } from '../util/types.js';
-import { Gadgets } from './gadgets/gadgets.js';
-import { ForeignField as FF, Field3 } from './gadgets/foreign-field.js';
+import { Bool } from './bool.js';
+import { Field, checkBitLength, withMessage } from './field.js';
 import { assert } from './gadgets/common.js';
 import { fieldToField3 } from './gadgets/comparison.js';
-import { l3, l } from './gadgets/range-check.js';
+import { ForeignField as FF, Field3 } from './gadgets/foreign-field.js';
+import { Gadgets } from './gadgets/gadgets.js';
+import { l, l3 } from './gadgets/range-check.js';
+import { Provable } from './provable.js';
 import { ProvablePureExtended } from './types/struct.js';
 
 // external API
 export { createForeignField };
-export type { ForeignField, UnreducedForeignField, AlmostForeignField, CanonicalForeignField };
+export type { AlmostForeignField, CanonicalForeignField, ForeignField, UnreducedForeignField };
 
 class ForeignField {
   static _Bigint: FiniteField | undefined = undefined;
@@ -152,7 +152,6 @@ class ForeignField {
   }
 
   /**
-   * @internal
    * Checks whether this field element is a constant.
    *
    * See {@link FieldVar} to understand constants vs variables.
@@ -162,7 +161,6 @@ class ForeignField {
   }
 
   /**
-   * @internal
    * Convert this field element to a constant.
    *
    * See {@link FieldVar} to understand constants vs variables.
@@ -722,7 +720,7 @@ type Constructor<T> = new (...args: any[]) => T;
 function provable<
   F extends ForeignField & {
     type: 'Unreduced' | 'AlmostReduced' | 'FullyReduced';
-  }
+  },
 >(
   Class: Constructor<F> & { check(x: ForeignField): void }
 ): ProvablePureExtended<F, bigint, string> {

--- a/src/lib/provable/gadgets/common.ts
+++ b/src/lib/provable/gadgets/common.ts
@@ -1,12 +1,12 @@
+import type { Field, VarField } from '../field.js';
+import { FieldVar, VarFieldVar } from '../core/fieldvar.js';
 import { Tuple } from '../../util/types.js';
 import type { Bool } from '../bool.js';
+import { fieldVar } from '../gates.js';
 import { existsOne } from '../core/exists.js';
 import { createField, isBool } from '../core/field-constructor.js';
-import { FieldVar, VarFieldVar } from '../core/fieldvar.js';
-import type { Field, VarField } from '../field.js';
-import { fieldVar } from '../gates.js';
 
-export { assert, bit, bitSlice, divideWithRemainder, isConstant, isVar, packBits, toVar, toVars };
+export { toVars, toVar, isVar, assert, bitSlice, bit, divideWithRemainder, packBits, isConstant };
 
 /**
  * Given a Field, collapse its AST to a pure Var. See {@link FieldVar}.

--- a/src/lib/provable/gadgets/common.ts
+++ b/src/lib/provable/gadgets/common.ts
@@ -1,15 +1,14 @@
-import type { Field, VarField } from '../field.js';
-import { FieldVar, VarFieldVar } from '../core/fieldvar.js';
 import { Tuple } from '../../util/types.js';
 import type { Bool } from '../bool.js';
-import { fieldVar } from '../gates.js';
 import { existsOne } from '../core/exists.js';
 import { createField, isBool } from '../core/field-constructor.js';
+import { FieldVar, VarFieldVar } from '../core/fieldvar.js';
+import type { Field, VarField } from '../field.js';
+import { fieldVar } from '../gates.js';
 
-export { toVars, toVar, isVar, assert, bitSlice, bit, divideWithRemainder, packBits, isConstant };
+export { assert, bit, bitSlice, divideWithRemainder, isConstant, isVar, packBits, toVar, toVars };
 
 /**
- * @internal
  * Given a Field, collapse its AST to a pure Var. See {@link FieldVar}.
  *
  * This is useful to prevent rogue Generic gates added in the middle of gate chains,

--- a/src/lib/provable/gadgets/foreign-field.ts
+++ b/src/lib/provable/gadgets/foreign-field.ts
@@ -1,34 +1,34 @@
 /**
  * Foreign field arithmetic gadgets.
  */
-import { inverse as modInverse, mod } from '../../../bindings/crypto/finite-field.js';
-import { provableTuple } from '../types/provable-derivers.js';
-import { Unconstrained } from '../types/unconstrained.js';
+import { mod, inverse as modInverse } from '../../../bindings/crypto/finite-field.js';
+import { Tuple, TupleN } from '../../util/types.js';
+import type { Bool } from '../bool.js';
+import { exists } from '../core/exists.js';
+import { createBool, createField, getField } from '../core/field-constructor.js';
 import type { Field } from '../field.js';
 import { Gates, foreignFieldAdd } from '../gates.js';
-import { exists } from '../core/exists.js';
 import { modifiedField } from '../types/fields.js';
-import { Tuple, TupleN } from '../../util/types.js';
+import { provableTuple } from '../types/provable-derivers.js';
+import { ProvablePureExtended } from '../types/struct.js';
+import { Unconstrained } from '../types/unconstrained.js';
 import { assertOneOf } from './basic.js';
 import { assert, bitSlice, toVar, toVars } from './common.js';
 import {
+  compactMultiRangeCheck,
   l,
-  lMask,
-  multiRangeCheck,
   l2,
   l2Mask,
   l3,
-  compactMultiRangeCheck,
+  lMask,
+  multiRangeCheck,
 } from './range-check.js';
-import { createBool, createField, getField } from '../core/field-constructor.js';
-import type { Bool } from '../bool.js';
-import { ProvablePureExtended } from '../types/struct.js';
 
 // external API
-export { ForeignField, Field3 };
+export { Field3, ForeignField };
 
 // internal API
-export { bigint3, Sign, split, combine, weakBound, Sum, assertMul, field3FromBits };
+export { Sign, Sum, assertMul, bigint3, combine, field3FromBits, split, weakBound };
 
 /**
  * A 3-tuple of Fields, representing a 3-limb bigint.
@@ -569,8 +569,6 @@ function assertMul(
 }
 
 /**
- * @internal
- *
  * Lazy sum of {@link Field3} elements, which can be used as input to `Gadgets.ForeignField.assertMul()`.
  */
 class Sum {

--- a/src/lib/provable/gadgets/foreign-field.ts
+++ b/src/lib/provable/gadgets/foreign-field.ts
@@ -1,34 +1,34 @@
 /**
  * Foreign field arithmetic gadgets.
  */
-import { mod, inverse as modInverse } from '../../../bindings/crypto/finite-field.js';
-import { Tuple, TupleN } from '../../util/types.js';
-import type { Bool } from '../bool.js';
-import { exists } from '../core/exists.js';
-import { createBool, createField, getField } from '../core/field-constructor.js';
+import { inverse as modInverse, mod } from '../../../bindings/crypto/finite-field.js';
+import { provableTuple } from '../types/provable-derivers.js';
+import { Unconstrained } from '../types/unconstrained.js';
 import type { Field } from '../field.js';
 import { Gates, foreignFieldAdd } from '../gates.js';
+import { exists } from '../core/exists.js';
 import { modifiedField } from '../types/fields.js';
-import { provableTuple } from '../types/provable-derivers.js';
-import { ProvablePureExtended } from '../types/struct.js';
-import { Unconstrained } from '../types/unconstrained.js';
+import { Tuple, TupleN } from '../../util/types.js';
 import { assertOneOf } from './basic.js';
 import { assert, bitSlice, toVar, toVars } from './common.js';
 import {
-  compactMultiRangeCheck,
   l,
+  lMask,
+  multiRangeCheck,
   l2,
   l2Mask,
   l3,
-  lMask,
-  multiRangeCheck,
+  compactMultiRangeCheck,
 } from './range-check.js';
+import { createBool, createField, getField } from '../core/field-constructor.js';
+import type { Bool } from '../bool.js';
+import { ProvablePureExtended } from '../types/struct.js';
 
 // external API
-export { Field3, ForeignField };
+export { ForeignField, Field3 };
 
 // internal API
-export { Sign, Sum, assertMul, bigint3, combine, field3FromBits, split, weakBound };
+export { bigint3, Sign, split, combine, weakBound, Sum, assertMul, field3FromBits };
 
 /**
  * A 3-tuple of Fields, representing a 3-limb bigint.
@@ -569,6 +569,7 @@ function assertMul(
 }
 
 /**
+ *
  * Lazy sum of {@link Field3} elements, which can be used as input to `Gadgets.ForeignField.assertMul()`.
  */
 class Sum {

--- a/src/lib/provable/gadgets/gadgets.ts
+++ b/src/lib/provable/gadgets/gadgets.ts
@@ -1,43 +1,43 @@
 /**
  * Wrapper file for various gadgets, with a namespace and doccomments.
  */
-import { Field } from '../wrapped.js';
-import { addMod32, addMod64, divMod32, divMod64 } from './arithmetic.js';
-import { arrayGet, arrayGetGeneric } from './basic.js';
-import { sliceField3 } from './bit-slices.js';
-import {
-  and,
-  leftShift32,
-  leftShift64,
-  not,
-  or,
-  rightShift64,
-  rotate32,
-  rotate64,
-  xor,
-} from './bitwise.js';
-import { BLAKE2B } from './blake2b.js';
-import { Field3, ForeignField, Sum as ForeignFieldSum } from './foreign-field.js';
-import { inTable, rangeCheck3x12 } from './lookup.js';
 import {
   compactMultiRangeCheck,
-  isDefinitelyInRangeN,
-  l,
-  l2,
-  l2Mask,
-  l3,
-  lMask,
   multiRangeCheck,
+  rangeCheck8,
   rangeCheck16,
   rangeCheck32,
   rangeCheck64,
-  rangeCheck8,
   rangeCheckN,
+  isDefinitelyInRangeN,
+  l2Mask,
+  lMask,
+  l2,
+  l,
+  l3,
 } from './range-check.js';
+import {
+  not,
+  rotate32,
+  rotate64,
+  xor,
+  and,
+  or,
+  leftShift64,
+  rightShift64,
+  leftShift32,
+} from './bitwise.js';
+import { Field } from '../wrapped.js';
+import { ForeignField, Field3, Sum as ForeignFieldSum } from './foreign-field.js';
+import { divMod32, addMod32, divMod64, addMod64 } from './arithmetic.js';
 import { SHA2 } from './sha2.js';
 import { SHA256 } from './sha256.js';
+import { BLAKE2B } from './blake2b.js';
+import { rangeCheck3x12, inTable } from './lookup.js';
+import { arrayGet, arrayGetGeneric } from './basic.js';
+import { sliceField3 } from './bit-slices.js';
 
-export { Field3, ForeignFieldSum, Gadgets };
+export { Gadgets, Field3, ForeignFieldSum };
 
 const Gadgets = {
   /**
@@ -599,7 +599,7 @@ const Gadgets = {
    * @param pair1
    * @param pair2
    *
-   * @deprecated {@link inTable} is deprecated in favor of RuntimeTable class,
+   * @deprecated {@link inTable} is deprecated in favor of RuntimeTable class, 
    * which provides a more ergonomic API.
    */
   inTable(
@@ -730,6 +730,7 @@ const Gadgets = {
     },
 
     /**
+     *
      * Foreign field multiplication: `x * y mod f`
      *
      * The modulus `f` does not need to be prime, but has to be smaller than 2^259.
@@ -767,6 +768,7 @@ const Gadgets = {
     },
 
     /**
+     *
      * Foreign field inverse: `x^(-1) mod f`
      *
      * See {@link Gadgets.ForeignField.mul} for assumptions on inputs and usage examples.
@@ -778,6 +780,7 @@ const Gadgets = {
     },
 
     /**
+     *
      * Foreign field division: `x * y^(-1) mod f`
      *
      * See {@link Gadgets.ForeignField.mul} for assumptions on inputs and usage examples.
@@ -791,6 +794,7 @@ const Gadgets = {
     },
 
     /**
+     *
      * Optimized multiplication of sums in a foreign field, for example: `(x - y)*z = a + b + c mod f`
      *
      * Note: This is much more efficient than using {@link Gadgets.ForeignField.add} and {@link Gadgets.ForeignField.sub} separately to
@@ -835,6 +839,7 @@ const Gadgets = {
     },
 
     /**
+     *
      * Lazy sum of {@link Field3} elements, which can be used as input to {@link Gadgets.ForeignField.assertMul}.
      */
     Sum(x: Field3) {
@@ -842,6 +847,7 @@ const Gadgets = {
     },
 
     /**
+     *
      * Prove that each of the given {@link Field3} elements is "almost" reduced modulo f,
      * i.e., satisfies the assumptions required by {@link Gadgets.ForeignField.mul} and other gadgets:
      * - each limb is in the range [0, 2^88)

--- a/src/lib/provable/gadgets/gadgets.ts
+++ b/src/lib/provable/gadgets/gadgets.ts
@@ -1,43 +1,43 @@
 /**
  * Wrapper file for various gadgets, with a namespace and doccomments.
  */
+import { Field } from '../wrapped.js';
+import { addMod32, addMod64, divMod32, divMod64 } from './arithmetic.js';
+import { arrayGet, arrayGetGeneric } from './basic.js';
+import { sliceField3 } from './bit-slices.js';
 import {
-  compactMultiRangeCheck,
-  multiRangeCheck,
-  rangeCheck8,
-  rangeCheck16,
-  rangeCheck32,
-  rangeCheck64,
-  rangeCheckN,
-  isDefinitelyInRangeN,
-  l2Mask,
-  lMask,
-  l2,
-  l,
-  l3,
-} from './range-check.js';
-import {
+  and,
+  leftShift32,
+  leftShift64,
   not,
+  or,
+  rightShift64,
   rotate32,
   rotate64,
   xor,
-  and,
-  or,
-  leftShift64,
-  rightShift64,
-  leftShift32,
 } from './bitwise.js';
-import { Field } from '../wrapped.js';
-import { ForeignField, Field3, Sum as ForeignFieldSum } from './foreign-field.js';
-import { divMod32, addMod32, divMod64, addMod64 } from './arithmetic.js';
+import { BLAKE2B } from './blake2b.js';
+import { Field3, ForeignField, Sum as ForeignFieldSum } from './foreign-field.js';
+import { inTable, rangeCheck3x12 } from './lookup.js';
+import {
+  compactMultiRangeCheck,
+  isDefinitelyInRangeN,
+  l,
+  l2,
+  l2Mask,
+  l3,
+  lMask,
+  multiRangeCheck,
+  rangeCheck16,
+  rangeCheck32,
+  rangeCheck64,
+  rangeCheck8,
+  rangeCheckN,
+} from './range-check.js';
 import { SHA2 } from './sha2.js';
 import { SHA256 } from './sha256.js';
-import { BLAKE2B } from './blake2b.js';
-import { rangeCheck3x12, inTable } from './lookup.js';
-import { arrayGet, arrayGetGeneric } from './basic.js';
-import { sliceField3 } from './bit-slices.js';
 
-export { Gadgets, Field3, ForeignFieldSum };
+export { Field3, ForeignFieldSum, Gadgets };
 
 const Gadgets = {
   /**
@@ -599,7 +599,7 @@ const Gadgets = {
    * @param pair1
    * @param pair2
    *
-   * @deprecated {@link inTable} is deprecated in favor of RuntimeTable class, 
+   * @deprecated {@link inTable} is deprecated in favor of RuntimeTable class,
    * which provides a more ergonomic API.
    */
   inTable(
@@ -730,8 +730,6 @@ const Gadgets = {
     },
 
     /**
-     * @internal
-     *
      * Foreign field multiplication: `x * y mod f`
      *
      * The modulus `f` does not need to be prime, but has to be smaller than 2^259.
@@ -769,8 +767,6 @@ const Gadgets = {
     },
 
     /**
-     * @internal
-     *
      * Foreign field inverse: `x^(-1) mod f`
      *
      * See {@link Gadgets.ForeignField.mul} for assumptions on inputs and usage examples.
@@ -782,8 +778,6 @@ const Gadgets = {
     },
 
     /**
-     * @internal
-     *
      * Foreign field division: `x * y^(-1) mod f`
      *
      * See {@link Gadgets.ForeignField.mul} for assumptions on inputs and usage examples.
@@ -797,8 +791,6 @@ const Gadgets = {
     },
 
     /**
-     * @internal
-     *
      * Optimized multiplication of sums in a foreign field, for example: `(x - y)*z = a + b + c mod f`
      *
      * Note: This is much more efficient than using {@link Gadgets.ForeignField.add} and {@link Gadgets.ForeignField.sub} separately to
@@ -843,8 +835,6 @@ const Gadgets = {
     },
 
     /**
-     * @internal
-     *
      * Lazy sum of {@link Field3} elements, which can be used as input to {@link Gadgets.ForeignField.assertMul}.
      */
     Sum(x: Field3) {
@@ -852,8 +842,6 @@ const Gadgets = {
     },
 
     /**
-     * @internal
-     *
      * Prove that each of the given {@link Field3} elements is "almost" reduced modulo f,
      * i.e., satisfies the assumptions required by {@link Gadgets.ForeignField.mul} and other gadgets:
      * - each limb is in the range [0, 2^88)

--- a/src/lib/provable/provable.ts
+++ b/src/lib/provable/provable.ts
@@ -3,33 +3,33 @@
  * - a namespace with tools for writing provable code
  * - the main interface for types that can be used in provable code
  */
-import { InferValue } from '../../bindings/lib/provable-generic.js';
-import { ToProvable } from '../../lib/provable/types/provable-intf.js';
-import { Context } from '../util/global-context.js';
 import { Bool } from './bool.js';
-import {
-  asProver,
-  constraintSystem,
-  generateWitness,
-  inCheckedComputation,
-  inProver,
-} from './core/provable-context.js';
 import { Field } from './field.js';
+import { Provable as Provable_, ProvableType } from './types/provable-intf.js';
+import type { FlexibleProvable, FlexibleProvableType, ProvableExtended } from './types/struct.js';
+import { Context } from '../util/global-context.js';
 import {
   HashInput,
   InferJson,
   InferProvableType,
   InferredProvable,
 } from './types/provable-derivers.js';
-import { Provable as Provable_, ProvableType } from './types/provable-intf.js';
-import type { FlexibleProvable, FlexibleProvableType, ProvableExtended } from './types/struct.js';
+import {
+  inCheckedComputation,
+  inProver,
+  asProver,
+  constraintSystem,
+  generateWitness,
+} from './core/provable-context.js';
 import { witness, witnessAsync, witnessFields } from './types/witness.js';
+import { InferValue } from '../../bindings/lib/provable-generic.js';
+import { ToProvable } from '../../lib/provable/types/provable-intf.js';
 
 // external API
 export { Provable };
 
 // internal API
-export { getBlindingValue, memoizationContext, MemoizationContext, memoizeWitness };
+export { memoizationContext, MemoizationContext, memoizeWitness, getBlindingValue };
 
 /**
  * `Provable<T>` is the general interface for provable types in o1js.

--- a/src/lib/provable/provable.ts
+++ b/src/lib/provable/provable.ts
@@ -3,33 +3,33 @@
  * - a namespace with tools for writing provable code
  * - the main interface for types that can be used in provable code
  */
-import { Bool } from './bool.js';
-import { Field } from './field.js';
-import { Provable as Provable_, ProvableType } from './types/provable-intf.js';
-import type { FlexibleProvable, FlexibleProvableType, ProvableExtended } from './types/struct.js';
+import { InferValue } from '../../bindings/lib/provable-generic.js';
+import { ToProvable } from '../../lib/provable/types/provable-intf.js';
 import { Context } from '../util/global-context.js';
+import { Bool } from './bool.js';
+import {
+  asProver,
+  constraintSystem,
+  generateWitness,
+  inCheckedComputation,
+  inProver,
+} from './core/provable-context.js';
+import { Field } from './field.js';
 import {
   HashInput,
   InferJson,
   InferProvableType,
   InferredProvable,
 } from './types/provable-derivers.js';
-import {
-  inCheckedComputation,
-  inProver,
-  asProver,
-  constraintSystem,
-  generateWitness,
-} from './core/provable-context.js';
+import { Provable as Provable_, ProvableType } from './types/provable-intf.js';
+import type { FlexibleProvable, FlexibleProvableType, ProvableExtended } from './types/struct.js';
 import { witness, witnessAsync, witnessFields } from './types/witness.js';
-import { InferValue } from '../../bindings/lib/provable-generic.js';
-import { ToProvable } from '../../lib/provable/types/provable-intf.js';
 
 // external API
 export { Provable };
 
 // internal API
-export { memoizationContext, MemoizationContext, memoizeWitness, getBlindingValue };
+export { getBlindingValue, memoizationContext, MemoizationContext, memoizeWitness };
 
 /**
  * `Provable<T>` is the general interface for provable types in o1js.
@@ -200,7 +200,6 @@ const Provable = {
    */
   Array: provableArray,
   /**
-   * @internal
    * Check whether a value is constant.
    * See {@link FieldVar} for more information about constants and variables.
    *

--- a/src/lib/provable/scalar.ts
+++ b/src/lib/provable/scalar.ts
@@ -1,18 +1,18 @@
 import { Fq } from '../../bindings/crypto/finite-field.js';
 import { Scalar as SignableFq } from '../../mina-signer/src/curve-bigint.js';
-import { assert } from '../util/assert.js';
-import { Bool } from './bool.js';
 import { Field, checkBitLength } from './field.js';
-import { isConstant } from './gadgets/common.js';
-import { field3FromBits } from './gadgets/foreign-field.js';
+import { Bool } from './bool.js';
 import {
   ShiftedScalar,
   field3ToShiftedScalar,
   fieldToShiftedScalar,
   shiftedScalarToField3,
 } from './gadgets/native-curve.js';
+import { isConstant } from './gadgets/common.js';
 import { Provable } from './provable.js';
+import { assert } from '../util/assert.js';
 import type { HashInput } from './types/provable-derivers.js';
+import { field3FromBits } from './gadgets/foreign-field.js';
 
 export { Scalar, ScalarConst };
 

--- a/src/lib/provable/scalar.ts
+++ b/src/lib/provable/scalar.ts
@@ -1,18 +1,18 @@
 import { Fq } from '../../bindings/crypto/finite-field.js';
 import { Scalar as SignableFq } from '../../mina-signer/src/curve-bigint.js';
-import { Field, checkBitLength } from './field.js';
+import { assert } from '../util/assert.js';
 import { Bool } from './bool.js';
+import { Field, checkBitLength } from './field.js';
+import { isConstant } from './gadgets/common.js';
+import { field3FromBits } from './gadgets/foreign-field.js';
 import {
   ShiftedScalar,
   field3ToShiftedScalar,
   fieldToShiftedScalar,
   shiftedScalarToField3,
 } from './gadgets/native-curve.js';
-import { isConstant } from './gadgets/common.js';
 import { Provable } from './provable.js';
-import { assert } from '../util/assert.js';
 import type { HashInput } from './types/provable-derivers.js';
-import { field3FromBits } from './gadgets/foreign-field.js';
 
 export { Scalar, ScalarConst };
 
@@ -51,7 +51,6 @@ class Scalar implements ShiftedScalar {
   }
 
   /**
-   * @internal
    * Provable method to convert a {@link ShiftedScalar} to a {@link Scalar}.
    */
   static fromShiftedScalar(s: ShiftedScalar) {
@@ -78,7 +77,6 @@ class Scalar implements ShiftedScalar {
   }
 
   /**
-   * @internal
    * Convert this {@link Scalar} into a constant if it isn't already.
    *
    * If the scalar is a variable, this only works inside `asProver` or `witness` blocks.


### PR DESCRIPTION
I ran the docs generator with these changes, and no new warnings seemed to pop up.  `npm run build:docs` still has warnings in general, but these tags aren't preventing them