### PR TITLE
docs: add o1js-scan to Community Packages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,8 @@ This project adheres to
 
 - Removed `@internal` JSDoc tags from public APIs so they appear in generated
   documentation. https://github.com/o1-labs/o1js/pull/2881
+- Documented the `o1js-scan` community package in the README.
+  https://github.com/o1-labs/o1js/pull/2898
 
 ### Removed
 

--- a/README.md
+++ b/README.md
@@ -61,6 +61,10 @@ your project.
 - **eddsa-o1js** A library for provable EdDSA and Twisted Edwards Curve
   operations. [Github](https://github.com/o1-labs-XT/eddsa-o1js) and
   [npm](https://www.npmjs.com/package/eddsa-o1js)
+- **o1js-scan** A dependency-free static analyzer that flags application-layer
+  soundness bugs — under-constrained witnesses, missing state preconditions,
+  raw-Field transfer amounts, and weak account permissions — in o1js zkApps.
+  Runs as a CLI in CI. [GitHub](https://github.com/auditinfra-io/o1js-scan)
 
 To include your package, see
 [Creating high-quality community packages](https://github.com/o1-labs/o1js/blob/main/CONTRIBUTING.md#creating-high-quality-community-packages).


### PR DESCRIPTION
## What

Adds **o1js-scan** to the Community Packages list in the README.

## What it is

o1js-scan is a dependency-free static analyzer for o1js zkApps. It flags application-layer soundness bugs before they reach a prover:

- Bare `this.x.get()` without `requireEquals` / `getAndRequireEquals` (missing state preconditions)
- `@method` witness arguments flowing to `this.send` / state `.set` with no or only-trivial constraints
- Raw `Field` used as a transfer amount instead of range-checked `UInt64` / `UInt32`
- `editState` / `send` permissions set to `proofOrSignature()` / `none()`, letting the zkApp key bypass proof logic

It runs as a single-command CLI (`pip install o1js-scan`) with JSONL output and CI-friendly exit codes, and it suppresses admin-gated methods (`this.requireSignature()`) to keep false positives down. Calibrated against real zkApps including the Zeko x402 settlement contract.

- GitHub: https://github.com/auditinfra-io/o1js-scan
- PyPI: https://pypi.org/project/o1js-scan/
- License: Apache-2.0, tests + CI included

Happy to adjust the wording or placement to fit the list's conventions.

