### PR TITLE
Standalone verification of chunked proofs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,11 +23,16 @@ This project adheres to
 - Mesa-compatible native prover access from Node.js
   https://github.com/o1-labs/o1js/pull/2823
 - Expose `Client.getZkappCommandCommitments` and
-  `Client.getZkappCommandCommitmentsFromJSON` on `mina-signer` for computing
-  the commitment and full commitment of a zkApp transaction.
+  `Client.getZkappCommandCommitmentsFromJSON` on `mina-signer` for computing the
+  commitment and full commitment of a zkApp transaction.
   https://github.com/o1-labs/o1js/pull/2869
 - Proof serialization helper for chunking compatibility.
   https://github.com/o1-labs/o1js/pull/2878
+
+### Fixed
+
+- Standalone verification of chunked proofs.
+  https://github.com/o1-labs/o1js/pull/2886
 
 ## [3.0.0-mesa.0](https://github.com/o1-labs/o1js/compare/ff6c201b...v3.0.0-mesa.0) - 2026-03-26
 
@@ -81,7 +86,7 @@ Mina protocol.
 
 ### Added
 
-- Native Kimchi access from Node.js with x2 prover performance boost. 
+- Native Kimchi access from Node.js with x2 prover performance boost.
   https://github.com/o1-labs/o1js/pull/2843
 - Enabled chunking through Native prover enabling x4 larger circuits on Node.js.
   https://github.com/o1-labs/o1js/pull/2843

--- a/src/bindings.d.ts
+++ b/src/bindings.d.ts
@@ -734,7 +734,10 @@ declare const Pickles: {
   verify(
     statement: Pickles.Statement<FieldConst>,
     proof: Pickles.Proof,
-    verificationKey: Base64VerificationKeyString
+    verificationKey: Base64VerificationKeyString,
+    options?: {
+      numChunks?: number;
+    }
   ): Promise<boolean>;
 
   loadSrsFp(): WasmFpSrs;

--- a/src/bindings/ocaml/lib/pickles_bindings.ml
+++ b/src/bindings/ocaml/lib/pickles_bindings.ml
@@ -771,11 +771,19 @@ let proof_of_base64_chunked str i : some_proof =
   | _ ->
       failwith "invalid proof index"
 
+let num_chunks_of_config config =
+  match Js.Optdef.to_option config with
+  | None ->
+      None
+  | Some config ->
+      Js.Optdef.to_option config##.numChunks
+
 let verify (statement : Statement.Constant.t) (proof : proof)
-    (vk : Js.js_string Js.t) =
+    (vk : Js.js_string Js.t) config =
   let i, o = statement in
   let typ = statement_typ (Array.length i) (Array.length o) in
   let proof = Pickles.Side_loaded.Proof.of_proof proof in
+  let num_chunks = num_chunks_of_config config in
   let vk =
     match Pickles.Side_loaded.Verification_key.of_base64 (Js.to_string vk) with
     | Ok vk_ ->
@@ -784,7 +792,7 @@ let verify (statement : Statement.Constant.t) (proof : proof)
         failwithf "Could not decode base64 verification key: %s"
           (Error.to_string_hum err) ()
   in
-  Pickles.Side_loaded.verify_promise ~typ [ (vk, statement, proof) ]
+  Pickles.Side_loaded.verify_promise ?num_chunks ~typ [ (vk, statement, proof) ]
   |> Promise.map ~f:(fun x -> Js.bool (Or_error.is_ok x))
   |> Promise_js_helpers.to_js
 

--- a/src/bindings/ocaml/lib/pickles_bindings.mli
+++ b/src/bindings/ocaml/lib/pickles_bindings.mli
@@ -83,6 +83,7 @@ val pickles :
       (   Statement.Constant.t
        -> proof
        -> Js.js_string Js.t
+       -> < numChunks : int Js.optdef_prop > Js.t Js.optdef
        -> bool Js.t Promise_js_helpers.js_promise )
       Js.readonly_prop
   ; loadSrsFp : (unit -> Kimchi_bindings.Protocol.SRS.Fp.t) Js.readonly_prop

--- a/src/examples/zkprogram/program-chunking-cross-backend.ts
+++ b/src/examples/zkprogram/program-chunking-cross-backend.ts
@@ -1,7 +1,7 @@
 import fs from 'node:fs/promises';
 import path from 'node:path';
 import type { JsonProof, VerificationKey } from 'o1js';
-import { Cache, Field, Gadgets, ZkProgram, setBackend } from 'o1js';
+import { Cache, Field, Gadgets, ZkProgram, setBackend, verify } from 'o1js';
 import { Pickles, initializeBindings } from '../../bindings.js';
 import { Performance } from '../../lib/testing/perf-regression.js';
 
@@ -123,9 +123,15 @@ async function verifyWithBackend(backend: 'native' | 'wasm') {
   let isValid = await MyProgram.verify(proofInstance);
   perf.end();
 
+  perf.start('verify', 'standalone');
+  let standaloneIsValid = await verify(proof, verificationKey, { numChunks: 2 });
+  perf.end();
+
   console.log(`Succeeded to verify chunked proof with ${backend} verifier`);
   console.log('isValid?', isValid);
+  console.log('standaloneIsValid?', standaloneIsValid);
   if (!isValid) throw new Error('proof verification failed!');
+  if (!standaloneIsValid) throw new Error('standalone proof verification failed!');
 }
 
 async function proofToChunkedJson(proof: {

--- a/src/index.ts
+++ b/src/index.ts
@@ -75,7 +75,14 @@ export { Cache, CacheHeader } from './lib/proof-system/cache.js';
 export { FeatureFlags } from './lib/proof-system/feature-flags.js';
 export { DynamicProof, Proof, type ProofBase } from './lib/proof-system/proof.js';
 export { VerificationKey } from './lib/proof-system/verification-key.js';
-export { Empty, SelfProof, Undefined, verify, Void } from './lib/proof-system/zkprogram.js';
+export {
+  Empty,
+  SelfProof,
+  Undefined,
+  type VerifyOptions,
+  verify,
+  Void,
+} from './lib/proof-system/zkprogram.js';
 export type { JsonProof } from './lib/proof-system/zkprogram.js';
 
 export {

--- a/src/lib/proof-system/zkprogram.ts
+++ b/src/lib/proof-system/zkprogram.ts
@@ -43,7 +43,17 @@ import { VerificationKey } from './verification-key.js';
 import { DeclaredProof, ZkProgramContext } from './zkprogram-context.js';
 
 // public API
-export { Empty, JsonProof, Method, SelfProof, Undefined, Void, ZkProgram, verify };
+export {
+  Empty,
+  JsonProof,
+  Method,
+  SelfProof,
+  Undefined,
+  type VerifyOptions,
+  Void,
+  ZkProgram,
+  verify,
+};
 
 // internal API
 export {
@@ -73,6 +83,14 @@ const Void: ProvablePureExtended<void, void, null> = EmptyVoid<Field>();
 
 type MethodAnalysis = ConstraintSystemSummary & {
   proofs: ProofClass[];
+};
+
+type VerifyOptions = {
+  /**
+   * Number of chunks used when compiling/proving a chunked proof. Required for
+   * standalone verification of proofs produced by a program with `numChunks > 1`.
+   */
+  numChunks?: number;
 };
 
 function createProgramState() {
@@ -106,11 +124,13 @@ function createProgramState() {
  * @note This function is meant to be called in JavaScript, not for use in a circuit.  The verification key data and hash are not confirmed to match.
  * @param proof Either a `Proof` instance or a serialized JSON proof
  * @param verificationKey Either a base64 serialized verification key or a `VerificationKey` instance which will be base64 serialized for use in the bindings.
+ * @param options Optional Pickles verifier options. Pass `numChunks` for standalone verification of chunked proofs.
  * @returns A promise that resolves to a boolean indicating whether the proof is valid.
  */
 async function verify(
   proof: ProofBase<any, any> | JsonProof,
-  verificationKey: Base64VerificationKeyString | VerificationKey
+  verificationKey: Base64VerificationKeyString | VerificationKey,
+  options?: VerifyOptions
 ) {
   await initializeBindings();
   let picklesProof: Pickles.Proof;
@@ -131,7 +151,7 @@ async function verify(
   }
   let vk = typeof verificationKey === 'string' ? verificationKey : verificationKey.data;
   return prettifyStacktracePromise(
-    withThreadPool(() => Pickles.verify(statement, picklesProof, vk))
+    withThreadPool(() => Pickles.verify(statement, picklesProof, vk, options))
   );
 }
 


### PR DESCRIPTION
Adds standalone verification support for chunked proofs by passing the circuit chunk count from o1js into the Pickles verifier.  This allows verifying a chunked proof together with verification keys without needing to compile the ZkProgram again.

mina side: