### PR TITLE
Keep verification key version from fetched accounts

### DIFF
--- a/AGENT_LOG.md
+++ b/AGENT_LOG.md
@@ -85,7 +85,7 @@ tags: [<free-form>, <tags>, <for-search>]
 
 | Category             | Use when...                                                |
 | -------------------- | ---------------------------------------------------------- |
-| `rust-wasm-boundary` | Issues crossing the Rust↔WASM↔TypeScript boundary          |
+| `rust-wasm-boundary` | Issues crossing the Rust↔WASM↔TypeScript boundary        |
 | `native-ffi`         | Neon/napi-rs native binding issues                         |
 | `circuit-model`      | Compile-time vs prove-time behavior, constraint generation |
 | `provable-types`     | Type system surprises, serialization, Struct issues        |
@@ -162,9 +162,9 @@ computation. When compiled to WASM, threading behaves fundamentally differently
 than in native environments.
 
 **What happened:** Panics inside Rayon worker threads in WASM environments
-produce cryptic, unrecoverable errors. The panic cannot be caught at the WASM↔JS
-boundary, and the entire WASM instance becomes corrupted. This has been hit
-multiple times across different debugging sessions.
+produce cryptic, unrecoverable errors. The panic cannot be caught at the
+WASM↔JS boundary, and the entire WASM instance becomes corrupted. This has been
+hit multiple times across different debugging sessions.
 
 **Root cause:** WASM's threading model (SharedArrayBuffer + Web Workers) doesn't
 support the panic unwinding that Rayon expects. When a Rayon worker panics, the

--- a/AGENT_LOG.md
+++ b/AGENT_LOG.md
@@ -85,7 +85,7 @@ tags: [<free-form>, <tags>, <for-search>]
 
 | Category             | Use when...                                                |
 | -------------------- | ---------------------------------------------------------- |
-| `rust-wasm-boundary` | Issues crossing the Rust↔WASM↔TypeScript boundary        |
+| `rust-wasm-boundary` | Issues crossing the Rust↔WASM↔TypeScript boundary          |
 | `native-ffi`         | Neon/napi-rs native binding issues                         |
 | `circuit-model`      | Compile-time vs prove-time behavior, constraint generation |
 | `provable-types`     | Type system surprises, serialization, Struct issues        |
@@ -162,9 +162,9 @@ computation. When compiled to WASM, threading behaves fundamentally differently
 than in native environments.
 
 **What happened:** Panics inside Rayon worker threads in WASM environments
-produce cryptic, unrecoverable errors. The panic cannot be caught at the
-WASM↔JS boundary, and the entire WASM instance becomes corrupted. This has been
-hit multiple times across different debugging sessions.
+produce cryptic, unrecoverable errors. The panic cannot be caught at the WASM↔JS
+boundary, and the entire WASM instance becomes corrupted. This has been hit
+multiple times across different debugging sessions.
 
 **Root cause:** WASM's threading model (SharedArrayBuffer + Web Workers) doesn't
 support the panic unwinding that Rayon expects. When a Rayon worker panics, the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,11 @@ This project adheres to
   `Client.getZkappCommandCommitmentsFromJSON` on `mina-signer` for computing the
   commitment and full commitment of a zkApp transaction.
   https://github.com/o1-labs/o1js/pull/2869
+  
+### Fixed
+
+- Preserve `permissions.setVerificationKey.txnVersion` when converting fetched
+  accounts. https://github.com/o1-labs/o1js/pull/2901
 
 ## [3.0.0-mesa.0](https://github.com/o1-labs/o1js/compare/ff6c201b...v3.0.0-mesa.0) - 2026-03-26
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,7 +28,7 @@ This project adheres to
   `Client.getZkappCommandCommitmentsFromJSON` on `mina-signer` for computing the
   commitment and full commitment of a zkApp transaction.
   https://github.com/o1-labs/o1js/pull/2869
-  
+
 ### Fixed
 
 - Preserve `permissions.setVerificationKey.txnVersion` when converting fetched

--- a/npmDepsHash
+++ b/npmDepsHash
@@ -1,1 +1,1 @@
-sha256-45JyPj3ZLJ+u7ueqXZWn3RokJVa1GZpJQnqpneREy4w=
+sha256-RVDG1wr+MXbsMUSgLp3w6DxCYL41oLgUAB04c8wwEus=

--- a/package-lock.json
+++ b/package-lock.json
@@ -101,7 +101,6 @@
       "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.23.3.tgz",
       "integrity": "sha512-Jg+msLuNuCJDyBvFv5+OKOUjWMZgd85bKjbICd3zWrKAo+bJ49HJufi7CQE0q0uR8NGyO6xkCACScNqyjHSZew==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "@ampproject/remapping": "^2.2.0",
         "@babel/code-frame": "^7.22.13",
@@ -3384,7 +3383,64 @@
       }
     },
     "node_modules/@o1js/native": {
-      "optional": true
+      "version": "3.0.0-mesa.rc2",
+      "resolved": "https://registry.npmjs.org/@o1js/native/-/native-3.0.0-mesa.rc2.tgz",
+      "integrity": "sha512-FXRm7mkGV75dQ1vqK5vcLY/sEAzpiRlkvyIV4WmJZydK9Uttd9+8WYf0IzC6I6pPMweqrmBD4YgpsiuXNU7Ixw==",
+      "optional": true,
+      "optionalDependencies": {
+        "@o1js/native-darwin-arm64": "3.0.0-mesa.rc2",
+        "@o1js/native-darwin-x64": "3.0.0-mesa.rc2",
+        "@o1js/native-linux-arm64": "3.0.0-mesa.rc2",
+        "@o1js/native-linux-x64": "3.0.0-mesa.rc2"
+      }
+    },
+    "node_modules/@o1js/native-darwin-arm64": {
+      "version": "3.0.0-mesa.rc2",
+      "resolved": "https://registry.npmjs.org/@o1js/native-darwin-arm64/-/native-darwin-arm64-3.0.0-mesa.rc2.tgz",
+      "integrity": "sha512-febdYMcSnxObf5mMuTrfAe2bbItSboc75ZIim7eglmjo9I/bb9bCsJgVdDG/z9t9q+Cbk45X34RRle83Bc3Tkw==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@o1js/native-darwin-x64": {
+      "version": "3.0.0-mesa.rc2",
+      "resolved": "https://registry.npmjs.org/@o1js/native-darwin-x64/-/native-darwin-x64-3.0.0-mesa.rc2.tgz",
+      "integrity": "sha512-FXJWHnjK1p/OJSBfPCVzsisllz92D7+Xt6HzaQbFT+4qsmjGhRODDpUZxW0FVPFbkJ6Ygw4LYfwd2BOjZpu7rg==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@o1js/native-linux-arm64": {
+      "version": "3.0.0-mesa.rc2",
+      "resolved": "https://registry.npmjs.org/@o1js/native-linux-arm64/-/native-linux-arm64-3.0.0-mesa.rc2.tgz",
+      "integrity": "sha512-iMfggvFTepRpamtNF8SMRYVrwwuMNQk9qlSA4eM77gtakxC15eN/sCcaNkwPrvJYI+rb7D57nnChiNTEFfnMiw==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@o1js/native-linux-x64": {
+      "version": "3.0.0-mesa.rc2",
+      "resolved": "https://registry.npmjs.org/@o1js/native-linux-x64/-/native-linux-x64-3.0.0-mesa.rc2.tgz",
+      "integrity": "sha512-Ar3OnP3alQ+jRw9GryuMzqzjM13h+afPF8RYjRQvj4mXFpc/jI6EPbZ6QS1vGlLQhGKKkXd7Ohh96JcI2EvAMA==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ]
     },
     "node_modules/@octokit/action": {
       "version": "6.1.0",
@@ -3451,7 +3507,6 @@
       "integrity": "sha512-1LFfa/qnMQvEOAdzlQymH0ulepxbxnCYAKJZfMci/5XJyIHWgEYnDmgnKakbTh7CH2tFQ5O60oYDvns4i9RAIg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@octokit/auth-token": "^4.0.0",
         "@octokit/graphql": "^7.1.0",
@@ -3681,7 +3736,6 @@
       "integrity": "sha512-DhGl4xMVFGVIyMwswXeyzdL4uXD5OGILGX5N8Y+f6W7LhC1Ze2poSNrkF/fedpVDHEEZ+PHFW0vL14I+mm8K3Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@octokit/auth-token": "^6.0.0",
         "@octokit/graphql": "^9.0.3",
@@ -4172,7 +4226,6 @@
       "resolved": "https://registry.npmjs.org/@types/node/-/node-18.18.9.tgz",
       "integrity": "sha512-0f5klcuImLnG4Qreu9hPj/rEfFq6YRc5n2mAjSsH+ec/mJL+3voBH0+8T7o8RpFjH7ovc+TRsL/c7OYIQsPTfQ==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "undici-types": "~5.26.4"
       }
@@ -4452,7 +4505,6 @@
           "url": "https://github.com/sponsors/ai"
         }
       ],
-      "peer": true,
       "dependencies": {
         "caniuse-lite": "^1.0.30001541",
         "electron-to-chromium": "^1.4.535",
@@ -5597,7 +5649,6 @@
       "resolved": "https://registry.npmjs.org/jest/-/jest-28.1.3.tgz",
       "integrity": "sha512-N4GT5on8UkZgH0O5LUavMRV1EDEhNTL0KEfRmDIeZHSV7p2XgLoY9t9VDUgL6o+yfdgYHVxuz81G8oB9VG5uyA==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "@jest/core": "^28.1.3",
         "@jest/types": "^28.1.3",
@@ -7609,7 +7660,6 @@
       "integrity": "sha512-I7AIg5boAr5R0FFtJ6rCfD+LFsWHp81dolrFD8S79U9tb8Az2nGrJncnMSnys+bpQJfRUzqs9hnA81OAA3hCuQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "prettier": "bin/prettier.cjs"
       },
@@ -8362,7 +8412,6 @@
       "integrity": "sha512-5PzUddaA9FbaarUzIsEc4wNXCiO4Ot3bJNeMF2qKpYlTmM9TTaSHQ7162w756ERCkXER/+o2purRG6YOAv6EMA==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@gerrit0/mini-shiki": "^3.2.2",
         "lunr": "^2.3.9",
@@ -8435,7 +8484,6 @@
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.4.5.tgz",
       "integrity": "sha512-vcI4UpRgg81oIRUFwR0WSIHKt11nJ7SAVlYNIu+QpqeyXP+gpQJy/Z4+F0aGxSE4MqwjyXvW/TzgkLAx2AGHwQ==",
       "dev": true,
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"

--- a/src/lib/mina/v1/account-update.ts
+++ b/src/lib/mina/v1/account-update.ts
@@ -470,10 +470,18 @@ let Permissions = {
     permissions: NonNullable<Types.Json.AccountUpdate['body']['update']['permissions']>
   ): Permissions => {
     return Object.fromEntries(
-      Object.entries(permissions).map(([k, v]) => [
-        k,
-        Permissions.fromString(typeof v === 'string' ? v : v.auth),
-      ])
+      Object.entries(permissions).map(([key, value]) => {
+        if (key === 'setVerificationKey' && typeof value !== 'string') {
+          return [
+            key,
+            new VerificationKeyPermission(
+              Permissions.fromString(value.auth),
+              UInt32.from(value.txnVersion)
+            ),
+          ];
+        }
+        return [key, Permissions.fromString(value as AuthRequired)];
+      })
     ) as unknown as Permissions;
   },
 };

--- a/src/lib/mina/v1/fetch.unit-test.ts
+++ b/src/lib/mina/v1/fetch.unit-test.ts
@@ -1,9 +1,10 @@
-import { PrivateKey, TokenId } from 'o1js';
+import { PrivateKey, TokenId, Types } from 'o1js';
 import {
   createActionsList,
   fetchAccount,
   fetchActions,
   fetchEvents,
+  parseFetchedAccount,
   setArchiveDefaultHeaders,
   setArchiveGraphqlEndpoint,
   setGraphqlEndpoint,
@@ -12,7 +13,7 @@ import {
 import { mockFetchActionsResponse as fetchResponseWithTxInfo } from './fixtures/fetch-actions-response-with-transaction-info.js';
 import { mockFetchActionsResponse as fetchResponseNoTxInfo } from './fixtures/fetch-actions-response-without-transaction-info.js';
 import { test, describe, beforeEach, afterEach } from 'node:test';
-import { removeJsonQuotes } from './graphql.js';
+import { removeJsonQuotes, type FetchedAccountResponse } from './graphql.js';
 import { expect } from 'expect';
 
 console.log('testing regex helpers');
@@ -134,6 +135,58 @@ expect(actual).toEqual(expected);
 console.log('regex tests complete 🎉');
 
 describe('Fetch', () => {
+  test('preserves permissions from fetched accounts', () => {
+    const txnVersion = '17';
+    const permissions = {
+      editState: 'Proof',
+      access: 'None',
+      send: 'Signature',
+      receive: 'Either',
+      setDelegate: 'Impossible',
+      setPermissions: 'Proof',
+      setVerificationKey: {
+        auth: 'Signature',
+        txnVersion,
+      },
+      setZkappUri: 'None',
+      editActionState: 'Either',
+      setTokenSymbol: 'Impossible',
+      incrementNonce: 'Signature',
+      setVotingFor: 'Proof',
+      setTiming: 'None',
+    } satisfies NonNullable<FetchedAccountResponse['account']['permissions']>;
+    const fetchedAccountResponse: FetchedAccountResponse = {
+      account: {
+        publicKey: PrivateKey.random().toPublicKey().toBase58(),
+        token: TokenId.toBase58(TokenId.default),
+        nonce: '0',
+        balance: { total: '1' },
+        tokenSymbol: null,
+        receiptChainHash: null,
+        timing: {
+          initialMinimumBalance: null,
+          cliffTime: null,
+          cliffAmount: null,
+          vestingPeriod: null,
+          vestingIncrement: null,
+        },
+        permissions,
+        delegateAccount: null,
+        votingFor: null,
+        zkappState: null,
+        verificationKey: null,
+        actionState: null,
+        provedState: null,
+        zkappUri: null,
+      },
+    };
+
+    const account = parseFetchedAccount(fetchedAccountResponse.account);
+
+    expect(account.permissions.setVerificationKey.txnVersion.toString()).toEqual(txnVersion);
+    expect(Types.Account.toJSON(account).permissions).toEqual(permissions);
+  });
+
   describe('#createActionsList with default params', () => {
     const defaultPublicKey = PrivateKey.random().toPublicKey().toBase58();
     const defaultActionStates = {


### PR DESCRIPTION
Updated `Permissions.fromJSON()` to handle `setVerificationKey` separately from ordinary permissions. The conversion now constructs a `VerificationKeyPermission` containing:
- `auth`, converted using the existing `Permissions.fromString()` logic
- `txnVersion`, converted from the network response using `UInt32.from()`

All other permissions continue through the existing string conversion path unchanged.

## Testing

Added a regression test using a fake fetched-account response with `txnVersion: "17"`. The test passes the response through `parseFetchedAccount()` and verifies that:
- `setVerificationKey.txnVersion` remains `"17"`
- `setVerificationKey.auth` is preserved

The complete set of ordinary permissions converts back to the original values without regressions

Closes https://github.com/o1-labs/o1js/issues/2900